### PR TITLE
Use Vercel envs for site URLs

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -75,7 +75,7 @@ If rendering fails, the raw code block is shown.
 - Sitemap: `/sitemap.xml`
 - Robots: `/robots.txt`
 
-Set `NEXT_PUBLIC_SITE_URL` in production for correct canonical URLs.
+Canonical URLs are derived from Vercel system environment variables when deployed on Vercel.
 
 ## Quick checklist
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@next/mdx": "^16.1.6",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
+        "@t3-oss/env-nextjs": "^0.13.10",
         "@tailwindcss/typography": "^0.5.19",
         "feed": "^4.2.2",
         "mermaid": "^11.5.0",
@@ -206,6 +207,10 @@
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
+
+    "@t3-oss/env-core": ["@t3-oss/env-core@0.13.10", "", { "peerDependencies": { "arktype": "^2.1.0", "typescript": ">=5.0.0", "valibot": "^1.0.0-beta.7 || ^1.0.0", "zod": "^3.24.0 || ^4.0.0" }, "optionalPeers": ["arktype", "typescript", "valibot", "zod"] }, "sha512-NNFfdlJ+HmPHkLi2HKy7nwuat9SIYOxei9K10lO2YlcSObDILY7mHZNSHsieIM3A0/5OOzw/P/b+yLvPdaG52g=="],
+
+    "@t3-oss/env-nextjs": ["@t3-oss/env-nextjs@0.13.10", "", { "dependencies": { "@t3-oss/env-core": "0.13.10" }, "peerDependencies": { "arktype": "^2.1.0", "typescript": ">=5.0.0", "valibot": "^1.0.0-beta.7 || ^1.0.0", "zod": "^3.24.0 || ^4.0.0" }, "optionalPeers": ["arktype", "typescript", "valibot", "zod"] }, "sha512-JfSA2WXOnvcc/uMdp31paMsfbYhhdvLLRxlwvrnlPE9bwM/n0Z+Qb9xRv48nPpvfMhOrkrTYw1I5Yc06WIKBJQ=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.1.18", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.18" } }, "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ=="],
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,3 +1,4 @@
+import "./src/env";
 import path from "node:path";
 import createMDX from "@next/mdx";
 import type { NextConfig } from "next";
@@ -8,6 +9,7 @@ const nextConfig: NextConfig = {
     ignoreBuildErrors: true,
   },
   outputFileTracingIncludes: {
+    "/blog/[slug]": ["./src/content/**/*"],
     "/blog/[slug]/opengraph-image": ["./src/content/**/*"],
     "/blog/[slug]/twitter-image": ["./src/content/**/*"],
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@next/mdx": "^16.1.6",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
+    "@t3-oss/env-nextjs": "^0.13.10",
     "@tailwindcss/typography": "^0.5.19",
     "feed": "^4.2.2",
     "mermaid": "^11.5.0",

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -11,7 +11,7 @@ import {
   importBlogPostModule,
 } from "@/lib/blog-utils";
 import { formatDate } from "@/lib/date";
-import { absoluteUrl, resolveRequestBaseUrl, siteConfig } from "@/lib/site";
+import { absoluteUrl, siteConfig } from "@/lib/site";
 
 type PageParams = Promise<{ slug: string }>;
 
@@ -36,15 +36,14 @@ export async function generateMetadata({
   if (!post) return {};
 
   const { metadata, date, updatedAt } = post;
-  const baseUrl = await resolveRequestBaseUrl();
-  const url = absoluteUrl(`/blog/${slug}`, baseUrl);
+  const url = absoluteUrl(`/blog/${slug}`);
   const ogAsset = await findMetadataImageAsset(post.importPath, "opengraph");
   const twitterAsset = await findMetadataImageAsset(post.importPath, "twitter");
   const ogImageUrl = ogAsset
-    ? absoluteUrl(`/blog/${slug}/opengraph-image`, baseUrl)
+    ? absoluteUrl(`/blog/${slug}/opengraph-image`)
     : undefined;
   const twitterImageUrl = twitterAsset
-    ? absoluteUrl(`/blog/${slug}/twitter-image`, baseUrl)
+    ? absoluteUrl(`/blog/${slug}/twitter-image`)
     : ogImageUrl;
 
   return {
@@ -90,12 +89,11 @@ export default async function BlogPostPage({ params }: { params: PageParams }) {
   if (!module?.default) notFound();
 
   const Content = module.default;
-  const baseUrl = await resolveRequestBaseUrl();
-  const url = absoluteUrl(`/blog/${slug}`, baseUrl);
+  const url = absoluteUrl(`/blog/${slug}`);
 
   const ogAsset = await findMetadataImageAsset(importPath, "opengraph");
   const resolvedImageUrl = ogAsset
-    ? absoluteUrl(`/blog/${slug}/opengraph-image`, baseUrl)
+    ? absoluteUrl(`/blog/${slug}/opengraph-image`)
     : undefined;
 
   const jsonLd = {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -11,7 +11,7 @@ import {
   importBlogPostModule,
 } from "@/lib/blog-utils";
 import { formatDate } from "@/lib/date";
-import { absoluteUrl, siteConfig } from "@/lib/site";
+import { absoluteUrl, resolveRequestBaseUrl, siteConfig } from "@/lib/site";
 
 type PageParams = Promise<{ slug: string }>;
 
@@ -36,14 +36,15 @@ export async function generateMetadata({
   if (!post) return {};
 
   const { metadata, date, updatedAt } = post;
-  const url = absoluteUrl(`/blog/${slug}`);
+  const baseUrl = await resolveRequestBaseUrl();
+  const url = absoluteUrl(`/blog/${slug}`, baseUrl);
   const ogAsset = await findMetadataImageAsset(post.importPath, "opengraph");
   const twitterAsset = await findMetadataImageAsset(post.importPath, "twitter");
   const ogImageUrl = ogAsset
-    ? absoluteUrl(`/blog/${slug}/opengraph-image`)
+    ? absoluteUrl(`/blog/${slug}/opengraph-image`, baseUrl)
     : undefined;
   const twitterImageUrl = twitterAsset
-    ? absoluteUrl(`/blog/${slug}/twitter-image`)
+    ? absoluteUrl(`/blog/${slug}/twitter-image`, baseUrl)
     : ogImageUrl;
 
   return {
@@ -89,11 +90,12 @@ export default async function BlogPostPage({ params }: { params: PageParams }) {
   if (!module?.default) notFound();
 
   const Content = module.default;
-  const url = absoluteUrl(`/blog/${slug}`);
+  const baseUrl = await resolveRequestBaseUrl();
+  const url = absoluteUrl(`/blog/${slug}`, baseUrl);
 
   const ogAsset = await findMetadataImageAsset(importPath, "opengraph");
   const resolvedImageUrl = ogAsset
-    ? absoluteUrl(`/blog/${slug}/opengraph-image`)
+    ? absoluteUrl(`/blog/${slug}/opengraph-image`, baseUrl)
     : undefined;
 
   const jsonLd = {

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 export const env = createEnv({
   server: {
+    VERCEL_ENV: z.enum(["development", "preview", "production"]).optional(),
     VERCEL_URL: z.string().min(1).optional(),
     VERCEL_PROJECT_PRODUCTION_URL: z.string().min(1).optional(),
   },

--- a/src/env.ts
+++ b/src/env.ts
@@ -8,6 +8,8 @@ export const env = createEnv({
     VERCEL_ENV: z.enum(["development", "preview", "production"]).optional(),
     VERCEL_URL: z.string().min(1).optional(),
     VERCEL_PROJECT_PRODUCTION_URL: z.string().min(1).optional(),
+  },
+  client: {
     NEXT_PUBLIC_PORT: z.string().min(1).optional(),
   },
   experimental__runtimeEnv: process.env,

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,11 @@
+import { createEnv } from "@t3-oss/env-nextjs";
+import { z } from "zod";
+
+export const env = createEnv({
+  server: {
+    VERCEL_URL: z.string().min(1).optional(),
+    VERCEL_PROJECT_PRODUCTION_URL: z.string().min(1).optional(),
+  },
+  experimental__runtimeEnv: process.env,
+  emptyStringAsUndefined: true,
+});

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,9 +3,12 @@ import { z } from "zod";
 
 export const env = createEnv({
   server: {
+    NODE_ENV: z.enum(["development", "production", "test"]).optional(),
+    PORT: z.string().min(1).optional(),
     VERCEL_ENV: z.enum(["development", "preview", "production"]).optional(),
     VERCEL_URL: z.string().min(1).optional(),
     VERCEL_PROJECT_PRODUCTION_URL: z.string().min(1).optional(),
+    NEXT_PUBLIC_PORT: z.string().min(1).optional(),
   },
   experimental__runtimeEnv: process.env,
   emptyStringAsUndefined: true,

--- a/src/env.ts
+++ b/src/env.ts
@@ -12,6 +12,8 @@ export const env = createEnv({
   client: {
     NEXT_PUBLIC_PORT: z.string().min(1).optional(),
   },
-  experimental__runtimeEnv: process.env,
+  experimental__runtimeEnv: {
+    NEXT_PUBLIC_PORT: process.env.NEXT_PUBLIC_PORT,
+  },
   emptyStringAsUndefined: true,
 });

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -8,17 +8,26 @@ const withProtocol = (value: string) => {
 };
 
 const resolveSiteUrl = () => {
-  if (env.VERCEL_PROJECT_PRODUCTION_URL) {
-    return withProtocol(env.VERCEL_PROJECT_PRODUCTION_URL);
+  if (process.env.NODE_ENV === "development") {
+    const devPort = process.env.PORT ?? process.env.NEXT_PUBLIC_PORT ?? "3000";
+    return `http://localhost:${devPort}`;
+  }
+
+  if (env.VERCEL_ENV === "production") {
+    if (env.VERCEL_PROJECT_PRODUCTION_URL) {
+      return withProtocol(env.VERCEL_PROJECT_PRODUCTION_URL);
+    }
+    if (env.VERCEL_URL) {
+      return withProtocol(env.VERCEL_URL);
+    }
   }
 
   if (env.VERCEL_URL) {
     return withProtocol(env.VERCEL_URL);
   }
 
-  if (process.env.NODE_ENV === "development") {
-    const devPort = process.env.PORT ?? process.env.NEXT_PUBLIC_PORT ?? "3000";
-    return `http://localhost:${devPort}`;
+  if (env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return withProtocol(env.VERCEL_PROJECT_PRODUCTION_URL);
   }
 
   throw new Error(

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -48,20 +48,3 @@ export const siteConfig = {
 
 export const absoluteUrl = (path: string, baseUrl = siteConfig.url) =>
   new URL(path, baseUrl).toString();
-
-export const resolveRequestBaseUrl = async () => {
-  if (process.env.NODE_ENV !== "development") {
-    return siteConfig.url;
-  }
-
-  try {
-    const { headers } = await import("next/headers");
-    const headerList = await headers();
-    const host = headerList.get("x-forwarded-host") ?? headerList.get("host");
-    if (!host) return siteConfig.url;
-    const proto = headerList.get("x-forwarded-proto") ?? "http";
-    return `${proto}://${host}`;
-  } catch {
-    return siteConfig.url;
-  }
-};

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -17,7 +17,8 @@ const resolveSiteUrl = () => {
   }
 
   if (process.env.NODE_ENV === "development") {
-    return "http://localhost:3000";
+    const devPort = process.env.PORT ?? process.env.NEXT_PUBLIC_PORT ?? "3000";
+    return `http://localhost:${devPort}`;
   }
 
   throw new Error(

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -8,8 +8,8 @@ const withProtocol = (value: string) => {
 };
 
 const resolveSiteUrl = () => {
-  if (process.env.NODE_ENV === "development") {
-    const devPort = process.env.PORT ?? process.env.NEXT_PUBLIC_PORT ?? "3000";
+  if (env.NODE_ENV === "development") {
+    const devPort = env.PORT ?? env.NEXT_PUBLIC_PORT ?? "3000";
     return `http://localhost:${devPort}`;
   }
 

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,7 +1,34 @@
+import { env } from "@/env";
+
+const withProtocol = (value: string) => {
+  if (value.startsWith("http://") || value.startsWith("https://")) {
+    return value;
+  }
+  return value.includes("localhost") ? `http://${value}` : `https://${value}`;
+};
+
+const resolveSiteUrl = () => {
+  if (env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return withProtocol(env.VERCEL_PROJECT_PRODUCTION_URL);
+  }
+
+  if (env.VERCEL_URL) {
+    return withProtocol(env.VERCEL_URL);
+  }
+
+  if (process.env.NODE_ENV === "development") {
+    return "http://localhost:3000";
+  }
+
+  throw new Error(
+    "Missing Vercel system env vars. Expected VERCEL_PROJECT_PRODUCTION_URL or VERCEL_URL.",
+  );
+};
+
 export const siteConfig = {
   name: "F0RR0",
   description: "Creative developer building digital experiences.",
-  url: process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000",
+  url: resolveSiteUrl(),
   language: "en-US",
   locale: "en_US",
   author: {
@@ -9,5 +36,22 @@ export const siteConfig = {
   },
 };
 
-export const absoluteUrl = (path: string) =>
-  new URL(path, siteConfig.url).toString();
+export const absoluteUrl = (path: string, baseUrl = siteConfig.url) =>
+  new URL(path, baseUrl).toString();
+
+export const resolveRequestBaseUrl = async () => {
+  if (process.env.NODE_ENV !== "development") {
+    return siteConfig.url;
+  }
+
+  try {
+    const { headers } = await import("next/headers");
+    const headerList = await headers();
+    const host = headerList.get("x-forwarded-host") ?? headerList.get("host");
+    if (!host) return siteConfig.url;
+    const proto = headerList.get("x-forwarded-proto") ?? "http";
+    return `${proto}://${host}`;
+  } catch {
+    return siteConfig.url;
+  }
+};


### PR DESCRIPTION
Adds typed Vercel env validation and derives canonical/OG URLs from deployment hosts. Improves blog OG URLs in dev and ensures blog routes can read content files for metadata. Updates docs and dependencies to match the new env setup.