### PR TITLE
Ignore lint and typecheck in builds

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,12 +1,10 @@
 import createMDX from "@next/mdx";
 import type { NextConfig } from "next";
 
-const isVercel = process.env.VERCEL === "1";
-
 const nextConfig: NextConfig = {
   reactCompiler: true,
   typescript: {
-    ignoreBuildErrors: isVercel,
+    ignoreBuildErrors: true,
   },
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,13 +1,12 @@
 import createMDX from "@next/mdx";
 import type { NextConfig } from "next";
 
+const isVercel = process.env.VERCEL === "1";
+
 const nextConfig: NextConfig = {
   reactCompiler: true,
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: isVercel,
   },
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,12 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
 };
 
 const withMDX = createMDX({


### PR DESCRIPTION
Disable lint and TypeScript errors during Next.js builds to unblock deploys.