### PR TITLE
fix: align resume metadata and PDF extraction

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 0,
   "workspaces": {
     "": {
-      "name": "f0rr0.github.io",
+      "name": "f0rr0.dev",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
         "@mdx-js/loader": "^3.1.1",

--- a/career/generated/sid-jain-resume-dark.typ
+++ b/career/generated/sid-jain-resume-dark.typ
@@ -3,7 +3,7 @@
   author: "Sid Jain",
   keywords: (
     "AI product engineer",
-    "AI lead",
+    "Applied AI lead",
     "staff full-stack engineer",
     "founding engineer",
     "TypeScript",
@@ -32,7 +32,16 @@
   size: 10.5pt,
   weight: "regular",
   style: "normal",
-) = text(font: font, fill: fill, size: size, weight: weight, style: style, s)
+  kerning: true,
+) = text(
+  font: font,
+  fill: fill,
+  size: size,
+  weight: weight,
+  style: style,
+  kerning: kerning,
+  s,
+)
 #let logo-tile(
   path,
   fill: background,
@@ -156,6 +165,7 @@
             size: 12pt,
             weight: "bold",
             style: "normal",
+            kerning: false,
           )
           #v(-6pt)
           #t(
@@ -310,6 +320,7 @@
           size: 12pt,
           weight: "bold",
           style: "normal",
+          kerning: false,
         )
         #v(-6pt)
         #t(
@@ -440,6 +451,7 @@
           size: 12pt,
           weight: "bold",
           style: "normal",
+          kerning: false,
         )
         #v(-6pt)
         #t(
@@ -659,6 +671,7 @@
           size: 12pt,
           weight: "bold",
           style: "normal",
+          kerning: false,
         )
         #v(-6pt)
         #t(
@@ -743,6 +756,7 @@
           size: 12pt,
           weight: "bold",
           style: "normal",
+          kerning: false,
         )
         #v(-6pt)
         #t(
@@ -850,6 +864,7 @@
           size: 12pt,
           weight: "bold",
           style: "normal",
+          kerning: false,
         )
         #v(-6pt)
         #t(
@@ -957,6 +972,7 @@
           size: 12pt,
           weight: "bold",
           style: "normal",
+          kerning: false,
         )
         #v(-6pt)
         #t(
@@ -1087,6 +1103,7 @@
           size: 12pt,
           weight: "bold",
           style: "normal",
+          kerning: false,
         )
         #v(-6pt)
         #t(
@@ -1209,6 +1226,7 @@
             size: 12pt,
             weight: "bold",
             style: "normal",
+            kerning: false,
           )
           #v(-6pt)
           #t(
@@ -1272,6 +1290,7 @@
           size: 12pt,
           weight: "bold",
           style: "normal",
+          kerning: false,
         )
         #v(-6pt)
         #t(

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "f0rr0.github.io",
+  "name": "f0rr0.dev",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/public/resume/sid-jain-resume.pdf
+++ b/public/resume/sid-jain-resume.pdf
@@ -1085,52 +1085,60 @@ g=„Ì¹¢9¢Â¹ªœ¨îzMÏ´Æõ²Æ2ý5ˆ
 endstream
 endobj
 292 0 obj
-<</Length 5427/Filter/FlateDecode>>
+<</Length 5397/Filter/FlateDecode>>
 stream
-xœí][ÝFr~×¯àXv,f5­¾7¹QœÄò>$ˆÖ[6Ö ƒ$fwgDûïò°/U]Õ$Ï9”„H6 93‡—¾UuÕW_U¿ø‡Ç÷ÿuÿëÝûîÇŸ_=ùS§:ÙÉîvú¡¤º»w/îdw÷çN
-%Õèe|'…iF­çV©à]÷ç»‡ùæwWº“ÝÛùçü”·ñqoŸüç“û'ÿúäw?¿zñË}xùòÅÏ¯þñ§NþðÃ?Mï7~~†ñU"øn4Rh;5ãƒì~úq«Š·¦¦ãéN'¬/;0J7zzƒNíŸ?åæ?ùñu'»×/îç¼¾/‡Cv¯ßýÛ³ßK)/¥Z~êÞÅ?™å§]~ºÞèø—/?Cÿï¯ÿéÉï^ÝÑUwœTbðÚu£sBÁ.nš	ÛIaýü_˜fD§G«4ì“ê‚p›:Åõõ&Ì?ßÌÿ¾Ÿÿ}8}£LñÍéßûþv8½ç±Wjy£ò½¶ÏŠ«¤jŒŒ!GF®­Ó40KwÒÀh¹tI›å
-‡Ž¾r¥ËËµº¿Uþù ©ãïËô2'Ú¡Ÿ–?[ŸrB«ie/Ì`¥9j5”€eèP¬id¯ä¦5r½1qÕ˜,jGT9~ÖÎMOC0Œ?©Ä GcÒzûDmŸÈÅûß€¿¾ïUR8®WË =O€‚Š¿½‡oW°Uqb`›Ò´HÔ—8=§6ß÷z™äiÅëešè©LýE-‰SÇ)µÐ¡ëQã2\Þ#ú	]¼{yú=5‚f¹ÖÄÅ‹pÑ Ps ÷¬WŠŠóøßÇõ0®$å³0¡¢±2d›ðÈÖ-Yc\UI‰™tEk´¦Ì†u¾´ÔèÆh1½3éù¼JðŒJF+´
-î0¥`,=AHH\<ñw[¾I›$¦}_ãÒÇü´þVGsÈèÞ¤ÏX
-‰yJÝˆÚiÂbíD×
-ÒsÆ]yÜÙPéúÛôK#‹°ŒüCîÔ¦ÅÝVÁRû8ÀHßFÝõíÒŒ<5š›UÖRT±ÕdµZ{ßßf‰VMI&´D¯±TË¿IÏ»$ÖMQÖ÷ìqé-^¯N¯R}˜Zy¨zYÉZZ
-¤\Ö}Ïûcþ.í¼`ìã›ª1¾'÷ íñB\”×–†^…ÕSÍ´¬*•–w
-ü>E¬X$cØPò½‹‹—i>ÞŒ¿s)#ˆª¡°êÝ¤Ü;áýí(Æqýè”Ve†FµœDúBaLŸÓÏàÀ	 uÂ«3Ó©ó|jBt|Ê¯C¿x…oúèoJäÒDçåË¯ÿòÇÿxñÏ¿þåÿóžë¯…(Â©»ÎÌhÎŒòÓÇ0X£LˆÈŽ²bB!Þu²óÂÙ0g‹OéÙÝuÊ‰éÆ	ÒFX§•Ÿ®0å­&Ýq7>ÝòvúœïÉŸò%f~ÃéV3ãLå3Ë»Ó-wîtþ`½ú¥“Bë`'ÏxúxÒÈ“rÖÓÚ°Au¿¼ú—NŠàºÿíl÷s“wŸß˜ä){»aNŸüBÈÔ‡MŸÆMY1Hï­ê¬Úwaôbtt0!xŠAðdá™ÓàO{¦dÚNé¦df»Of="¥)¤0©1V©(Å´=ŒNáÜ]ÝuãEH]ï‘j–ÉœL¸]©b*¯þºÁÐ(-®^öž7`»••¶ßOZoÇZeC9èÙ/iõà=z4›ïÁAkàÛÎ}&ÄG“{‚Ý¦7hëŒÛœkLe9Ú7§æg0Â˜qgÊ–ZõeU¯teL“RJ#³÷WptÐ£/œììGËD­ÜïÑßH…pÉüw…~¶T@L›`Ä¨l‚ÆœoÚ·”€¡MÃù¯]¶ó*0»MfÍÛ‡Ò·ŒécÁÕæ2CÎWß”¿|S[BÑV&Däj<-ù–’ï¦þ*}úi~Ïc‡ÛÆ@£Z7Ö‡å¤Ð)áÎçxNó÷ú¿™Õ°÷èè]Ó 5ÐeŸ?š…š	¥øjˆÍP>xì;#ýÞ
-ñúƒ!q•vžû]0Tg'yë*£q]ü»kcç¢Ý=Px¢§µÐ å94ƒþ0˜ù¯át&ˆ€wi²Á¢øM­Yè3€1¶[pújý {ÈhBBÑ¢ˆ·Bè‡ 3>
-~«pÐÊrË NXß.ðFØÂã*ÚlŒê±[xªmÈ)õÃÇìÔí£ÖÐ1¼Ä,×.DÖäÀ	²¶Â.B¢šá¼–ùµ¶ÒHD·àÚk©éåg¢uR –8j)ÉP¼;°±Êô4ÜvÉj¦À¢8Oá¬“öSØx#·.©F]qe>ßmbÕ¿]ó^ª;Bº²2ZäÃEQnY8˜ˆ–¦6 `Ð6ŠCËð£ÂÝWŒ¢ýŠXžC…Øc°žM3ØdK`›;á¼o-#YMY½ª÷éLZ±w*s|ëžÖ`JFâý8AüÇ…I’8n˜D€nBiùÙéš‘‘°¬kJÉ('¯tàÀ{àtÇ¨øMob/.é+^fhßo·b¥ëO½ÅtŠfÜùž‘‘±Òç'|e:xeÂ{Cü­…ÝÛIç¸šOÚ²44mð~RëóÉÁXZsz‡jÔ!”©´1£p:ZÈ;½÷égGìÖÈfYYt-w¹Â±£VQ58B(ÂrkqZ5×ù8¿Q:³UGlp-íFÂc[\üÍÌòz$ŠHun¼`wÖ9ÁÁš4K1Ú ŸèüO\ß7¯Á®U²…°ßŠVOÓj0œô:'œ9Ž½ä<•ßŸçn*RÀ[Z¤4,ÆçùqYÍàÍ#N±<ú8˜3u®1*Ö„hf³ã›¬L(?Sï®›€é|›;4ìñÆ
-÷)vg.ÖS5èSîÌ‡²È±¸Å„gá‡}Ðã~%w»ýîåc´bZÔïâ±Æ\¯é×¨nˆ¿cU1¿‡aC/¯£•ÿ}¾&ámhè.näµR†7kf,gmXwòè¬9Ã‚™x¯óuÐncQ˜Štª‹«Éšá9_)í¨.ßß2”`¨;MÛ\AŒ­¾7µ‘è½§Õ®(Ç;v3DŠ, Ó‚j×°?’;8ÉCÚ~8ÊßÅu£
-ÔüÿL¨ECò•R[iøPœ.šžÝÙq"Ó:?¿ÝMsi5‹rƒ®ö‡+²i}6 y½`Ó†ôç7ùYõ.<ËÆÖ7r]óAø(m²mÚ¿€­•m°Ó(Ð¬Ëø¼ë¥Ý2>(÷5åÂ:†j›-1S¥ªb+GN÷§î1˜9Œ³ýë†%H¨Ú\=CPF ynñŽ÷¤ÂÄýæÉÜ†oöÐ‘A[–yš¹kô0%“@¯órGxwÖ‰9ãâ³¤åví‹‚.{_vWcß†SêK²9[4ßo Òº8]}ª­€¨Ö qm&+,Ýö@áÆ—$¹1é5voüœAÕ9ë…Ò—Øî_‰ÂûˆÂµ2„N+bG;9®_u&é¸±:8ª¾ÓFÜ§à&õ	ñ£2gžÇDw“
-˜xãY›™¯ÏFJÈR}aÅÅBÛLÅÓ«AŠQÚ9_;Îxí«|à¦[F¢'9ÑMµç¢K§(sÊ™Òª³ö~¿¡Chð©)•“2N5ÞG¨€ñùƒ‹ÊÃE¯Ï‹¾¡H,'³r,’tU‰­ñœa
-øÙÍì6\3ç.¢*Ç{ÈÇ@ÕÛò!²¸qqâ8ŽPÒ(˜ˆgÜï“}A©&¹˜#ÓfDi†mÏÇl³vÄ`œÔŸb›å0]²QŸU3í\Q‡³:M*xÿ^(ÔŠžÏ—  bx¸D„KnQ];¯DeÌãñRÕÏÞXÊd«çg’%½ÑÊƒÈ‘8ÓË·ý¸(’m¶Rjkeƒ@o]ÑÌPimº\€N«ãQà-Ö­#èiçKkœ«ÜóxWÑ~³½LR‹Ê}SÄÙ0‹o}…àm½bB<ã¨NJ'3ÙÆ6«y%LMúäB°¼[Ê"!"îÈ'iDØ·TÎ¹VÒÆ´žªžÇ•·jÕë“k¯Ä`Çq8ÎÞé îZÆ¤UË‹.g	Æu¸3Hß²Ï8ŒßZ)†OaœYŽU_·ècçJÓÙŒgž0¨MrÂ‚nLzPÆŒ™¶‹®²/Û^™2,p‹gÒæç¯Yâà•&6"ûôáüG]ÜŒó!p±·:ÇÌ"_asnÝ/ÚÈ¹ñßþI£Ô±â„Va.BÚ›bÛmLÄB°"â*³ù’U½Ú¢jb~6@À%Äœ¢A‰¡‚ 9’˜ƒ7U¥çp¬—
-Ùe
-O®ù–ÚhªMp_RÐ±¢Xó³GrK)_ãñ²Ru@I/)Û×à¹˜1‚æ(%71'¹RÚÙQê/™ƒGë+¦Òß9Ä ?.TÝÙ ç¼ëLp"èe?šccOša¨6‚ëÑa”éðžk¨,öu%®¡®Uï3­&é‹tì@Ã’¶}®M5Ã–ù–GöA5µ¨³Þ¬!Úh „eÊÚtŽ j€ý	Yˆ+C—lKÍ£®)±§‚‚øhC*€ùdÐ¤§ýí	ýnUeÙ”#¹ñ,â˜¦7Ùl¤à[$d)¡–<m¥Ó °Êz©»þV¥%Ü ÉX¬7N	ë‚ÓÇðdž&ÒGy¶IýŸØ)qE üå»>¤ü_ÌkE¢N•ËˆæXš$S&ƒE¦DíjnE&¾$®JcÄ‰â÷Ú	§TgœÖÃQ‰¢ƒà†ÚÉƒ¹™ŸA¹ß"IP—Ló8IÐ£ðá8›¦te(£XƒðÚ¡¥‡«¦]ë(‘5Þ9›âÎh‘ªBH‘9»l	‰ŠªY’]DÅ â·‡rQ6ö÷ˆÃ¨`â@,¶öz#U	ÌM„$X<sÚ¸ì0˜†øs¤n£¼PÃ—ÇéøÈ‡T)FXë¡õ½·œ$pÛJmÛHkÂ˜_ï´î>ï€³P„e5OÝaºƒ,À}âã#Ì¸Â#XáŒQ*äéëÙ—•bò}&WVù)r0fòcU¾^«xÃÝòyºãíü9Ý’?åK¦RåñV­º·à‘¼o¹ãªs „8(ï>·AÉ3övuBiø G‘tÄ†aJ¡ÑƒnXÆíƒ¥AW‡|”Òóí£V:xNÞõïKµ¦À§M;å3ž„¿@ÍS~ÍriÍÐâañ¨Ájh 	®ÓÕ”L¬£äºu"VèG‰NŽ4!a%"^iIIÍ¦
-_áÖ¸2áYçÅ»¯l­sQ—>¡†oo'ŒaÿÃ2}ò½¶ù6*o Ÿ=Ï`“Ó¬º¤•†°ø!4ùÚ²m2?²qMs¾*cêLVÃäãC+”˜“Ü4‚e¡«É àt\Ö+ëj+!nSDî¾ìTf2E§r]9§Žuœ[…UxBLkO‘è›sË´Üô·ã³•òºíê‰•£]¼ãØ8ÔfÔºdÝ#![éf½3¬œû ¬:’„QBŠyÃ–®=“Y!ƒÒ%>¢1Úîxt}pTY´Ñ’dE<J†z‰G¢AŸq¡I1z¤s6ÿ—æƒ€Áùê€ U‘ƒoKàÒŠ!ÖÚnðóØ'†Ažb—ŽqC«o¬f”Rã†€¨NþMòCŠ-Emõ%ê ƒ²RX­èN]™Rù¹Ô¤‚›:•‰SîÊ«Ú—.•VULÁöQæÒYÎ`9þZÙGƒð’Üäi£ TV64¹ñƒýQŽÞÜ¶¡7Ä0°ªÅh1Œ(´z]‡Þ®åa¬ÍÊ–50ÿò7qæŠÄ¢Æl)v½©Xï5³½<%®ƒØ­,÷’÷rª^™–?*_¯.J¶Vb&ÒL]Úb„xpÕä*ÚÂBÈŠeìS6¶:xŽýùå½ÖÍØ¨Üw”qs+€j<Q[áþçUE;×J¥aêèC»¹ê{¦!ÖùÒ‰A‚˜Ao”BÍþÁ0~±î§¯þÿ±®ñurÔ0O%¾<íx6<¡ÆáDÁ<Â+x^'N·ëML¸8	ýíFgÀ'…‘ÊQ]¹. òÿ‰,Ážu²ÎZ>2 Üü¶*ONå'C³Ÿ;aOÆÑ9(PuÓ[èÇžLª“~Z[åeàuC®Ø€„¬†O‚ù”îPë¬“¤¹šžr+M‚òt eµW,Y‹[·­˜é>ckÃ‘H·¦‚’šìo#Uõ‡øC¥LËõ“1¡¥åF`²>B/TåÝÂ\ Þ8ažF¨ Ò¶×G&ºÕéW†æÔD:uÞc7WÌ¨ùLÛ4Zà<ÊKü	å‚
-©i†T˜©NÑX“B~² ¿Øˆª¯NÐ9è`¦›¦Üø…û„:euÀñ/Ø¸Ãl»©bå!† FS^€Y>…‘a}„œèQ§‡¾éµæó!üÞ0†'Â£ÃHÑWÏåpÏcV*‚½rÃ&ÙyS®IéÒTý6+a–Ó›Ð×")œ~øÙgp®yMÖåyñÆF(”ñb8î€ôÔ—g½–_9i4Ç¡iI#MFM¹Fwfª?n(ý#Û§›¡Fþq\#1›½k£¶£Ã¸'l`ðÚlÏ*:ê¸êÛší6e†dKž[qãá"—Õ`äÎ6å…—n¨©pðq²K×aÏ“ûÄg„,F­ENjËO(|dë~© «¯ ;V˜¬}£¥QKtabŒ=e?´ùøð‚ÔÂX;†ÃŽ'@6MŠJP; ‚ ³P~×[{"(EÑ„5sÀ&–ò z%á‘‘¸ºÁúDÜ"ŒÂÞÑctM`vx”Òç—’É¶ë±e»Ç¦Â?8WïïnwéU\’Ö“4±ûfe÷ýG±~Œ8„éõ²šãõŸ]Þç[“c)c>u£!løa*gìŽL‡¸^õÑžBL†vÕ.>k9QE%Ð2{Ø~Æ3GåƒŒ£s3€¡ý~sâ€˜ß8œš.ÓÕŒL\¢„*+"]¸=Ã<°Ñ„©€±Ç“Ì•ÜëL=G§àØá&wôae œ#§R ¶’òóÜññYåÞ|Q©ÕÿÖ…
+xœí][7r~×¯è±ìXÕpxg÷FqËû XoÙ<Xƒ$4»;;A´ÿ>è>M²«XÅ¾œÓ’É4gæô…·*V}õUñîŸþëôëýSóãÏ¯Ÿý©Qlds;üPRvÍýû»{ÙÜÿ¹‘BIÕ{:ßH!ûNš^ëñ£U*x×üùþa¼ù}ã•ndónü9>å]|Ü»gÿùìôì_Ÿýîç×w¿üñ×‡W¯î~~ý?5ò‡~üix¿ñã3Œo¬Á7½‘BÛ¡dóÓˆ[U¼55½ëÏw:aý¼½t]§‡7ˆîÜþñSnþ³ß4²yóxw[ðæ4Ù¼yÿo/~/¥ü½”jú©[ÿd¦ŸvúéZ£ãw>^>ýí¿¿ù§g¿{CtGÝqR‰Îk×ôÎ	»Ô¹a&l#…õãa˜mœî­Ò°Oª	Â­ê×#Ô›0þ|;þû4þûpþF™Ù7çOímw~Ïc«ÔôFå[m_Ì®’ª22†Ý¹¦·NSxÐÀLÝI£åÔ%m¦+t:úÊ….O×êöVùä¤Ž¿O/ÐÓœh‡~Z~ül9~Ê	­†•e¼0•æ¨!ÔP¦u¢ÃlíH#[%W­‘ë‰+ÆdR;2ˆ æ£áGÝáÜðñ<ÃÈø³Jp4­·MÔ¶‰\¼ÿ-øëS«’Âq­ší|Tüí	¾]ÁV=Æ‰mJÓ"Q_âôœÛ|jõ4ÉÃŠ×Ó4?ÐS™ú‹Z§6ŽSj¡C×£6Æe8-¼Gô-ºx÷ôô5‚fºÖÄÅ‹pÒ Ps ÷¬Wf#çñ¾ëa\IÊgaB-DceÈ6á‘-[²üÆ¸ª’3éŠ4ÖhM™ë|j©Ñ•ÑbzgÒóy•à•ÐõVhÜaJÁXz‚¹xâïvþ&m’˜>¶q|KóÓÚ[Í!£[“>c)$æ)u#j¤	gk'j4¸Vž3ŽèÊãÆ†J×Þ¦ï\YÔ€iär§V-îº
+–ÚÇFú6êÆ¨o§fä©ÑÜ¬:°~¢Ší(&«ÖÚS{›%ZU%™Ð­
+ÄRÿHzÞ%±nŠ²¾e;Hoñz%pz¥“"èÃÔÊCÑËBÖÒR å²ì{ÞówiçcßTŒñ‰Üs€¶ÇqR^XZÕÍ¬žbž eõP¨´¼Sà÷)bÅ"Ã†’o]\¼LóñfÌèüK	DT3Ûù¡ÜÐ@Ê­ÞÞö¢ïûÞ÷¹AiafhTËI¤/Æô9mð¼ vœ Z'¼Ú	˜Fíó©	ÑñL˜ÚÉ+|ÛFS"—&‚8¯^Ý½ùËÿãîŸýËþç‰ë¯ê…(Â¹»ÎŒhÎˆòtÃÇÐY£LˆÈŽ²b@!Þ7²ñÂÙÐggŸÒ²¹o”Ã¤°N+?\aæ·štÇýøù|Ë»ás¾'Ê—˜ñç[Íˆ3ÍŸ9¿;Ýr?ÃöÖë_)´vðŒ‡g<(g=¬TóËëi¤®ùßÆ6?ç1yÿùIž²w+æôÙ/„LõqØôyÜ”ôÞªÆz¡}z/z7@‚§O–ž9þ0°;%Ó6J_„vñšD)¦Á¡w¢{·r×ô—5Ø#},“™Àº¹^)€»ò[èûBKtvõ´á¼{¬,Tø~PõxÖ*[È+ÏÎH­OèyÐV>'>‚ÖÀ·í}&E“O‚}¥·h¿Œ{›«Lå|´¯,NÍ-Î`„1}v
+”Zt`U«ta“RJ#³ËWpôÊ£œŒì GsD-ÜïÑß2…ÀÈüw…~ÖT@‰F›`D¯l‚Æì·çkJÀÐöàø×&w…á—}%³äâCé›Æô1ÛJ™ÂÇ«oæ¿|Sš?Ñ@&½Bä_<Ÿÿò-?$ßÿüUúô=Ò,
+üžÇ·ÁCµ®¬ËI¡SÂíŽáxNÓ&Ñ¾ùo¦E%ÖÝ;ºE×ô?*tÙça¡fÂGgï(¾2”ãE;ÌHÁCg·€¹ù`\¥ç´	{ªáìD"ác`t ˜‹¿ƒbw-Dl/ÄÝˆ zZRžAÓ	éÃ–ÿNgÂÕ b—&,ŠßÔ šINØc»œ/Ö²‡Œ&$-Šx+Ä{1ƒ ¡à·ü,,·ŒÜ„åío„5®ÀžÍÊP»…§¡Z—RO0| Ž€Ú>ja	ÃKÌr]áâbUAœ k+Üq1"$ªÃ«™_K+„qÔ­¾–*8^~&Z'3”‡*%¹¢ Šw6@™ž†Û.YÍ´MTgàI#œuÒ~
+¯çÖ%Õ¨+®Ì—[BL¬ú·KÞKqGHWF’|¸(æ[Ž ¢eƒù(´Ž×P3ü¨÷Ãhÿ£Â”{ø[ÖÝÜ‚UÁl	¬sG#<€÷­i$‹)›‡¬Ê}z&-Ø;…9¾vO«Ð%#ñ¾pýãâŠ¤¿NIŽWÌ"*'5Ä`¸g£kF†¿²®™KÆ|òæxœî
+¿iMìÅ%}ÅË-ãÓz+VºöüØ[Ì¡XaÆ­ïÙ+}¹rÂ¦ƒW(æ·Å0ÄßZØ½Ž«ù¤5KCsÑï{!µÞÏ¾ÀÒÐšÓ;T£áI¥ÅÐÑBÞè½?b·F6ËÂ¢«¹ËŽˆµ‚ŸÁ±@–[ŠÓ¢¹ÎïÄù­ˆÇ™­:bƒ«i7[ãâ¯6`¦×#QDªtãŽuÞYçkÒ,ÅhhT4\|B¢ó?qE|_½»VÉÂ~+Z=U«ÁpÒëœpæ8Þóvsÿ*?ís7)à5-R*ãËü¸¬fðæ§Xî>&Jí5æ÷ bUˆf4;¾ÉÚÀ„ùgêÝ…c0§“ïou‡æ‚=ÞXá>ÅîÌÅzŠ}ÊùPê8ö×˜ð,ü°zÜ®ä. ´_B¸<pŒL‹ò]œ#V™ë%ýÕÀñw¬*Æ÷0èéu´ò?ÕàkÞæ €Š~áâF^+!åax³fÆrÔ†3òÁÝ€5gX0³íu¾Úm,
+S0M5cñ¯õ#Y3<')¥µÀåÛ[†u²Ic›ˆ±Ö÷ª6­÷´ú€ÀåxÇnFƒH±`ZPÍÀàöG2p2yH+ÃG¹ã›(£®WB ÿÿ‚Y´hH¾òhŸŠÃEÃ³ÛZç;á§¡û i­æbQ®ÓÅþpE
+-Â-µ#F4 £²²Éõ\'|þrDV›v*`Ue«ì)
+ä+ëy~{ÞßÒ¾ŸÍ”ÚšR]CªÍ6—)2Ñ …•#§ûÓwÌFŽÉüeÃx
+”j.‚> ¨€|´xÇ©Úq£!2¶á›-ÄcÐ–iÞŸg–=Lió×Ë\ÃñÙubL¨ø,	¸MÆõ¦á{.{*L¸‡«ñlÃ9³%Y—5Bï7 SÜ«6•N@¤jÐÆ¸6“½•n{È`ækÆ—$´¸2é%Joü˜ Õ8ë…Ò—Xé_)ÁÛ(Á¥2„î)âG‹8®_µ“^\Y)ßi#ŒîS°E‡“ú„HQvÕ&›#EàÝ$Z&Es`RfEDÆë}’&~&0¤úÂ‚3…¶™‚‘Ù€w´s¼ vœñÏ™¿UŒÄIr-šjÏÅ‘Îñä8”#yUgíý´‹C¸ï¹)…;J5ÞG¨ÐðÍƒ‹¿ÃE¯Ï‹¾¢H,'³²¬tU‰-‘›Ža
+âYÂl+\3¥.¢"…{œÇ€Òë2²¸qá8ŽPÒ(@ˆç‡œ¶ÎÉ¶ðS•FÌGŒi3bn†­ÄÇl³¶ëDgœÔŸb›åÐ[²QŸ)3í\Q‡³:Mªgÿ>S¨Ÿ¯  àÂ(ðp‰T¨•Ü¢ºv‰
+8nµ_õ³Ô6–Yë9ÁŽdém´²ÃµrLÎ4BímD?.ŠY›µäÙRÙ xäQTsQj›.G÷·Á	cõaŒ	¼Åº
+EÞùÊ{•{ï"®oÖWAª‘¶of5Ì×[^!x›Co€˜Ï-*ÓÏÉœµ¾Î_^ˆC“>¹,Ã–²HˆØ:òI*±ô5…q®•o´2§(°‡çqá­ZUäºãäÚ+ÑÙ¾ïŽs€7:€›–1iÕò¢ËY‚qnÇ×ì3ã·VŠîSg–ãÏ—-úØYÑtÞbÅ™'Lª“Ü"†°^“H”1c¦m"¦l‹5ã¶¦Ëü[ã™Ô¿¹‚k–8x¥‰†ˆÆ6}8þQÏnÆ™¸–[™Íæ
+Ñ¬°9
+·î»º†ErAü·€iR©d¬8¡ÕA˜‹öªØ6+S®¬ˆXÉlfdQŽvV1¿
+ àˆüaÎÑ ÄEÁ\ÏIÌÁ†”Žq8~Kì2u%—üKm4Å&¸-ýg‹ÇX©ùÙ#Y¤”¯ñxYQ†2 ƒ¤—”ík0ZL„ÁsTŠƒ˜ƒ\)íl/õ—LvÁ£õ•íRèï¢“ï'Ò‹nlsÞ5&8ô4ŠM|±†±'M×Áõˆ/DQ4ÎÂ!q\&<Õ°¯ìv»|,8ÕCŒù–ñA‰´DöÉ;IrnÏý˜ú?/8çVTd` Z]‡r‘Ð5s˜iF AT´÷Ìb}ùŒÐ¤çííòün+eÚ#Q*â˜¦7Ùlà[$$$¡–<¯åÈ ÊrýºöV¥30*ŒËáòÆ)a]púJÌóÄï˜ŸRR¦ô'"JÜ,G˜ÿò]RR/&«"§j`DË+M’™gxE%0èJEæ¸$ZJeÄ‰2öÚ	§TcœÖCG‰¢ƒ…ÒŸƒ	—ŸAm¸ß"IP—ðI*ó8IÐ½ðá8×[¡t¹'ŽXBëêQ¤‡«æý\ëP%29›·Îh‘¢ìÇ,vÚ
+¾Uˆ${ˆuA„jºå¬ìïÇ2PqDw bVlõJþ˜›ˆ>°ÐåŠqÙ±.ñç˜ÚFy¡º/¾ñ‘'(ò†°ÖCë{kH:‹¶–¯¶’Á„á½É©Ý½ï¨œ]€Á´š‡#ë0³AÎp|âã„ŒÂˆXáŒQ*äéëÑm•bð}¯Uù!HÐufpYU¾^«xÃýôy¸ãÝø9Ý’?åK†¢ãñV­šwà‘¼oºcZ@Õ´ ÊûÏmPòŒ½[œP)È#!‚®òbtg…ë¦qû`i|À•Ñ¥ôx{o…•žxw=Çãû™¥Z²ÝÓ¦’ÏÂ?È#=žýÐB3tö°xh`Œ*TWâæjÈ
+ÖÑrÝâL£ÄGš°…tÎ>Í¦
+_çAÔ¸Üà®“_ŽÝWÖ¯(ë™PÃ·D-‚Æýaí=ä^Ú|+å‹W°ŒwÏs%®ä4«.:)z¥!~#¾´l«$l\Óô®Â˜ÚI¸ª˜€|(hýr’›J\lÆÝª’%¸—õÂºZË}[|;Í;•	‚L%©\,…¤cqæZµžûÒÞÚsÐùfoí•›ö¶±P3·^±p´Ë#ô c‡ÚŒZ—¬{$äq+]A¢w†•s„UG0JH‘lØz´{0™Þ']·#¡îÞ€GG5À³bÑFKòñ(Í0ÔK<í¢óô“HŠÞÛ ]ŸSô¿4ÎW¨Š|›b”Vt¡³Ö6ÇÎ8Ñuò¦tŒâX}c½0½”ê7D-pðo’ò0ÛRÔZ_¢0(+…ÕŠîÔ•Ù“ŸK¡)¸©SI7ó]yQûÒõÏŠ2(Ø>Ê´9Ë9,ENS-Qãh^’›Ü#mÔ€ÊÂ†&7¾Ù`”C4×mè1¬j1Zt=
+­^×¡·K)K³²fŒ¿üMœƒ±Ì°h»>[ŠMk
+‚{IbŸŸuWˆA
+ìVÎ÷Š÷rŠ^™š?ÊY/.J¶®U"!Ò¤\Úb„xpÑä"ÚÂBÈŠeìS6e¶8MŽýþš]K'a¬Tîj³¹Ž@ÕŒ¨-Ðüóª¢9œKõÏ°GuôñÛ\I=Së‹|éD'AÌ`2J¡Fÿ ë¿X÷ ŒÓWÿ ˆ_î:;ª¸çº]žö<žP}wf[á¼,ƒgÛ´&æVœ…þv¥3à‰À‚“ÂHå¨®\PùÿD–à Ï2/g)õPn~[Ô§R‘¡ÙÏx°%¹èÀt
+¨ºi-ôc÷“ÊüžÚVyx]‘+6 ¡:+ºîÀã]>¥;T;À$i®ª§\Ë† <@YlãëÐâÖ­«PºÍØZqÎÆµYŸ¤&ûÛHUý!>ÅPÙÑrù8@Lh©¹˜¬…zÐUyó)/ˆ÷
+N˜g£*¨ƒ´õgð‘9me¦•¡ƒ9%‘Ní{ìêâåÉi›FË2y‰?¡\¡CÁ#5Ì
+#Õ)kRÈÎôqÀCõÕ© !ÌpÓ?qŸ‚°½±]£¬Îø!0þw­s7§<ÄÃÀh*Â0ËgfdEXagzÔù¡o[­ù|¿5Œá‰0FïE×ÓCôÕs9ÜsÁ˜•Ê5_¯\®°Jv^•k2wiŠ~›…°
+ËéMèë,ÿ›~øîƒ5¼*ëˆò¼x	c#ÊxÑwêyêË‹ÖFËo>i4Ç¡jI#MFÍ|nLJ\QåGB;–-Xx~äßg0³YÐë±6ª;:Œ{Â¯Íö,²p £Ž¼­ ©ÑnQQHÖáÞò‡+O¹¬Ü"w`)/¼ltC5‚“]ºÄ{HÜ'>øc2je/BpR[¦NÂÌH¶î—ê à±úê ¹Ãa…ÁÚ7Z5Eú ºÎØsöCG›ÿ/H-Œµ}8ì$dÓ¤¡µ"0
+åw­µg‚RMXlb)¢Užnð‰«+¬ÿ@Ä-B/\ï=F×Tq f‡ç#}~)™l»k¶{l*¬æƒs5ñþî6WYÅÕg=I;U‹¸o?_õcÄ!L«§Õ¯ÿûìò¾\›Kó©ñ`ÃCåbwd:Äõ
+~ôb2l°©Lñ®yäD•d@ËìaýÁÍ•2Žöf Cûýæu 1¾râ4]‘«™¸D	
+QDºp}†y`£	C­b×÷&™WŠ¶—™zŽN1À±ÃUîèÃÂ@.8GN¥N5­%å%
+ç¹ã“²æ{óEUUÿ%æÍ
 endstream
 endobj
 293 0 obj
-<</Length 4368/Filter/FlateDecode>>
+<</Length 4273/Filter/FlateDecode>>
 stream
-xœí]Ûr·}çW)ËâÐ&ˆû`\Š‹R;VªRâ[”“•­$%ÑÍTä¿OÍ—n 1»Ë]Q1Åîmƒi Ý§{Î¾¹¹ýçêÇ«Ûæù«óƒ7¢áoN‡Á¹k®Þ]ñæê—†3ÁEoyçlÃïW½”ã[-DgMóËÕõxò»Æ
-Ùðæíø:¶òÖ7÷öà«ƒ¿¼|u~æ¯üôéÙÅ¯?ÿýì‡ýé?·_ýüèˆ¬³Mo-ë{Ð9^¸»0vÍßªñOÏ½šYišwo,3ºsÊèä]8€7W0LuÃÛ·TL)ìp„JOUáŒ«ñýtÊÛá}<'¾‹‡¨ñ
-Ó©j”MÚfzv8åj'²:Ýp&e§ïÉiõøVtVw¢y}þç†³Î4ÿmtó*ÊäÝÇ'“8do×Óƒ×³ü^ÿüãõÓ§g¯Î¿{Ñp/69É­c½°\ÛhË¤mzíWrß{Þ¼ø©Ð„È$ïÔ(yÓ1§ÓYÚsãœTƒÎ¸IgÆwQež_4¼¹¸9[ñFÈæb•ª o.Þýõøçü—ºUfz¿š¿1­˜¿áÒ¶»øþàåE¡·’ê­VÌ¤µc_Þ*3è×0Mì4c:Ø[Ñôdg§>q3÷MŽ¯7Ó'ÅýýÌGuãëåøÿzøß€¸èà‰Â¯ãññùJ·ÉoóU¥ ’{Ô
-y¸l?W¿F†{Òå»ð¤§tËC¤¨!’œõÝ–j0¾Ì£ôdîÞ$3.l+õ1W*aºqt °®àï’§Ã45÷æ²×Qà®¼¨ü±°ùð½@¯†8®"r[OË™Tªé¥`½ÝV1TE1ìžŸÑJ´bÉ,)¦Õ£ôÃg`â«ô§Q'>‡ï’ù'ÒÏ_¢ù\kè+ZŠ†˜¸®ï™ ëµ >ÈMÛño\¹å$N	e¨©™ëUJ´ÿ*wÈfêM¹C›jU•ÞpåíGèÂ+´T\vp°Ñóíë•fÕÊ …¨ÑD•½¦Îæ[¤*ÑeØ
-žYw<ÌÕlòø›	çêìj~~+|»¸Ç¾§¨×ñê¡ß:=O,¶<­ø~Ãý©VŠãB‹«²îz V¹òÚf°n‡1˜û¯‚DÁ…4šŠf2Üxù¶:0¼à$qS>ÍÔ|Ò-ÎyÚ¾t”:;Ãl?x„{Rh/„ü¶ˆ™oÓßvQ¯¼®dí®Ò=Î"ÝZofüì×D‹ï4ž§™1oÏÕà¡¤ç<mO‰ª&âwí|ÖM+:¬ªÈ0ø”‚3`£pÇÃœîŒJç·CÈ#Òø”31N
-árpˆ¥õ)>Ä&Ç¡øPfy§¥œãC§ãZØÈ{Q{Ê-Ò63[»…J"›‰p1HV²àQ¬àÚœBlÕmë#Îà¡ Ÿ[MŸ/[¡B N_•©÷þÃçÙ:¨$¾[ÇÌ·'l«ðbÃëmQì%vÁ‡¾…ÅS'÷)ƒñ²H‚é­épQYÅ§æƒ’L™n/Qøô#|ˆ¦Gš¿1/Št¿3®o¦©„õ2¸^Ð™sr	:v½pÜøûçñÇÉ«xW. xÏ-]®Ž³ß 7%Ž~5púãxÏœÜZ¹ÂõG­˜½€ËäˆÞFÐUø½_ÓïbW$’#LÚvl€aàÌ‰»øiô–"sÂ	?£N¿iggÅOseÊ‘ðWÃ¿ovR=¯H“ƒ:ç×P–(ªšðÃK}º×Àzj:N–ÀG˜ƒøE”/‰Î*Da8 F²<ç¡x1
-‘ôÅgDmøèUéd\+¨/FŠ`W5)Äà6œ£ÁµxxŸ¬µ>ÂÊž¬ø×K1 Ÿ…¼…¡Ó­pX$v½è,A|ñh‡9…ñvÄM`Ÿ¸ÄÞu&UŒ‘¡¿ÓÌ˜½éýÂ„Äv’Šý°ÕáEùì.¦	…ˆ3(@>y+^m†DÑÆÅ	Fèd³*‡Ó`@-µºÅŒ¼—Å…y
-]Úá;'ì¬+=¶éô­>‰÷ Ñë¢Ë™_Ö'ð™ kƒÆx!nÕÞYoD«$6ÐK¨"Ø…Ø˜i fæÙwèWÄð‘È«´¸y=ý Øº”Ñø}É©Ð7aÛS"t4¸iOãîtùR3å(› ù°;_OŸÐÈ¶ÆãÒH¨{I–ðB•õDÒ3*ø¸”ëZVtt…;Á±àL88@ÒèžxCŒE²ú„Åff ©=HeCëî˜°u³³ðÞË2+)à­ã"3#»b=ÐsR3qè8J¿Mé( Ä,Zœ™ãI”deÝ€GË½àŸ¥&%ØI®ß$ÿ—¹<qË4ø@	 ¯„¢ÔùÌ]–NCýâ¦¨w}o{?ò~ß­ª0±D¼Û#Kâœ—#@k
-kÂÍÔ0Šf­fb´ûÀ2ÏŠ,!¿²yQû0u¼›Çm7;1á´0ZÄÆkº„úýƒ¸ã8¿†™`ß¨Ý¹½ë À&=ˆÎWEÈ9 §­cš›ÆZ3ìJêî7‚¾¨á£'KÜ¶VDª©y«%Sî^ÂXIA%¥>í#xÇN Èüw^gÌx×Øg¤žÆ’q1I L46üû}$…ìôjW›ZPPY-‹~:‰&â@Èâe˜òþ›€MdÄ@{ÃXöé‡fkáváÛ²1ñÀ.2°°Êž½ÿã“o0rRh–:Q14ŸÐJÇÜ¾ø„/¶´<&KXÏwÉØ-£ƒ²£ì*ï˜³÷aU)  ïÑý:x]íiNž†™”V°°—q§Í«} Ý[0Ý ©Y™ •\×Q—2ðFòÖ6%º¤¢DêUôbJ;ŒíiB‚iü‹Û\Krø˜yx¦sŒ‹¨Üã–!FÝTíú„õd–¾GÄ;)fÆ1’™QpïUçQÎc¬C«Ä®PžÏ.ã·a<Ác5tú…Ï£™‘û@gÆO
-´  °Ižƒœ0°§2Øº§dqÿ0f7ÅöcZ°ãk F4³­D{ô!!¤j>…Ë%PìîP ±´B2>,SS05Ð/ã±x‰£ÏçÿS• É¸Q’õîcÍÊÚÛø~—@É‹Š@) Äˆa¡¹‡^Q0IÞ£]:ô·y'ô—Îaæª¶am1mzjç¨ŽyWíƒâ­%$s"Àâk²à½oÀŠ(¦P>šõ'p2d¯K´X@™Ê!ýNc¡“á`Š@-¿lìDQØ‰î-ëîD
-^D÷LC´,ž*¨*äJ`ð aÝ–vdR¢S:ò­¡?9ZQ0'«*÷#›¥¢d{ÆÇ£90=“ÈkKŠÖæ„f
-¹-Ä…Ë¤«x.€^2S‡z5Êå‡òÈgÜ'¸‡”ŠÏçó‚–X"1	Ô÷êå`§¢ˆxÚ)&¥¾‹ûµ”n™!½Þ*Ñ]rÈVâÝ¹¨×ËÚ	,ðw©»^ƒK•#¼«Áiý}ìB©žÃ¼Kuü6>]À|8d\7Ù¡Ø	E~×€ïz«Æ˜ãÙ$/¿¸0ÍâNé#þT(ÔàË€
-[æñïC*SÜxˆeeA\ûÌo+ÔÎA5­Z¢ÙûÑ* š b§Ê¹ü«]nÍ)¥×Žu|o[Ï€g‚œ"/E^Ê=-ßò’G¨ð`E 5Ø|lœPÜY›S`1=¶´‚S{ÊaFÂ6Šò˜6²]¢¬\Qò•ˆ{­ô	Þ9–íF½+&Ã6•+µù‚w­³ýè|„™ž!BÕyp·5£¢î‚Rwe˜œË½­òžZöÛ°›ZázÓéV¨j	¶‡qºÐCd*:šB¿¦ÒïðÄëËcÍÂ”À÷I{‰)DÉùì~K°¾;rL=¥#rò*³“Â®µÐL¸{ð‰µ¢ô%ëÑ¾Ç%¾JniX…erK$sÏ°C…bÞéúBÞM^B§Ì:Z8‹1KÒ¡ˆdë¢^XHdŒ±@HÄñÇ(*eo­0£Pí©ZŽjCØ œ,–zßoHh¨ä!ÝÅÌËªp&Êæõ.tå4S
-­… hl,aëæü”LNÀâúÄOÈVø	=3ÂgL,esRN…cu™§ ©z‰ª3h%ÚOáqVÃç2ÉK‰¦.°b”K¸&õx" X;+°D-°#0±#øÛY³Ÿ§G<	0	¨í“õ—ì‹á£ÖÅÚ¬©W|*{ZYÎœæ\í‡«1»Âi¢Ëm1¡á:ÙKŒ¥
-Çœ©	£Qþbþ ¼ç8?õËX)Xvÿ*²„˜È?8JHMÈïÌ;è·¥ó–Ký†u)ìë'Ó“g0üÞ¡ß r|Œë ùË³J—!VËÑRÌ[¥SbŸy8¾ï¤ƒmž4Sªü»«’½¡ø—L?•ìÏìçÁ‰Ã}T#¬Â·Ò9n¯dºWR=S{ÉÆ‰„”›y±Ñ5/D %îþÜÂaAŸr7&öç<Ä,yR£©`JKEÞT=<%,3
-™Í
-4-vê>÷JªÈ	Î¬$ÊÒÅhïÀ!YÁäÄz2_áÎdñ„§Â+×Åûˆ†®s^*.Lžðn05,/¾ ûƒQ* ¯B‰dVHvA1}É¸7ÕT0*n^³Xrœ×å-÷ àÉ°Ýøb¶l-5Zª¸b\uz»ÚiÄÚSˆ·Ñ¾'Ä	<GjUiG|«ú½;NÅð»~­›ÞT›Ÿø!pî(SOå2sä.+æjÓ÷_'$/å|&(¢ßJ^k÷LUøU¤2Ú‰ŠZJB-¥ë™Ñû$›à9ŒÆË†/d„ŽÜ‘éüÛö4Ô‰^sE TÝGiÝ€4Ü‡‹D•},ti‡#dH‹–s*ÌÄ$«6ðÆjÌÝmSè6ªWE<¦`Ë$ê:Áô3|×C¸¡Œ©Ý<,Ÿò–z¾_ 	¨\È¾µ³VÓjC ®R
-¦‡²[†öf¨„³Xà6 Z×¦¡a€q¼ð }Ûcð¢Ê[`ÞWáçLÅ D?Ü®Œ‡ìíCÆà±¸>að™6Y„Á[æ¸3½r3/:Ë:mº1voÊ(¼¡°6±ŸTÁ7m9=xe½ò´’FÞÕ`Gl{:
-9Ê“ûyÏ&û¨þdj¿(bú ÄxXƒ¿0¯y—ÓC¾FÈgBJ—Ð—IW×+«o(ú­è³¦‡ONÛ%ï×‰£¢Æ¿Cs,]•e@&õî"0‡¡Y~¼Ü¹c + âQaÅ- ó¸†HÐ6æ'tÏ„Ú pã¨h`Å4Ì‡Pô1éAƒ~\^þ°Šë¹³9Ê©­f’ËF˜aCüÿë.U?G$«žýl{<{³•|(Wè„Ì‡™-ŒíÏg’éøT"§•PÝƒ.€åõÉóÉô8 ˜’3§8ïÜT$¡<¥uo›ž³Îñ½-û>–bç‰¡©¢ïý<œ(hnºâ—±Ä9!mÒ{«f§%¤žÎ»VRúg¡l¬Öy+¸0ôÔ
-K+zK«³/çnNOâl¥›ÎóL>ùÕ°ÎõÛƒ`5æl¶ÃE	»Y¢E¶å_[|¨ìóN1iyZ-æ·â–žœÛ¥äClÅp‰ütïà£Õ
-?y‹ÒKÓžÎ7xÚêÉ×-³øèIÏ¬¸Û¶ eX1<r½é4»K’I_	ü¬Ëª‰ÏšŒžº¶šÀUÜFºóþ8(Ú·àO<’ý&ß
+xœí][“Û¶~ß_Áµ“xéDXÜ	fÜ¤ñ¥iÒ¸3ï[Ý‡x§š¶coÒÍvêüû)Ä98”´’×í‡•d x€sûðáèü›ë›®¼¼i?ròïF5²‘ÍjxQR†æòÍù¥l.i¤PRõ^vÁ7RÈ>HÓk=¾µJuÞ5¿\^ß4^éF6¯Ç×±—×±»×'ÿ8YŸüåäÙó'çñÎ_üúóßÏøñ×ŸþsóÕWŸ‚X%:ßôÞ‹¾ÃÑã»qãÐÂð¿füg§Ñ(+¼vÍ›F6^8Ûãlö.] ›ËF9aºáíëFaV~¸ÂäMMjq9¾ß4y=¼ŸÛÌïæKÌx‡MS3Ê&ï3oš\DVO^4RhÝY'ûA@z3‰v|«:o;Õ¼xòçFŠÎ5ÿmló|–É›÷O&ó”½ÞbNO^Lò{ñóW?òÝÓFF±éÜ:Ñ+/•óõBû¦·AH£ù½•ÍÓŸˆ.T!ù`FÉ»N›¯Ò^º´t&ltf|7«ÌÉã‹F6×çkÙ(Ý\¬s”ÍÅ›¿ž½”R¾”ÚŽ¯ëé“›^}û·‹ïOž]£ÔÜ(­.¤ÇèÜðÖ¸A¯†åá7+¥ƒ£TMÏòt3&Ç¦Ç×ëÍ'#ÁsHÙ¯¯Æ¿WÃß|!U*?¼~:_?_2Ýé&ûnº«V@jãu÷[¥Ï@¯Z%ÏÀÝ¯Ð…é™,ý±ƒ¼I·<E†›"-Eßí¹£+;K¦ámd&•oµ=Ò’Ædó¡Ý,xT°ià÷ZæÓ´éîå«6ÝÇ€/¤‰¢ŠkÄÃîÓÿ+ôê˜ë*"·¥ÕôRhcš^+Ñû}ÃTÃÁáÅmT«&‘L’’`YÝÏ?|¾É¿uâ3ø.[*ÿüZÏµŽ¾ä¥è˜…ú^(à§Ãàxä 7ëÇ£ÇÖqj(CË­Ü¨Rª½ø= _¨wô€v›Ôª*½”&Ú‰&0*DTh©¤îà<`£ûQ>*ÍºÕIQ§™*GMÌŸôH1L¦Ë°¼²<xZ«Åâ‰“ÚÚânq}ü¸xÄq¤hWóÝÓ¸mÞN-ö¼ñøyÓó™V«3¢Ç5­»Q¨Wi¢¶9¬Ûi¦ñ›$ÑSp#‹V€á„™M7^G±¯,†(8ÍÜÁ‘Â­ÐJ-]ÑâšçíKÇ©spÂ÷C$x$…ŽB(‹Y™ócÆÇ&õ*êJÑï:Ÿ°¤Ñã*²­f&®.pOä|7ó¹*ˆëb/x­¦%oó¨]1ª&âwíÔêºUVUdbÆÀ°SšœÁvÎäkAú!ÕQy^*……
+rRˆ¥õ1/Ä&' ¼P)áegµžòÂ`œÖŒ˜È[E'†=Y_˜­Ã¥†Q¢/šltØƒ­¡¿J`žJÍá
+°Î’7ètµŒ!~ú<™ ã@Oó÷<KruÈRÅV8²†áÓhµcŽ¦¨â„”ä¦Óha\w”$úb†Z‘J–½¦œ9…³{rT¢‘Ü]òæQ Elñ
+ìjáºñûÏæ/7«îœ&”¿ÇÀ+÷6gE‚NŠ¸³¶’÷)´	²Aï­›ÙöýVMNüX’qôPíŠøörE"%@d}'ô4()‚ºM˜Å/ðÙ14&ÙðËvŠ5â2ö'²_¾9@F<vô¸"MËéBÒBY¾£¤XY&Œ¦Æt§yñ4Õ|š'›MJš'SÓEßµ"’(œÏ&#Iæ¾e&2"1ƒ¡ôˆOãµ&_Œ[åädh˜üs]“Âœ›¦V0™Û:ÿ†Ï)ZS¬ìîxµ”²'ìXqÀYš:Ûª€Eâ·K®2ÀÏvZSž‰‘WÇ<ÚÌ.ö¶+©bŒ§øÎMïìFls±Ÿ¶6= ¢[°–eb^A@ÊÅ[ðz7 ‰ïpvN0Á.—5ƒ	õœwqF8}'Î…Ãhˆ!p=aì®+=¶éð¬¾ˆ ÑÛ‚ÃE\”üøÌ`­É c¸÷ê˜è¬"/‰ô(Èãm)Çf ›…yŽC†‰0J““ÑbE9·¨§ï×:ÒÀÃ}`<–b’ˆ±)ß®´ÃqsŠÉÛUüäÍÛùÀÙ+‡Mõ»r<)}ÂH‰¤Vgž)u§d	oTñ'š_Q)ÆåBWZÑÑn…¦vJ
+àÍ`ªÒÎö’ û|X*’ÕG(µ03Ú‹6ôÞØN(ßøÐ	?	ï­¦aTÍoT…9Žé'‰Y“›ˆÓš“‘IdarJJkÔ<åÃ ë£`Ÿäæ#=	LÍ¯³¿Ë´›yw3Å;øï„2Ò©å¡ Ê¡qI×ì¸¾÷}tsq‹yÐ
+ðŠ1ÄÑ”8'×HÉþ_oÁââh\Þ[¡F›pÜòœ$ôD/ESÒñi>m»)`IÍÒl1{¤¹»Œ;óæàôšVB†s£~§þ®Øš`´*B.Á;ëƒ°Ò5Þ»aÑv¿,ôi}¸DÁÀjE¤–[·Vî$eÕ,Bé xhÂ67–ßË:¹%†ÁÑ8#õäð”‚æ‡÷óÁBÃŸß×ùLÈþÁv½ÿ%@IÆä,rˆ“n ‹giÉÇÿI8DÁáC7Ì[ÿhöc¾¥Iq‘Ý öuÒû?.ñ¦0O£$tò²4ˆŠ¡á¨^ŽEý{FØRzN–pï2Ø-#ºãìªìDðwaU¹¤¿ÑÝr/(Xíªä9CƒŒLä;m±oq«ªc Ú{Ò ÿØ¸‹\Õdc)f»rÒæ¢DêEF1Ônb»êQJ°™rKkIï3eÎuAH5+ä í„„[¨Q7Í‡Œì }Äu
+Kß#ŽœV9Î9-Ü(¸·†Æt‡é8—8¢ó	Å‰F@Â^TŽèpÀŒsV8}X&£õäz €—”'˜æë ñlœ†?æì9¡;þ°b×dÿóÑ'`À·€ŠxúÅ»ÿ.±£ê™-qF¡3ª‡ƒc ¶Ò*-äàŸdÚÅ‰1v
+ £_®Å¾o/+§¡0-¤S3Zôá}=9µ+¨ñý!’§r‰Sƒ‡¹ƒHÞpøH9¢CFò7å9K(=!òËumWÚ§°Ä°÷ê@ {6ªý Èi)œÉ¬ä–” øì;PÈcŽ“fý	4†´ámÙðË4	ÚñÀ¤ó×Î€mš4±½Ý­˜¿KHè‘9`ˆûQ$R„ªBBFÐÒ°°,p %Zñ)omcãÙò(Âœ¬«b•*Êölv8§Œt•…ÏôÙ³L È7g\RH`anL3«æ¶ s)LÕ(—è™/Npó(_<s:X¢‚Ì5ãØ¹QîrŽmgƒZÛÛ„_KG"ˆ7áZ§¥ˆn5Þ–›õzY;þ.×k8©	Lt5­ª¿‹í'ÓssXé½>¥¾OLÀ0é×]¶&Âƒ?4Ò»×ŒkV}£ ß“ŽiwÎËhï+epRGà–	¶,ß§à<¹ã˜ ÊŠCK„úÂÕzÄMk–¸ôq¶hTÀ<(ú¼ýúP†ÛJNém<Úž3 ˜  (JQRçDéG¾Å	.=X3h6û%'AÖ—<WÌ¥<8·™œV$ìƒd‰ÏgCö;M«KP±ó¬•1Á'Ç²Ýitäù_˜Âæråv]ðvu±ñƒ´ÒD¨ºnç3*ê®8u7Nh%¥>š—œ2°Ñ†ÃTZLèÍŸ©B•E°=äØÑÄ‘©èxžü–JC>áÃ¨{¢Ì5‰%Ÿ²õ2SQ¦]6ÿ¾e¨Ý;®~nc&ãUV'‡][e…
+w[ÃéK1¢c9Ç%¢JiùW„›ÜÉç3íÇp©ƒwFGO®)ËÜÐt£%€Ñ‹“8ƒl[Ô‰ÍÑ!8ñÃËÛ*Í *2UKFíÐ'¢‘«ãŽ€„†ÊòC,¢¬
+Y‚6¯·á!˜`…1È‚‚®syÙ0Bù€Y	X\‰	…±ˆ˜Ð§ÜÐbCO0Þˆ õ¦¨«¥	
+–«ih:‡<Ñ¡
+ŸÖHõÈ½‚Nr¼Q½ž¢H,èž×€ÑôMV@Rç%[PÁ‘8š<Æ^2Ô7—ŸUî|³ñR+¥9ÑbŠcóã)7ä1„«l#p.ÎC\óäŒRû|ú °æ¬lúE«c\œÌr|UÅ1–™5
+@t  |²¸<n¨vËµt“SI›òYì€)¯UIAë0nö}Š+å)‹Z¯!Vë½r|Yc‚0ê˜§gbÁÛŠµåQª´î¡jâ¦Â[:ÿ|²%SþÕœ«£]²”-Awë´°½iŒé…9Êš™>“W‹tŽ«‰ðbÜO=œúTÆˆðè}IBA´5Ž	æ£TäÍœ3ÊgÙ|G)ãOrPw¹ÑQ…=ðyH¦¾'_.æô5<RXO!`E¿ý)ÞÉDVî‹7_HœªÞË¢•ði0¯«, Çƒ!.›®â€ìY•mabî’B_¯«¸¸¤wËjÄóº¦÷Ëw@o7†í:V‹ËP§ã N#¦³ÇÛ’N0!Ö"YF›–0ÉOØ«UÔvö^r|€"nÙµaó¦Ú}y|}äP¦£zD¹¯¦;ÝC”$?~É|ŒxÁ(—(Iã>ðV[_¦B¦¨ÂŒ³¨¨¥fÔR‡^8{L¦^Ã¬QdäÂ9Î‘ø±iÓ®bäƒ»èí¸ÊŒÚ‡&¸‹‰+ÌHé€3äX‹V*´Âì,l"}Õh·û|Û©¢ó; {}®³Cß1=w;xÊ˜ÛŠÃò¡÷ÃK°Ò	P‘%,{ï`­¦ÕŽAKµVÂ…ùöLíÝP«fñ$ÿM«&q]µÓ›”&'j—\çÇtn «~(JôXæ^
+;”kRýð¸~0º÷2€ŽÅõ@/´É# Ý‹ ƒëM˜tÕyÑY×¹û[GCèŽÃÚÔqø½lÛÕGDðÊç,@Î‹S`žŠ7ës);ºêü¦§Ï‰4
+Œ&kˆ0=ÌL¬œ‰xÅpêUìG„UÞõðwÆ	­G£¯Ä›ñOÅ!¸x®UœEÌÊËß›Q6ŒchúÇØ¶8•˜vûa1T¿)¹OeÇe<jè´ã <e{¡ÌqÐi §#ƒœ‡-
+)A\ùœYàˆ*Áÿ¸\ùËé¸ýü(œ/!Kë­ÐR7Ê[Óÿ_À5UlÑjàô×ûƒÓ»¹å¡:`@x°V¶r¾Â˜LÇßð	Ö(Ó}ÐÕ	°¼>†1…'HRKŒ”]ØÔ)è†0ÆXÛû¦—¢‹B|ëé@Æs<95”þ4C*}œŸòIš‹=]¸v5+ý)M€éåôŸ8Ä¼À‹¼,`´©¶øÏñ[;[œ.÷ìO¡:Ñ…~Ðª¤<›ãÐïà£8ÕPlÑ×üwÔ»3B{™×dù­8úSê§d»üê50Ý¢lƒtäð¯SI…AuíÚÕô€«ÖnHÌ g1ÿ£‡-+µ' ¯†ßo:+ns¢£¯¤:qÕõ¹'½E¿c“¶† EnûÜz?”Æ[¾’ýGÛ5
 endstream
 endobj
 294 0 obj
@@ -3080,12 +3088,12 @@ P·”˜a@H¿ÒÃ NÖ‘Òt†¢D^‘½†ahCÀ½Ðb†Þ8Ý&eŸŠÃð*l¯‹kiî¥aþƒÉ•2WÓ0~èo˜¹†a
 endstream
 endobj
 326 0 obj
-<</Title(Sid Jain Resume)/Keywords(AI product engineer, AI lead, staff full-stack engineer, founding engineer, TypeScript, React Native, Chromium, DNS)/Author(Sid Jain)/Creator(Typst 0.15.0)/ModDate(D:20260727231435Z)/CreationDate(D:20260727231435Z)>>
+<</Title(Sid Jain Resume)/Keywords(AI product engineer, Applied AI lead, staff full-stack engineer, founding engineer, TypeScript, React Native, Chromium, DNS)/Author(Sid Jain)/Creator(Typst 0.15.0)/ModDate(D:20260727234138Z)/CreationDate(D:20260727234138Z)>>
 endobj
 327 0 obj
-<</Length 4304/Type/Metadata/Subtype/XML>>
+<</Length 4312/Type/Metadata/Subtype/XML>>
 stream
-<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/"  xmlns:pdfaExtension="http://www.aiim.org/pdfa/ns/extension/"  xmlns:pdfaSchema="http://www.aiim.org/pdfa/ns/schema#"  xmlns:pdfaProperty="http://www.aiim.org/pdfa/ns/property#" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Sid Jain Resume</rdf:li></rdf:Alt></dc:title><pdf:Keywords>AI product engineer, AI lead, staff full-stack engineer, founding engineer, TypeScript, React Native, Chromium, DNS</pdf:Keywords><dc:creator><rdf:Seq><rdf:li>Sid Jain</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.15.0</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-07-27T23:14:35+00:00</xmp:ModifyDate><xmp:CreateDate>2026-07-27T23:14:35+00:00</xmp:CreateDate><xmpMM:History><rdf:Seq><rdf:li rdf:parseType="Resource"><stEvt:action>saved</stEvt:action><stEvt:when>2026-07-27T23:14:35+00:00</stEvt:when><stEvt:instanceID>76nhCT6clFDKjzrXhtl71Q==_source</stEvt:instanceID></rdf:li><rdf:li rdf:parseType="Resource"><stEvt:action>converted</stEvt:action><stEvt:when>2026-07-27T23:14:35+00:00</stEvt:when><stEvt:softwareAgent>Typst 0.15.0</stEvt:softwareAgent><stEvt:instanceID>76nhCT6clFDKjzrXhtl71Q==_source</stEvt:instanceID></rdf:li></rdf:Seq></xmpMM:History><pdfaExtension:schemas><rdf:Bag><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>XMP Media Management schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/xap/1.0/mm/</pdfaSchema:namespaceURI><pdfaSchema:prefix>xmpMM</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>UUID based identifier for specific incarnation of a document</pdfaProperty:description><pdfaProperty:name>InstanceID</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>Adobe PDF schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/pdf/1.3/</pdfaSchema:namespaceURI><pdfaSchema:prefix>pdf</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>external</pdfaProperty:category><pdfaProperty:description>Keywords associated with the document</pdfaProperty:description><pdfaProperty:name>Keywords</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Version of the PDF specification to which the document conforms</pdfaProperty:description><pdfaProperty:name>PDFVersion</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Name of the application that created the PDF document</pdfaProperty:description><pdfaProperty:name>Producer</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Whether the document has been trapped</pdfaProperty:description><pdfaProperty:name>Trapped</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li></rdf:Bag></pdfaExtension:schemas><pdfaid:part>2</pdfaid:part><pdfaid:conformance>U</pdfaid:conformance><xmpTPg:NPages>2</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>76nhCT6clFDKjzrXhtl71Q==</xmpMM:InstanceID><xmpMM:DocumentID>8WwkqRF/py529rYo68LIrg==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/"  xmlns:pdfaExtension="http://www.aiim.org/pdfa/ns/extension/"  xmlns:pdfaSchema="http://www.aiim.org/pdfa/ns/schema#"  xmlns:pdfaProperty="http://www.aiim.org/pdfa/ns/property#" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Sid Jain Resume</rdf:li></rdf:Alt></dc:title><pdf:Keywords>AI product engineer, Applied AI lead, staff full-stack engineer, founding engineer, TypeScript, React Native, Chromium, DNS</pdf:Keywords><dc:creator><rdf:Seq><rdf:li>Sid Jain</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.15.0</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-07-27T23:41:38+00:00</xmp:ModifyDate><xmp:CreateDate>2026-07-27T23:41:38+00:00</xmp:CreateDate><xmpMM:History><rdf:Seq><rdf:li rdf:parseType="Resource"><stEvt:action>saved</stEvt:action><stEvt:when>2026-07-27T23:41:38+00:00</stEvt:when><stEvt:instanceID>4A0rfv1Dz4ByjkIr6k1UGA==_source</stEvt:instanceID></rdf:li><rdf:li rdf:parseType="Resource"><stEvt:action>converted</stEvt:action><stEvt:when>2026-07-27T23:41:38+00:00</stEvt:when><stEvt:softwareAgent>Typst 0.15.0</stEvt:softwareAgent><stEvt:instanceID>4A0rfv1Dz4ByjkIr6k1UGA==_source</stEvt:instanceID></rdf:li></rdf:Seq></xmpMM:History><pdfaExtension:schemas><rdf:Bag><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>XMP Media Management schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/xap/1.0/mm/</pdfaSchema:namespaceURI><pdfaSchema:prefix>xmpMM</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>UUID based identifier for specific incarnation of a document</pdfaProperty:description><pdfaProperty:name>InstanceID</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>Adobe PDF schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/pdf/1.3/</pdfaSchema:namespaceURI><pdfaSchema:prefix>pdf</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>external</pdfaProperty:category><pdfaProperty:description>Keywords associated with the document</pdfaProperty:description><pdfaProperty:name>Keywords</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Version of the PDF specification to which the document conforms</pdfaProperty:description><pdfaProperty:name>PDFVersion</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Name of the application that created the PDF document</pdfaProperty:description><pdfaProperty:name>Producer</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Whether the document has been trapped</pdfaProperty:description><pdfaProperty:name>Trapped</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li></rdf:Bag></pdfaExtension:schemas><pdfaid:part>2</pdfaid:part><pdfaid:conformance>U</pdfaid:conformance><xmpTPg:NPages>2</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>4A0rfv1Dz4ByjkIr6k1UGA==</xmpMM:InstanceID><xmpMM:DocumentID>8WwkqRF/py529rYo68LIrg==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 328 0 obj
@@ -3386,44 +3394,44 @@ xref
 0000068849 00000 n
 0000069280 00000 n
 0000072721 00000 n
-0000078219 00000 n
-0000082658 00000 n
-0000083065 00000 n
-0000088406 00000 n
-0000216077 00000 n
-0000219534 00000 n
-0000226990 00000 n
-0000237412 00000 n
-0000270867 00000 n
-0000273809 00000 n
-0000276480 00000 n
-0000279853 00000 n
-0000286906 00000 n
-0000294950 00000 n
-0000390752 00000 n
-0000399469 00000 n
-0000404994 00000 n
-0000409708 00000 n
-0000413719 00000 n
-0000418091 00000 n
-0000420679 00000 n
-0000426274 00000 n
-0000429560 00000 n
-0000433699 00000 n
-0000437655 00000 n
-0000447913 00000 n
-0000454612 00000 n
-0000474035 00000 n
-0000480569 00000 n
-0000484444 00000 n
-0000490629 00000 n
-0000493842 00000 n
-0000526825 00000 n
-0000537754 00000 n
-0000538023 00000 n
-0000542405 00000 n
+0000078189 00000 n
+0000082533 00000 n
+0000082940 00000 n
+0000088281 00000 n
+0000215952 00000 n
+0000219409 00000 n
+0000226865 00000 n
+0000237287 00000 n
+0000270742 00000 n
+0000273684 00000 n
+0000276355 00000 n
+0000279728 00000 n
+0000286781 00000 n
+0000294825 00000 n
+0000390627 00000 n
+0000399344 00000 n
+0000404869 00000 n
+0000409583 00000 n
+0000413594 00000 n
+0000417966 00000 n
+0000420554 00000 n
+0000426149 00000 n
+0000429435 00000 n
+0000433574 00000 n
+0000437530 00000 n
+0000447788 00000 n
+0000454487 00000 n
+0000473910 00000 n
+0000480444 00000 n
+0000484319 00000 n
+0000490504 00000 n
+0000493717 00000 n
+0000526700 00000 n
+0000537629 00000 n
+0000537906 00000 n
+0000542296 00000 n
 trailer
-<</Size 329/Root 328 0 R/Info 326 0 R/ID[(8WwkqRF/py529rYo68LIrg==)(76nhCT6clFDKjzrXhtl71Q==)]>>
+<</Size 329/Root 328 0 R/Info 326 0 R/ID[(8WwkqRF/py529rYo68LIrg==)(4A0rfv1Dz4ByjkIr6k1UGA==)]>>
 startxref
-542595
+542486
 %%EOF

--- a/scripts/build-resume-pdf.ts
+++ b/scripts/build-resume-pdf.ts
@@ -76,12 +76,14 @@ const text = (
   {
     fill = "muted",
     font = "Source Sans 3",
+    kerning,
     size = fontSize.sm,
     style = "normal",
     weight = "regular",
   }: {
     fill?: string;
     font?: string;
+    kerning?: boolean;
     size?: string;
     style?: string;
     weight?: string;
@@ -89,7 +91,9 @@ const text = (
 ) =>
   `#t(${quote(clean(value))}, fill: ${fill}, font: ${quote(
     font
-  )}, size: ${size}, weight: ${quote(weight)}, style: ${quote(style)})`;
+  )}, size: ${size}, weight: ${quote(weight)}, style: ${quote(style)}${
+    kerning === undefined ? "" : `, kerning: ${kerning}`
+  })`;
 
 const paragraph = (
   value: string,
@@ -271,6 +275,7 @@ const experienceItem = (item: ResumeExperience) => `
     ${text(item.company, {
       fill: "strong",
       font: "Literata",
+      kerning: false,
       size: fontSize.base,
       weight: "bold",
     })}
@@ -316,7 +321,7 @@ const buildTypst = () => {
   return `#set document(
   title: ${quote(resumeData.pdf.title)},
   author: ${quote(resumeData.person.name)},
-  keywords: ("AI product engineer", "AI lead", "staff full-stack engineer", "founding engineer", "TypeScript", "React Native", "Chromium", "DNS"),
+  keywords: ("AI product engineer", "Applied AI lead", "staff full-stack engineer", "founding engineer", "TypeScript", "React Native", "Chromium", "DNS"),
 )
 #set page(
   paper: "us-legal",
@@ -331,7 +336,7 @@ const buildTypst = () => {
 #let muted = rgb("#a8a29e")
 #let accent = rgb("#d97706")
 #let rule-color = rgb("#3a3836")
-#let t(s, fill: muted, font: "Source Sans 3", size: ${fontSize.sm}, weight: "regular", style: "normal") = text(font: font, fill: fill, size: size, weight: weight, style: style, s)
+#let t(s, fill: muted, font: "Source Sans 3", size: ${fontSize.sm}, weight: "regular", style: "normal", kerning: true) = text(font: font, fill: fill, size: size, weight: weight, style: style, kerning: kerning, s)
 #let logo-tile(path, fill: background, size: ${spacing[10]}, image-width: ${spacing[7]}, image-height: ${spacing[5]}, dy: ${pt(0)}) = rect(
   width: size,
   height: size,

--- a/src/app/(portfolio)/page.tsx
+++ b/src/app/(portfolio)/page.tsx
@@ -5,15 +5,15 @@ import { publicUrl, siteConfig } from "@/lib/site";
 
 import { ResumePageContent } from "./resume/page";
 
+const resumeDescription = `Sid Jain resume: ${resumeData.person.role}, founder of Yuppies Tech, and AI product engineer at Namefi.`;
+
 export const metadata: Metadata = {
   alternates: {
     canonical: "/",
   },
-  description:
-    "Sid Jain resume: Senior Full-Stack Engineer / AI Lead, founder of Yuppies Tech, and AI product engineer at Namefi.",
+  description: resumeDescription,
   openGraph: {
-    description:
-      "Sid Jain resume: Senior Full-Stack Engineer / AI Lead, founder of Yuppies Tech, and AI product engineer at Namefi.",
+    description: resumeDescription,
     images: [resumeData.person.image],
     locale: siteConfig.locale,
     siteName: siteConfig.name,
@@ -24,8 +24,7 @@ export const metadata: Metadata = {
   title: "Resume",
   twitter: {
     card: "summary",
-    description:
-      "Sid Jain resume: Senior Full-Stack Engineer / AI Lead, founder of Yuppies Tech, and AI product engineer at Namefi.",
+    description: resumeDescription,
     images: [resumeData.person.image],
     title: "Sid Jain Resume",
   },

--- a/src/app/(portfolio)/resume/page.tsx
+++ b/src/app/(portfolio)/resume/page.tsx
@@ -16,6 +16,8 @@ import {
   ResumeThemeToggle,
 } from "./resume-controls";
 
+const resumeDescription = `Sid Jain resume: ${resumeData.person.role}, founder of Yuppies Tech, and AI product engineer at Namefi.`;
+
 const literata = Literata({
   subsets: ["latin"],
   variable: "--resume-font-heading",
@@ -38,11 +40,9 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "/resume",
   },
-  description:
-    "Sid Jain resume: Senior Full-Stack Engineer / AI Lead, founder of Yuppies Tech, and AI product engineer at Namefi.",
+  description: resumeDescription,
   openGraph: {
-    description:
-      "Sid Jain resume: Senior Full-Stack Engineer / AI Lead, founder of Yuppies Tech, and AI product engineer at Namefi.",
+    description: resumeDescription,
     images: [resumeData.person.image],
     locale: siteConfig.locale,
     siteName: siteConfig.name,
@@ -53,8 +53,7 @@ export const metadata: Metadata = {
   title: "Resume",
   twitter: {
     card: "summary",
-    description:
-      "Sid Jain resume: Senior Full-Stack Engineer / AI Lead, founder of Yuppies Tech, and AI product engineer at Namefi.",
+    description: resumeDescription,
     images: [resumeData.person.image],
     title: "Sid Jain Resume",
   },

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,6 +1,7 @@
+import { resumeData } from "@/content/resume";
 import { env } from "@/env";
 
-const PUBLIC_SITE_URL = "https://f0rr0.github.io";
+const CANONICAL_SITE_URL = "https://f0rr0.dev";
 
 const withProtocol = (value: string) => {
   const normalized = value.trim().replace(/\/+$/, "");
@@ -46,19 +47,18 @@ const resolveSiteUrl = () => {
     return withProtocol(env.VERCEL_PROJECT_PRODUCTION_URL);
   }
 
-  return PUBLIC_SITE_URL;
+  return CANONICAL_SITE_URL;
 };
 
 export const siteConfig = {
   author: {
-    bio: "Senior Full-Stack Engineer / AI Lead building AI-native products and hard production systems from zero to launch.",
+    bio: `${resumeData.person.role} building AI-native products and hard production systems from zero to launch.`,
     handle: "f0rr0",
     image: "/resume/sid-jain-profile.png",
     name: "Sid Jain",
-    role: "Senior Full-Stack Engineer / AI Lead",
+    role: resumeData.person.role,
   },
-  description:
-    "Sid Jain is a Senior Full-Stack Engineer / AI Lead building AI-native products, mobile/browser platforms, and production infrastructure.",
+  description: `${resumeData.person.name} is a ${resumeData.person.role} building AI-native products, mobile/browser platforms, and production infrastructure.`,
   language: "en-US",
   locale: "en_US",
   name: "Sid Jain",
@@ -72,5 +72,5 @@ export const absoluteUrl = (path: string, baseUrl = siteConfig.url) =>
 export const publicUrl = (path: string) =>
   absoluteUrl(
     path,
-    siteConfig.url.includes("localhost") ? PUBLIC_SITE_URL : siteConfig.url
+    siteConfig.url.includes("localhost") ? CANONICAL_SITE_URL : siteConfig.url
   );


### PR DESCRIPTION
## Summary

- derive resume SEO/social metadata and site bio from the canonical `resumeData.person.role`
- make `https://f0rr0.dev` the canonical fallback and align the package identity
- disable kerning for PDF company headings, regenerate the Typst output, and rebuild the public resume PDF
- preserve the resume copy introduced by the two latest `next` commits

## Why

The visible resume used “Applied AI Lead,” while duplicated metadata strings shortened it to “AI Lead.” Builds outside Vercel also fell back to the retired `f0rr0.github.io` domain. Separately, Literata kerning caused PDF text extraction to return “BCG Digital V entures,” which could degrade ATS parsing.

## Impact

Search metadata, social previews, structured exports, and local/CI builds now consistently use the canonical role and `f0rr0.dev`. The PDF remains visually consistent while extracting “BCG Digital Ventures” correctly.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `typstyle --check career`
- regenerated and visually inspected the two-page PDF
- verified PDF text extraction contains `Yilu, Lufthansa Group / BCG Digital Ventures`
- verified tracked files contain no `f0rr0.github.io` references
