### PR TITLE
feat: strengthen resume leadership positioning

### DIFF
--- a/career/generated/sid-jain-resume-dark.typ
+++ b/career/generated/sid-jain-resume-dark.typ
@@ -17,7 +17,7 @@
   margin: 0.58in,
   fill: rgb("#1a1918"),
 )
-#set text(font: "Source Sans 3", size: 10.5pt, fill: rgb("#a8a29e"), lang: "en")
+#set text(font: "Source Sans 3", size: 10pt, fill: rgb("#a8a29e"), lang: "en")
 #set par(leading: 0.625em, justify: false)
 
 #let background = rgb("#1a1918")
@@ -29,7 +29,7 @@
   s,
   fill: muted,
   font: "Source Sans 3",
-  size: 10.5pt,
+  size: 10pt,
   weight: "regular",
   style: "normal",
   kerning: true,
@@ -120,10 +120,10 @@
   #block[
     #set par(leading: 0.625em)
     #t(
-      "Applied AI Lead and senior full-stack engineer who turns ambiguous customer problems into production AI systems. Blends customer discovery, technical advisory, evaluation and workflow design, hands-on prototyping, and production architecture across AI, marketplace, browser, mobile, and infrastructure-heavy products.",
+      "Applied AI Lead and hands-on engineering leader who turns loosely defined customer needs into production systems. Leads customer discovery, technical strategy, teams, architecture, and delivery while remaining directly involved in AI workflow design, evaluation, prototyping, and full-stack implementation across marketplaces, browsers, mobile apps, and infrastructure-heavy products.",
       fill: muted,
       font: "Source Sans 3",
-      size: 10.5pt,
+      size: 10pt,
       weight: "regular",
       style: "normal",
     )
@@ -169,7 +169,7 @@
           )
           #v(-6pt)
           #t(
-            "AI-powered registrar for tokenized domains and domainer workflows.",
+            "ICANN-accredited registrar building AI products for domain ownership and sales.",
             fill: muted,
             font: "Source Sans 3",
             size: 9pt,
@@ -181,19 +181,37 @@
           #grid(
             columns: (1fr, auto),
             gutter: 12pt,
-            [#t(
-              "Lead Applied AI Engineer",
-              fill: strong,
-              font: "Source Sans 3",
-              size: 10.5pt,
-              weight: "medium",
-              style: "normal",
+            [#grid(
+              columns: (auto, auto),
+              gutter: 4pt,
+              align: horizon,
+              [#t(
+                "Lead Applied AI Engineer",
+                fill: strong,
+                font: "Source Sans 3",
+                size: 10pt,
+                weight: "medium",
+                style: "normal",
+              )],
+              [#box(
+                inset: (x: 4pt, y: 1.5pt),
+                radius: 8pt,
+                fill: rgb("#2d2418"),
+                stroke: 0.75pt + rgb("#9a6a2b"),
+              )[#t(
+                "Hands-on",
+                fill: rgb("#f0b85f"),
+                font: "Source Sans 3",
+                size: 7.5pt,
+                weight: "medium",
+                style: "normal",
+              )]],
             )],
             [#t(
               "San Francisco Bay Area / Remote · Jan 2025 - Present",
               fill: muted,
               font: "Source Sans 3",
-              size: 9pt,
+              size: 8.25pt,
               weight: "regular",
               style: "normal",
             )],
@@ -209,15 +227,15 @@
               "·",
               fill: accent,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "bold",
               style: "normal",
             )],
             [#t(
-              "Led customer discovery with large domain owners and turned manual sales workflows into Namefi Outbound: AI-assisted buyer hypotheses, web research, lead scoring, contact discovery, and editable outreach, reducing prep from days to minutes.",
+              "Interviewed owners of large domain portfolios and built Namefi Outbound to streamline buyer research, lead scoring, contact discovery, and outreach drafting, reducing sales preparation from days to minutes.",
               fill: muted,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "regular",
               style: "normal",
             )],
@@ -232,15 +250,15 @@
               "·",
               fill: accent,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "bold",
               style: "normal",
             )],
             [#t(
-              "Designed Brand Studio as a multi-stage AI workflow that turns domains into buyer-ready logos, posters, and motion concepts with strategist/concept passes, exact domain/TLD constraints, and animation workflows.",
+              "Designed Brand Studio, a multi-stage AI system that creates logos, posters, and motion concepts for domains. It separates strategy, concept generation, and animation while preserving the exact domain name, including its top-level domain.",
               fill: muted,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "regular",
               style: "normal",
             )],
@@ -255,15 +273,15 @@
               "·",
               fill: accent,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "bold",
               style: "normal",
             )],
             [#t(
-              "Built Namefi Feed, an AI-enriched listing intelligence layer that normalizes roughly 4,000-5,000 public domain listings from X, NamePros, DNForum, and marketplaces into searchable/RSS surfaces.",
+              "Built Namefi Feed, which aggregates and structures roughly 4,000 to 5,000 public domain listings from X, forums, and marketplaces, making them searchable on the web and through RSS feeds.",
               fill: muted,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "regular",
               style: "normal",
             )],
@@ -278,15 +296,15 @@
               "·",
               fill: accent,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "bold",
               style: "normal",
             )],
             [#t(
-              "Built production registrar and domain systems across registrar integrations, DNS/DNSSEC, nameservers, ENS/.eth, renewals, payments, checkout, analytics, and Temporal-backed long-running workflows.",
+              "Built production registrar systems for third-party integrations, registration, renewals, payments, checkout, and analytics. Added DNS record and DNSSEC management, nameserver controls, ENS and .eth support, and long-running Temporal workflows.",
               fill: muted,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "regular",
               style: "normal",
             )],
@@ -297,7 +315,7 @@
     ]
 
   ]
-  #v(18pt)
+  #v(12pt)
 
   #block(breakable: false)[
     #grid(
@@ -324,7 +342,7 @@
         )
         #v(-6pt)
         #t(
-          "Built EdWrite, Memorang's AI-native, graph-based headless CMS for education.",
+          "AI-assisted educational content platform for structured curricula and assessments.",
           fill: muted,
           font: "Source Sans 3",
           size: 9pt,
@@ -336,19 +354,50 @@
         #grid(
           columns: (1fr, auto),
           gutter: 12pt,
-          [#t(
-            "Lead Product Engineer, AI Content Platform",
-            fill: strong,
-            font: "Source Sans 3",
-            size: 10.5pt,
-            weight: "medium",
-            style: "normal",
+          [#grid(
+            columns: (auto, auto, auto),
+            gutter: 4pt,
+            align: horizon,
+            [#t(
+              "Lead Product Engineer, AI Content Platform",
+              fill: strong,
+              font: "Source Sans 3",
+              size: 10pt,
+              weight: "medium",
+              style: "normal",
+            )],
+            [#box(
+              inset: (x: 4pt, y: 1.5pt),
+              radius: 8pt,
+              fill: rgb("#2d2418"),
+              stroke: 0.75pt + rgb("#9a6a2b"),
+            )[#t(
+              "Hands-on",
+              fill: rgb("#f0b85f"),
+              font: "Source Sans 3",
+              size: 7.5pt,
+              weight: "medium",
+              style: "normal",
+            )]],
+            [#box(
+              inset: (x: 4pt, y: 1.5pt),
+              radius: 8pt,
+              fill: rgb("#2a2429"),
+              stroke: 0.75pt + rgb("#7a6171"),
+            )[#t(
+              "Leadership",
+              fill: rgb("#e3bfd7"),
+              font: "Source Sans 3",
+              size: 7.5pt,
+              weight: "medium",
+              style: "normal",
+            )]],
           )],
           [#t(
             "San Francisco Bay Area / Remote · Apr 2024 - Jan 2025",
             fill: muted,
             font: "Source Sans 3",
-            size: 9pt,
+            size: 8.25pt,
             weight: "regular",
             style: "normal",
           )],
@@ -364,15 +413,15 @@
             "·",
             fill: accent,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "bold",
             style: "normal",
           )],
           [#t(
-            "Built EdWrite, Memorang's graph-based headless CMS, turning Cambridge/TOEFL and subject-matter expert requirements into structured, versioned curricula, assessments, and content APIs.",
+            "Built EdWrite, a graph-based headless CMS that represents Cambridge and TOEFL curricula and assessment requirements in versioned schemas exposed through content APIs.",
             fill: muted,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "regular",
             style: "normal",
           )],
@@ -387,15 +436,15 @@
             "·",
             fill: accent,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "bold",
             style: "normal",
           )],
           [#t(
-            "Designed human-in-the-loop agent workflows for experts to generate, review, and manage complete question sets and companion audio/image media at scale; built adaptive practice, scoring, and embedding-based media recommendations.",
+            "Designed human-in-the-loop workflows that let subject-matter experts generate, review, and manage complete question sets with supporting audio and images. Also built adaptive practice and scoring, plus semantic recommendations for related media.",
             fill: muted,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "regular",
             style: "normal",
           )],
@@ -410,15 +459,38 @@
             "·",
             fill: accent,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "bold",
             style: "normal",
           )],
           [#t(
-            "Led the CMS team and roadmap across backend, frontend, app, CTO, and CEO while modernizing a large JS/Flow monorepo toward TypeScript, Bun, and Biome with agentic refactors and codemods.",
+            "Managed a three-developer CMS team and owned its roadmap, coordinating with backend, frontend, and mobile teams while working directly with the CTO and CEO.",
             fill: muted,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
+            weight: "regular",
+            style: "normal",
+          )],
+        )
+        #v(1.5pt)
+
+        #grid(
+          columns: (6pt, 1fr),
+          gutter: 6pt,
+          align: top,
+          [#t(
+            "·",
+            fill: accent,
+            font: "Source Sans 3",
+            size: 10pt,
+            weight: "bold",
+            style: "normal",
+          )],
+          [#t(
+            "Led the gradual migration of a large Flow-typed JavaScript monorepo to TypeScript, introducing Bun, Biome, codemods, and AI-assisted refactoring.",
+            fill: muted,
+            font: "Source Sans 3",
+            size: 10pt,
             weight: "regular",
             style: "normal",
           )],
@@ -428,7 +500,7 @@
     )
   ]
 
-  #v(18pt)
+  #v(12pt)
 
   #block(breakable: false)[
     #grid(
@@ -455,7 +527,7 @@
         )
         #v(-6pt)
         #t(
-          "Founder-led product engineering consultancy for high-ambiguity client work.",
+          "Product engineering consultancy for complex client products.",
           fill: muted,
           font: "Source Sans 3",
           size: 9pt,
@@ -467,29 +539,60 @@
         #grid(
           columns: (1fr, auto),
           gutter: 12pt,
-          [#t(
-            "Founder & Technical Director",
-            fill: strong,
-            font: "Source Sans 3",
-            size: 10.5pt,
-            weight: "medium",
-            style: "normal",
+          [#grid(
+            columns: (auto, auto, auto),
+            gutter: 4pt,
+            align: horizon,
+            [#t(
+              "Founder & Technical Director",
+              fill: strong,
+              font: "Source Sans 3",
+              size: 10pt,
+              weight: "medium",
+              style: "normal",
+            )],
+            [#box(
+              inset: (x: 4pt, y: 1.5pt),
+              radius: 8pt,
+              fill: rgb("#2d2418"),
+              stroke: 0.75pt + rgb("#9a6a2b"),
+            )[#t(
+              "Hands-on",
+              fill: rgb("#f0b85f"),
+              font: "Source Sans 3",
+              size: 7.5pt,
+              weight: "medium",
+              style: "normal",
+            )]],
+            [#box(
+              inset: (x: 4pt, y: 1.5pt),
+              radius: 8pt,
+              fill: rgb("#2a2429"),
+              stroke: 0.75pt + rgb("#7a6171"),
+            )[#t(
+              "Leadership",
+              fill: rgb("#e3bfd7"),
+              font: "Source Sans 3",
+              size: 7.5pt,
+              weight: "medium",
+              style: "normal",
+            )]],
           )],
           [#t(
             "Mumbai / Remote · Jan 2021 - Apr 2024",
             fill: muted,
             font: "Source Sans 3",
-            size: 9pt,
+            size: 8.25pt,
             weight: "regular",
             style: "normal",
           )],
         )
         #v(2.25pt)
         #t(
-          "Founded and led a product engineering consultancy as client-facing technical partner, translating ambiguous requirements into architecture, delivery plans, and shipped systems.",
+          "Founded and grew Yuppies Tech to 15 engineers while remaining the client-facing technical lead. Turned unclear requirements into architecture, delivery plans, and production releases.",
           fill: muted,
           font: "Source Sans 3",
-          size: 10.5pt,
+          size: 10pt,
           weight: "regular",
           style: "normal",
         )
@@ -511,14 +614,14 @@
               "Veera Browser: ",
               fill: strong,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "medium",
               style: "normal",
             )#t(
-              "led Android Chromium browser delivery from zero to Play Store, owning Chromium/Brave patch management, build/release tooling, rewards/feed/onboarding/search/tabs, privacy/security updates, and later iOS platform setup.",
+              "led a Chromium-based Android browser from initial architecture through Play Store launch, owning upstream patch management, release tooling, product features, and privacy updates. Later established the iOS platform and release setup.",
               fill: muted,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "regular",
               style: "normal",
             )],
@@ -541,14 +644,14 @@
               "Texts: ",
               fill: strong,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "medium",
               style: "normal",
             )#t(
-              "built production Messenger channel by reverse-engineering undocumented infrastructure and implementing MQTT/Facebook Thrift, encrypted payloads, sync, groups, attachments, reactions, receipts, typing, and presence.",
+              "built a production Facebook Messenger integration by reverse-engineering undocumented protocols, then implemented encrypted messaging, synchronization, groups, attachments, reactions, read receipts, typing indicators, and presence.",
               fill: muted,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "regular",
               style: "normal",
             )],
@@ -571,14 +674,14 @@
               "ZebPay: ",
               fill: strong,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "medium",
               style: "normal",
             )#t(
-              "client-facing technical lead for a 10-person team modernizing iOS/Android apps, release infrastructure, exchange features, payment flows, and international KYC; moved stabilization releases from monthly/bi-monthly to weekly.",
+              "led modernization of ZebPay's iOS and Android apps, release infrastructure, exchange and payment features, and international KYC. During stabilization, increased the release cadence from every two weeks to weekly.",
               fill: muted,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "regular",
               style: "normal",
             )],
@@ -601,14 +704,14 @@
               "Mitsubishi Motors: ",
               fill: strong,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "medium",
               style: "normal",
             )#t(
-              "client-facing technical lead for MiAR, turning remote dealership goals into native iOS/iPadOS and WebAR with optimized 3D vehicles, low-end Android support, bilingual content, and contest/admin workflows.",
+              "led MiAR, a remote dealership experience delivered through native iOS and iPadOS apps plus WebAR. Shipped optimized 3D vehicle models, support for lower-end Android devices, bilingual content, and contest-administration tooling.",
               fill: muted,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "regular",
               style: "normal",
             )],
@@ -631,14 +734,14 @@
               "Airbus Tripset: ",
               fill: strong,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "medium",
               style: "normal",
             )#t(
-              "solo technical partner to Milkinside for Airbus's public iOS/Android COVID travel companion, translating urgent traveler guidance needs into app/backend layers over Airbus/Amadeus APIs, CMS rules, and itinerary notifications.",
+              "owned end-to-end technical delivery of Airbus Tripset, a public iOS and Android travel companion launched during COVID. Built the React Native app and backend services that combined Airbus and Amadeus APIs, CMS-managed travel guidance, itinerary data, and notifications.",
               fill: muted,
               font: "Source Sans 3",
-              size: 10.5pt,
+              size: 10pt,
               weight: "regular",
               style: "normal",
             )],
@@ -648,7 +751,7 @@
     )
   ]
 
-  #v(18pt)
+  #v(12pt)
 
   #block(breakable: false)[
     #grid(
@@ -687,19 +790,50 @@
         #grid(
           columns: (1fr, auto),
           gutter: 12pt,
-          [#t(
-            "Vice President of Engineering",
-            fill: strong,
-            font: "Source Sans 3",
-            size: 10.5pt,
-            weight: "medium",
-            style: "normal",
+          [#grid(
+            columns: (auto, auto, auto),
+            gutter: 4pt,
+            align: horizon,
+            [#t(
+              "Vice President of Engineering",
+              fill: strong,
+              font: "Source Sans 3",
+              size: 10pt,
+              weight: "medium",
+              style: "normal",
+            )],
+            [#box(
+              inset: (x: 4pt, y: 1.5pt),
+              radius: 8pt,
+              fill: rgb("#2d2418"),
+              stroke: 0.75pt + rgb("#9a6a2b"),
+            )[#t(
+              "Hands-on",
+              fill: rgb("#f0b85f"),
+              font: "Source Sans 3",
+              size: 7.5pt,
+              weight: "medium",
+              style: "normal",
+            )]],
+            [#box(
+              inset: (x: 4pt, y: 1.5pt),
+              radius: 8pt,
+              fill: rgb("#2a2429"),
+              stroke: 0.75pt + rgb("#7a6171"),
+            )[#t(
+              "Leadership",
+              fill: rgb("#e3bfd7"),
+              font: "Source Sans 3",
+              size: 7.5pt,
+              weight: "medium",
+              style: "normal",
+            )]],
           )],
           [#t(
-            "Mumbai · Jan 2020 - Dec 2021",
+            "Mumbai · Jan 2020 - Jan 2021",
             fill: muted,
             font: "Source Sans 3",
-            size: 9pt,
+            size: 8.25pt,
             weight: "regular",
             style: "normal",
           )],
@@ -715,15 +849,38 @@
             "·",
             fill: accent,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "bold",
             style: "normal",
           )],
           [#t(
-            "Built the first product and technical foundation for a consumer beauty/skincare shopping app from the ground up across AWS, Elixir, Swift, and Kotlin.",
+            "Led a 10-engineer team and owned Kult's zero-to-one product and engineering strategy, covering an AWS-hosted Elixir backend and native iOS and Android apps.",
             fill: muted,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
+            weight: "regular",
+            style: "normal",
+          )],
+        )
+        #v(1.5pt)
+
+        #grid(
+          columns: (6pt, 1fr),
+          gutter: 6pt,
+          align: top,
+          [#t(
+            "·",
+            fill: accent,
+            font: "Source Sans 3",
+            size: 10pt,
+            weight: "bold",
+            style: "normal",
+          )],
+          [#t(
+            "Architected both apps and contributed directly in Swift and Kotlin while establishing CI/CD, analytics, deep linking, observability, and the foundations for commerce and engagement features.",
+            fill: muted,
+            font: "Source Sans 3",
+            size: 10pt,
             weight: "regular",
             style: "normal",
           )],
@@ -733,7 +890,7 @@
     )
   ]
 
-  #v(18pt)
+  #v(12pt)
 
   #block(breakable: false)[
     #grid(
@@ -750,7 +907,7 @@
       )]],
       [
         #t(
-          "Yilu, Lufthansa Group / BCG Digital Ventures",
+          "Yilu",
           fill: strong,
           font: "Literata",
           size: 12pt,
@@ -760,7 +917,7 @@
         )
         #v(-6pt)
         #t(
-          "Smart travel platform for Lufthansa Group.",
+          "Smart travel platform built for Lufthansa Group with BCG Digital Ventures.",
           fill: muted,
           font: "Source Sans 3",
           size: 9pt,
@@ -772,19 +929,37 @@
         #grid(
           columns: (1fr, auto),
           gutter: 12pt,
-          [#t(
-            "Founding Engineer",
-            fill: strong,
-            font: "Source Sans 3",
-            size: 10.5pt,
-            weight: "medium",
-            style: "normal",
+          [#grid(
+            columns: (auto, auto),
+            gutter: 4pt,
+            align: horizon,
+            [#t(
+              "Founding Engineer",
+              fill: strong,
+              font: "Source Sans 3",
+              size: 10pt,
+              weight: "medium",
+              style: "normal",
+            )],
+            [#box(
+              inset: (x: 4pt, y: 1.5pt),
+              radius: 8pt,
+              fill: rgb("#2d2418"),
+              stroke: 0.75pt + rgb("#9a6a2b"),
+            )[#t(
+              "Hands-on",
+              fill: rgb("#f0b85f"),
+              font: "Source Sans 3",
+              size: 7.5pt,
+              weight: "medium",
+              style: "normal",
+            )]],
           )],
           [#t(
             "Berlin · Nov 2018 - Dec 2019",
             fill: muted,
             font: "Source Sans 3",
-            size: 9pt,
+            size: 8.25pt,
             weight: "regular",
             style: "normal",
           )],
@@ -800,15 +975,15 @@
             "·",
             fill: accent,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "bold",
             style: "normal",
           )],
           [#t(
-            "Built native mobile architecture, CI/CD and release automation, Terraform-backed AWS web infrastructure, and iOS/Android features for Eurowings.",
+            "Designed the native mobile architecture and release automation, built Terraform-managed AWS infrastructure, and shipped iOS and Android features for Eurowings.",
             fill: muted,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "regular",
             style: "normal",
           )],
@@ -823,15 +998,15 @@
             "·",
             fill: accent,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "bold",
             style: "normal",
           )],
           [#t(
-            "Helped hire and structure the initial engineering team through job descriptions, technical tasks, interviews, and Scrum Master responsibilities.",
+            "Helped establish the engineering team by writing job descriptions, creating technical exercises, and interviewing candidates. Also served as Scrum Master.",
             fill: muted,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "regular",
             style: "normal",
           )],
@@ -841,7 +1016,7 @@
     )
   ]
 
-  #v(18pt)
+  #v(12pt)
 
   #block(breakable: false)[
     #grid(
@@ -858,7 +1033,7 @@
       )]],
       [
         #t(
-          "8fit by Withings",
+          "8fit",
           fill: strong,
           font: "Literata",
           size: 12pt,
@@ -868,7 +1043,7 @@
         )
         #v(-6pt)
         #t(
-          "Fitness and nutrition platform, now part of Withings.",
+          "Fitness and nutrition platform later acquired by Withings.",
           fill: muted,
           font: "Source Sans 3",
           size: 9pt,
@@ -880,19 +1055,37 @@
         #grid(
           columns: (1fr, auto),
           gutter: 12pt,
-          [#t(
-            "Senior Technical Architect",
-            fill: strong,
-            font: "Source Sans 3",
-            size: 10.5pt,
-            weight: "medium",
-            style: "normal",
+          [#grid(
+            columns: (auto, auto),
+            gutter: 4pt,
+            align: horizon,
+            [#t(
+              "Senior Technical Architect",
+              fill: strong,
+              font: "Source Sans 3",
+              size: 10pt,
+              weight: "medium",
+              style: "normal",
+            )],
+            [#box(
+              inset: (x: 4pt, y: 1.5pt),
+              radius: 8pt,
+              fill: rgb("#2d2418"),
+              stroke: 0.75pt + rgb("#9a6a2b"),
+            )[#t(
+              "Hands-on",
+              fill: rgb("#f0b85f"),
+              font: "Source Sans 3",
+              size: 7.5pt,
+              weight: "medium",
+              style: "normal",
+            )]],
           )],
           [#t(
             "Berlin · Nov 2017 - Oct 2018",
             fill: muted,
             font: "Source Sans 3",
-            size: 9pt,
+            size: 8.25pt,
             weight: "regular",
             style: "normal",
           )],
@@ -908,15 +1101,15 @@
             "·",
             fill: accent,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "bold",
             style: "normal",
           )],
           [#t(
-            "Architected a hybrid Apple TV fitness app that reached #1 Health & Fitness in Germany and 30+ countries and #7 in the US.",
+            "Architected a hybrid Apple TV fitness app that ranked No. 1 in its Health & Fitness category in more than 30 countries, including Germany, and No. 7 in the United States.",
             fill: muted,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "regular",
             style: "normal",
           )],
@@ -931,7 +1124,7 @@
             "·",
             fill: accent,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "bold",
             style: "normal",
           )],
@@ -939,7 +1132,7 @@
             "Built cross-platform mobile features across JavaScript, Swift, Objective-C, Java, and Kotlin.",
             fill: muted,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "regular",
             style: "normal",
           )],
@@ -949,7 +1142,7 @@
     )
   ]
 
-  #v(18pt)
+  #v(12pt)
 
   #block(breakable: false)[
     #grid(
@@ -988,19 +1181,50 @@
         #grid(
           columns: (1fr, auto),
           gutter: 12pt,
-          [#t(
-            "Team Lead",
-            fill: strong,
-            font: "Source Sans 3",
-            size: 10.5pt,
-            weight: "medium",
-            style: "normal",
+          [#grid(
+            columns: (auto, auto, auto),
+            gutter: 4pt,
+            align: horizon,
+            [#t(
+              "Team Lead",
+              fill: strong,
+              font: "Source Sans 3",
+              size: 10pt,
+              weight: "medium",
+              style: "normal",
+            )],
+            [#box(
+              inset: (x: 4pt, y: 1.5pt),
+              radius: 8pt,
+              fill: rgb("#2d2418"),
+              stroke: 0.75pt + rgb("#9a6a2b"),
+            )[#t(
+              "Hands-on",
+              fill: rgb("#f0b85f"),
+              font: "Source Sans 3",
+              size: 7.5pt,
+              weight: "medium",
+              style: "normal",
+            )]],
+            [#box(
+              inset: (x: 4pt, y: 1.5pt),
+              radius: 8pt,
+              fill: rgb("#2a2429"),
+              stroke: 0.75pt + rgb("#7a6171"),
+            )[#t(
+              "Leadership",
+              fill: rgb("#e3bfd7"),
+              font: "Source Sans 3",
+              size: 7.5pt,
+              weight: "medium",
+              style: "normal",
+            )]],
           )],
           [#t(
             "Mumbai · Oct 2016 - Oct 2017",
             fill: muted,
             font: "Source Sans 3",
-            size: 9pt,
+            size: 8.25pt,
             weight: "regular",
             style: "normal",
           )],
@@ -1016,15 +1240,15 @@
             "·",
             fill: accent,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "bold",
             style: "normal",
           )],
           [#t(
-            "Led Housing's React Native mobile architecture, building more than 90% of the app in JavaScript for shared iOS/Android delivery with Redux, redux-observable/RxJS, immutable state, offline persistence, and component-driven UI.",
+            "Led the architecture of Housing's React Native app, sharing more than 90% of its JavaScript code across iOS and Android.",
             fill: muted,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "regular",
             style: "normal",
           )],
@@ -1039,15 +1263,15 @@
             "·",
             fill: accent,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "bold",
             style: "normal",
           )],
           [#t(
-            "Built the mobile quality and release platform with Storybook, Jest/Detox, Sentry, Fastlane, Jenkins, and CodePush, automating signed builds, device registration, beta distribution, source-map uploads, release notes, stakeholder notifications, OTA rollouts, and Git tagging.",
+            "Designed its state management, reactive data flows, offline persistence, and component-driven UI. Also built automated testing and release systems covering diagnostics, signed builds, beta distribution, and over-the-air updates.",
             fill: muted,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "regular",
             style: "normal",
           )],
@@ -1062,7 +1286,7 @@
             "·",
             fill: accent,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "bold",
             style: "normal",
           )],
@@ -1070,7 +1294,7 @@
             "Contributed to Housing.com's Progressive Web App for users on slow and inconsistent network connections.",
             fill: muted,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "regular",
             style: "normal",
           )],
@@ -1080,7 +1304,7 @@
     )
   ]
 
-  #v(18pt)
+  #v(12pt)
 
   #block(breakable: false)[
     #grid(
@@ -1119,19 +1343,37 @@
         #grid(
           columns: (1fr, auto),
           gutter: 12pt,
-          [#t(
-            "Software Engineer / Consultant",
-            fill: strong,
-            font: "Source Sans 3",
-            size: 10.5pt,
-            weight: "medium",
-            style: "normal",
+          [#grid(
+            columns: (auto, auto),
+            gutter: 4pt,
+            align: horizon,
+            [#t(
+              "Software Engineer and Consultant",
+              fill: strong,
+              font: "Source Sans 3",
+              size: 10pt,
+              weight: "medium",
+              style: "normal",
+            )],
+            [#box(
+              inset: (x: 4pt, y: 1.5pt),
+              radius: 8pt,
+              fill: rgb("#2d2418"),
+              stroke: 0.75pt + rgb("#9a6a2b"),
+            )[#t(
+              "Hands-on",
+              fill: rgb("#f0b85f"),
+              font: "Source Sans 3",
+              size: 7.5pt,
+              weight: "medium",
+              style: "normal",
+            )]],
           )],
           [#t(
             "Los Angeles / India · 2015 - 2016",
             fill: muted,
             font: "Source Sans 3",
-            size: 9pt,
+            size: 8.25pt,
             weight: "regular",
             style: "normal",
           )],
@@ -1147,15 +1389,15 @@
             "·",
             fill: accent,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "bold",
             style: "normal",
           )],
           [#t(
-            "Built startup web/mobile systems across customer-data email tooling, real-time doctor consultation, IoT fleet management, and JavaScript/Java/Ruby on Rails product engineering while studying Computer Science at UCLA.",
+            "Built web and mobile products for email and customer-data tools, real-time medical consultations, and connected fleet management using JavaScript, Java, and Ruby on Rails.",
             fill: muted,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "regular",
             style: "normal",
           )],
@@ -1170,7 +1412,7 @@
             "·",
             fill: accent,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "bold",
             style: "normal",
           )],
@@ -1178,7 +1420,7 @@
             "Mentored 1mg's mobile team on hybrid app architecture and modern development tooling.",
             fill: muted,
             font: "Source Sans 3",
-            size: 10.5pt,
+            size: 10pt,
             weight: "regular",
             style: "normal",
           )],
@@ -1230,7 +1472,7 @@
           )
           #v(-6pt)
           #t(
-            "BS, Computer Science and Engineering.",
+            "Bachelor of Science.",
             fill: muted,
             font: "Source Sans 3",
             size: 9pt,
@@ -1242,19 +1484,24 @@
           #grid(
             columns: (1fr, auto),
             gutter: 12pt,
-            [#t(
-              "Computer Science and Engineering",
-              fill: strong,
-              font: "Source Sans 3",
-              size: 10.5pt,
-              weight: "medium",
-              style: "normal",
+            [#grid(
+              columns: auto,
+              gutter: 4pt,
+              align: horizon,
+              [#t(
+                "Computer Science and Engineering",
+                fill: strong,
+                font: "Source Sans 3",
+                size: 10pt,
+                weight: "medium",
+                style: "normal",
+              )],
             )],
             [#t(
               "Los Angeles, CA · 2013 - 2016",
               fill: muted,
               font: "Source Sans 3",
-              size: 9pt,
+              size: 8.25pt,
               weight: "regular",
               style: "normal",
             )],
@@ -1267,7 +1514,7 @@
     ]
 
   ]
-  #v(18pt)
+  #v(12pt)
 
   #block(breakable: false)[
     #grid(
@@ -1306,19 +1553,24 @@
         #grid(
           columns: (1fr, auto),
           gutter: 12pt,
-          [#t(
-            "Computer Science, Physics, Chemistry, Math",
-            fill: strong,
-            font: "Source Sans 3",
-            size: 10.5pt,
-            weight: "medium",
-            style: "normal",
+          [#grid(
+            columns: auto,
+            gutter: 4pt,
+            align: horizon,
+            [#t(
+              "Computer Science, Physics, Chemistry, Math",
+              fill: strong,
+              font: "Source Sans 3",
+              size: 10pt,
+              weight: "medium",
+              style: "normal",
+            )],
           )],
           [#t(
             "New Delhi, India · 2011 - 2013",
             fill: muted,
             font: "Source Sans 3",
-            size: 9pt,
+            size: 8.25pt,
             weight: "regular",
             style: "normal",
           )],

--- a/public/resume/sid-jain-resume.pdf
+++ b/public/resume/sid-jain-resume.pdf
@@ -2,43 +2,43 @@
 %€€€€
 
 1 0 obj
-<</Type/Pages/Count 2/Kids[269 0 R 270 0 R]>>
+<</Type/Pages/Count 2/Kids[323 0 R 324 0 R]>>
 endobj
 2 0 obj
-<</Type/OutputIntent/DestOutputProfile 294 0 R/S/GTS_PDFA1/OutputConditionIdentifier(Custom)/OutputCondition(sRGB)/RegistryName()/Info(sRGB v4.2)>>
+<</Type/OutputIntent/DestOutputProfile 348 0 R/S/GTS_PDFA1/OutputConditionIdentifier(Custom)/OutputCondition(sRGB)/RegistryName()/Info(sRGB v4.2)>>
 endobj
 3 0 obj
 [2 0 R]
 endobj
 4 0 obj
-<</Type/StructTreeRoot/RoleMap<</Datetime/Span/Terms/Part/Title/P/Strong/Span/Em/Span>>/K[241 0 R]/ParentTree<</Nums[0 11 0 R 1 12 0 R 2 13 0 R 3 5 0 R 4 6 0 R]>>/ParentTreeNextKey 5>>
+<</Type/StructTreeRoot/RoleMap<</Datetime/Span/Terms/Part/Title/P/Strong/Span/Em/Span>>/K[295 0 R]/ParentTree<</Nums[0 11 0 R 1 12 0 R 2 13 0 R 3 5 0 R 4 6 0 R]>>/ParentTreeNextKey 5>>
 endobj
 5 0 obj
-[7 0 R 9 0 R 11 0 R 12 0 R 13 0 R 17 0 R 17 0 R 17 0 R 18 0 R 19 0 R 21 0 R 22 0 R 23 0 R 25 0 R 28 0 R 30 0 R 30 0 R 30 0 R 33 0 R 35 0 R 35 0 R 38 0 R 40 0 R 40 0 R 43 0 R 45 0 R 45 0 R 50 0 R 52 0 R 53 0 R 54 0 R 56 0 R 59 0 R 61 0 R 61 0 R 64 0 R 66 0 R 66 0 R 66 0 R 69 0 R 71 0 R 71 0 R 76 0 R 78 0 R 79 0 R 80 0 R 82 0 R 85 0 R 85 0 R 86 0 R 88 0 R 88 0 R 88 0 R 88 0 R 91 0 R 93 0 R 93 0 R 93 0 R 93 0 R 96 0 R 98 0 R 98 0 R 98 0 R 98 0 R 101 0 R 103 0 R 103 0 R 103 0 R 103 0 R 106 0 R 108 0 R 108 0 R 108 0 R 108 0 R]
+[7 0 R 9 0 R 11 0 R 12 0 R 13 0 R 17 0 R 17 0 R 17 0 R 17 0 R 18 0 R 19 0 R 21 0 R 22 0 R 23 0 R 25 0 R 29 0 R 32 0 R 34 0 R 34 0 R 37 0 R 39 0 R 39 0 R 39 0 R 42 0 R 44 0 R 44 0 R 47 0 R 49 0 R 49 0 R 49 0 R 54 0 R 56 0 R 57 0 R 58 0 R 60 0 R 62 0 R 66 0 R 69 0 R 71 0 R 71 0 R 74 0 R 76 0 R 76 0 R 76 0 R 79 0 R 81 0 R 81 0 R 84 0 R 86 0 R 86 0 R 91 0 R 93 0 R 94 0 R 95 0 R 97 0 R 99 0 R 103 0 R 106 0 R 106 0 R 107 0 R 109 0 R 109 0 R 109 0 R 109 0 R 112 0 R 114 0 R 114 0 R 114 0 R 114 0 R 117 0 R 119 0 R 119 0 R 119 0 R 119 0 R 122 0 R 124 0 R 124 0 R 124 0 R 124 0 R 127 0 R 129 0 R 129 0 R 129 0 R 129 0 R]
 endobj
 6 0 obj
-[113 0 R 115 0 R 116 0 R 117 0 R 119 0 R 122 0 R 124 0 R 124 0 R 129 0 R 131 0 R 132 0 R 133 0 R 135 0 R 138 0 R 140 0 R 140 0 R 143 0 R 145 0 R 145 0 R 150 0 R 152 0 R 153 0 R 154 0 R 156 0 R 159 0 R 161 0 R 161 0 R 164 0 R 166 0 R 171 0 R 173 0 R 174 0 R 175 0 R 177 0 R 180 0 R 182 0 R 182 0 R 182 0 R 185 0 R 187 0 R 187 0 R 187 0 R 190 0 R 192 0 R 197 0 R 199 0 R 200 0 R 201 0 R 203 0 R 206 0 R 208 0 R 208 0 R 208 0 R 211 0 R 213 0 R 218 0 R 219 0 R 221 0 R 222 0 R 223 0 R 225 0 R 230 0 R 232 0 R 233 0 R 234 0 R 236 0 R]
+[134 0 R 136 0 R 137 0 R 138 0 R 140 0 R 142 0 R 146 0 R 149 0 R 151 0 R 151 0 R 154 0 R 156 0 R 156 0 R 161 0 R 163 0 R 164 0 R 165 0 R 167 0 R 171 0 R 174 0 R 176 0 R 176 0 R 179 0 R 181 0 R 181 0 R 186 0 R 188 0 R 189 0 R 190 0 R 192 0 R 196 0 R 199 0 R 201 0 R 201 0 R 204 0 R 206 0 R 211 0 R 213 0 R 214 0 R 215 0 R 217 0 R 219 0 R 223 0 R 226 0 R 228 0 R 228 0 R 231 0 R 233 0 R 233 0 R 233 0 R 236 0 R 238 0 R 243 0 R 245 0 R 246 0 R 247 0 R 249 0 R 253 0 R 256 0 R 258 0 R 258 0 R 261 0 R 263 0 R 268 0 R 269 0 R 271 0 R 272 0 R 273 0 R 277 0 R 282 0 R 284 0 R 285 0 R 286 0 R 290 0 R]
 endobj
 7 0 obj
-<</Type/StructElem/S/Figure/P 8 0 R/A[<</O/Layout/Placement/Block>>]/K[0]/Pg 269 0 R>>
+<</Type/StructElem/S/Figure/P 8 0 R/A[<</O/Layout/Placement/Block>>]/K[0]/Pg 323 0 R>>
 endobj
 8 0 obj
 <</Type/StructElem/S/Div/P 16 0 R/K[7 0 R]>>
 endobj
 9 0 obj
-<</Type/StructElem/S/Span/P 10 0 R/A[<</O/Layout/Placement/Block>>]/K[1]/Pg 269 0 R>>
+<</Type/StructElem/S/Span/P 10 0 R/A[<</O/Layout/Placement/Block>>]/K[1]/Pg 323 0 R>>
 endobj
 10 0 obj
 <</Type/StructElem/S/Div/P 16 0 R/K[9 0 R]>>
 endobj
 11 0 obj
-<</Type/StructElem/S/Link/P 14 0 R/K[2<</Type/OBJR/Pg 269 0 R/Obj 242 0 R>>]/Pg 269 0 R>>
+<</Type/StructElem/S/Link/P 14 0 R/K[2<</Type/OBJR/Pg 323 0 R/Obj 296 0 R>>]/Pg 323 0 R>>
 endobj
 12 0 obj
-<</Type/StructElem/S/Link/P 14 0 R/K[3<</Type/OBJR/Pg 269 0 R/Obj 243 0 R>>]/Pg 269 0 R>>
+<</Type/StructElem/S/Link/P 14 0 R/K[3<</Type/OBJR/Pg 323 0 R/Obj 297 0 R>>]/Pg 323 0 R>>
 endobj
 13 0 obj
-<</Type/StructElem/S/Link/P 14 0 R/K[4<</Type/OBJR/Pg 269 0 R/Obj 244 0 R>>]/Pg 269 0 R>>
+<</Type/StructElem/S/Link/P 14 0 R/K[4<</Type/OBJR/Pg 323 0 R/Obj 298 0 R>>]/Pg 323 0 R>>
 endobj
 14 0 obj
 <</Type/StructElem/S/P/P 15 0 R/K[11 0 R 12 0 R 13 0 R]>>
@@ -47,535 +47,535 @@ endobj
 <</Type/StructElem/S/Div/P 16 0 R/K[14 0 R]>>
 endobj
 16 0 obj
-<</Type/StructElem/S/Div/P 241 0 R/K[8 0 R 10 0 R 15 0 R]>>
+<</Type/StructElem/S/Div/P 295 0 R/K[8 0 R 10 0 R 15 0 R]>>
 endobj
 17 0 obj
-<</Type/StructElem/S/Span/P 241 0 R/A[<</O/Layout/Placement/Block>>]/K[5 6 7]/Pg 269 0 R>>
+<</Type/StructElem/S/Span/P 295 0 R/A[<</O/Layout/Placement/Block>>]/K[5 6 7 8]/Pg 323 0 R>>
 endobj
 18 0 obj
-<</Type/StructElem/S/P/P 241 0 R/K[8]/Pg 269 0 R>>
+<</Type/StructElem/S/P/P 295 0 R/K[9]/Pg 323 0 R>>
 endobj
 19 0 obj
-<</Type/StructElem/S/Figure/P 20 0 R/A[<</O/Layout/Placement/Block>>]/K[9]/Pg 269 0 R>>
+<</Type/StructElem/S/Figure/P 20 0 R/A[<</O/Layout/Placement/Block>>]/K[10]/Pg 323 0 R>>
 endobj
 20 0 obj
-<</Type/StructElem/S/Div/P 49 0 R/K[19 0 R]>>
+<</Type/StructElem/S/Div/P 53 0 R/K[19 0 R]>>
 endobj
 21 0 obj
-<</Type/StructElem/S/P/P 48 0 R/K[10]/Pg 269 0 R>>
+<</Type/StructElem/S/P/P 52 0 R/K[11]/Pg 323 0 R>>
 endobj
 22 0 obj
-<</Type/StructElem/S/P/P 48 0 R/K[11]/Pg 269 0 R>>
+<</Type/StructElem/S/P/P 52 0 R/K[12]/Pg 323 0 R>>
 endobj
 23 0 obj
-<</Type/StructElem/S/Span/P 24 0 R/A[<</O/Layout/Placement/Block>>]/K[12]/Pg 269 0 R>>
+<</Type/StructElem/S/Span/P 24 0 R/A[<</O/Layout/Placement/Block>>]/K[13]/Pg 323 0 R>>
 endobj
 24 0 obj
 <</Type/StructElem/S/Div/P 27 0 R/K[23 0 R]>>
 endobj
 25 0 obj
-<</Type/StructElem/S/Span/P 26 0 R/A[<</O/Layout/Placement/Block>>]/K[13]/Pg 269 0 R>>
+<</Type/StructElem/S/Span/P 26 0 R/A[<</O/Layout/Placement/Block>>]/K[14]/Pg 323 0 R>>
 endobj
 26 0 obj
 <</Type/StructElem/S/Div/P 27 0 R/K[25 0 R]>>
 endobj
 27 0 obj
-<</Type/StructElem/S/Div/P 48 0 R/K[24 0 R 26 0 R]>>
+<</Type/StructElem/S/Div/P 28 0 R/K[24 0 R 26 0 R]>>
 endobj
 28 0 obj
-<</Type/StructElem/S/Span/P 29 0 R/A[<</O/Layout/Placement/Block>>]/K[14]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 31 0 R/K[27 0 R]>>
 endobj
 29 0 obj
-<</Type/StructElem/S/Div/P 32 0 R/K[28 0 R]>>
+<</Type/StructElem/S/Span/P 30 0 R/A[<</O/Layout/Placement/Block>>]/K[15]/Pg 323 0 R>>
 endobj
 30 0 obj
-<</Type/StructElem/S/Span/P 31 0 R/A[<</O/Layout/Placement/Block>>]/K[15 16 17]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 31 0 R/K[29 0 R]>>
 endobj
 31 0 obj
-<</Type/StructElem/S/Div/P 32 0 R/K[30 0 R]>>
+<</Type/StructElem/S/Div/P 52 0 R/K[28 0 R 30 0 R]>>
 endobj
 32 0 obj
-<</Type/StructElem/S/Div/P 48 0 R/K[29 0 R 31 0 R]>>
+<</Type/StructElem/S/Span/P 33 0 R/A[<</O/Layout/Placement/Block>>]/K[16]/Pg 323 0 R>>
 endobj
 33 0 obj
-<</Type/StructElem/S/Span/P 34 0 R/A[<</O/Layout/Placement/Block>>]/K[18]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 36 0 R/K[32 0 R]>>
 endobj
 34 0 obj
-<</Type/StructElem/S/Div/P 37 0 R/K[33 0 R]>>
+<</Type/StructElem/S/Span/P 35 0 R/A[<</O/Layout/Placement/Block>>]/K[17 18]/Pg 323 0 R>>
 endobj
 35 0 obj
-<</Type/StructElem/S/Span/P 36 0 R/A[<</O/Layout/Placement/Block>>]/K[19 20]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 36 0 R/K[34 0 R]>>
 endobj
 36 0 obj
-<</Type/StructElem/S/Div/P 37 0 R/K[35 0 R]>>
+<</Type/StructElem/S/Div/P 52 0 R/K[33 0 R 35 0 R]>>
 endobj
 37 0 obj
-<</Type/StructElem/S/Div/P 48 0 R/K[34 0 R 36 0 R]>>
+<</Type/StructElem/S/Span/P 38 0 R/A[<</O/Layout/Placement/Block>>]/K[19]/Pg 323 0 R>>
 endobj
 38 0 obj
-<</Type/StructElem/S/Span/P 39 0 R/A[<</O/Layout/Placement/Block>>]/K[21]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 41 0 R/K[37 0 R]>>
 endobj
 39 0 obj
-<</Type/StructElem/S/Div/P 42 0 R/K[38 0 R]>>
+<</Type/StructElem/S/Span/P 40 0 R/A[<</O/Layout/Placement/Block>>]/K[20 21 22]/Pg 323 0 R>>
 endobj
 40 0 obj
-<</Type/StructElem/S/Span/P 41 0 R/A[<</O/Layout/Placement/Block>>]/K[22 23]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 41 0 R/K[39 0 R]>>
 endobj
 41 0 obj
-<</Type/StructElem/S/Div/P 42 0 R/K[40 0 R]>>
+<</Type/StructElem/S/Div/P 52 0 R/K[38 0 R 40 0 R]>>
 endobj
 42 0 obj
-<</Type/StructElem/S/Div/P 48 0 R/K[39 0 R 41 0 R]>>
+<</Type/StructElem/S/Span/P 43 0 R/A[<</O/Layout/Placement/Block>>]/K[23]/Pg 323 0 R>>
 endobj
 43 0 obj
-<</Type/StructElem/S/Span/P 44 0 R/A[<</O/Layout/Placement/Block>>]/K[24]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 46 0 R/K[42 0 R]>>
 endobj
 44 0 obj
-<</Type/StructElem/S/Div/P 47 0 R/K[43 0 R]>>
+<</Type/StructElem/S/Span/P 45 0 R/A[<</O/Layout/Placement/Block>>]/K[24 25]/Pg 323 0 R>>
 endobj
 45 0 obj
-<</Type/StructElem/S/Span/P 46 0 R/A[<</O/Layout/Placement/Block>>]/K[25 26]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 46 0 R/K[44 0 R]>>
 endobj
 46 0 obj
-<</Type/StructElem/S/Div/P 47 0 R/K[45 0 R]>>
+<</Type/StructElem/S/Div/P 52 0 R/K[43 0 R 45 0 R]>>
 endobj
 47 0 obj
-<</Type/StructElem/S/Div/P 48 0 R/K[44 0 R 46 0 R]>>
+<</Type/StructElem/S/Span/P 48 0 R/A[<</O/Layout/Placement/Block>>]/K[26]/Pg 323 0 R>>
 endobj
 48 0 obj
-<</Type/StructElem/S/Div/P 49 0 R/K[21 0 R 22 0 R 27 0 R 32 0 R 37 0 R 42 0 R 47 0 R]>>
+<</Type/StructElem/S/Div/P 51 0 R/K[47 0 R]>>
 endobj
 49 0 obj
-<</Type/StructElem/S/Div/P 241 0 R/K[20 0 R 48 0 R]>>
+<</Type/StructElem/S/Span/P 50 0 R/A[<</O/Layout/Placement/Block>>]/K[27 28 29]/Pg 323 0 R>>
 endobj
 50 0 obj
-<</Type/StructElem/S/Figure/P 51 0 R/A[<</O/Layout/Placement/Block>>]/K[27]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 51 0 R/K[49 0 R]>>
 endobj
 51 0 obj
-<</Type/StructElem/S/Div/P 75 0 R/K[50 0 R]>>
+<</Type/StructElem/S/Div/P 52 0 R/K[48 0 R 50 0 R]>>
 endobj
 52 0 obj
-<</Type/StructElem/S/P/P 74 0 R/K[28]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 53 0 R/K[21 0 R 22 0 R 31 0 R 36 0 R 41 0 R 46 0 R 51 0 R]>>
 endobj
 53 0 obj
-<</Type/StructElem/S/P/P 74 0 R/K[29]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 295 0 R/K[20 0 R 52 0 R]>>
 endobj
 54 0 obj
-<</Type/StructElem/S/Span/P 55 0 R/A[<</O/Layout/Placement/Block>>]/K[30]/Pg 269 0 R>>
+<</Type/StructElem/S/Figure/P 55 0 R/A[<</O/Layout/Placement/Block>>]/K[30]/Pg 323 0 R>>
 endobj
 55 0 obj
-<</Type/StructElem/S/Div/P 58 0 R/K[54 0 R]>>
+<</Type/StructElem/S/Div/P 90 0 R/K[54 0 R]>>
 endobj
 56 0 obj
-<</Type/StructElem/S/Span/P 57 0 R/A[<</O/Layout/Placement/Block>>]/K[31]/Pg 269 0 R>>
+<</Type/StructElem/S/P/P 89 0 R/K[31]/Pg 323 0 R>>
 endobj
 57 0 obj
-<</Type/StructElem/S/Div/P 58 0 R/K[56 0 R]>>
+<</Type/StructElem/S/P/P 89 0 R/K[32]/Pg 323 0 R>>
 endobj
 58 0 obj
-<</Type/StructElem/S/Div/P 74 0 R/K[55 0 R 57 0 R]>>
+<</Type/StructElem/S/Span/P 59 0 R/A[<</O/Layout/Placement/Block>>]/K[33]/Pg 323 0 R>>
 endobj
 59 0 obj
-<</Type/StructElem/S/Span/P 60 0 R/A[<</O/Layout/Placement/Block>>]/K[32]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 64 0 R/K[58 0 R]>>
 endobj
 60 0 obj
-<</Type/StructElem/S/Div/P 63 0 R/K[59 0 R]>>
+<</Type/StructElem/S/Span/P 61 0 R/A[<</O/Layout/Placement/Block>>]/K[34]/Pg 323 0 R>>
 endobj
 61 0 obj
-<</Type/StructElem/S/Span/P 62 0 R/A[<</O/Layout/Placement/Block>>]/K[33 34]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 64 0 R/K[60 0 R]>>
 endobj
 62 0 obj
-<</Type/StructElem/S/Div/P 63 0 R/K[61 0 R]>>
+<</Type/StructElem/S/Span/P 63 0 R/A[<</O/Layout/Placement/Block>>]/K[35]/Pg 323 0 R>>
 endobj
 63 0 obj
-<</Type/StructElem/S/Div/P 74 0 R/K[60 0 R 62 0 R]>>
+<</Type/StructElem/S/Div/P 64 0 R/K[62 0 R]>>
 endobj
 64 0 obj
-<</Type/StructElem/S/Span/P 65 0 R/A[<</O/Layout/Placement/Block>>]/K[35]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 65 0 R/K[59 0 R 61 0 R 63 0 R]>>
 endobj
 65 0 obj
 <</Type/StructElem/S/Div/P 68 0 R/K[64 0 R]>>
 endobj
 66 0 obj
-<</Type/StructElem/S/Span/P 67 0 R/A[<</O/Layout/Placement/Block>>]/K[36 37 38]/Pg 269 0 R>>
+<</Type/StructElem/S/Span/P 67 0 R/A[<</O/Layout/Placement/Block>>]/K[36]/Pg 323 0 R>>
 endobj
 67 0 obj
 <</Type/StructElem/S/Div/P 68 0 R/K[66 0 R]>>
 endobj
 68 0 obj
-<</Type/StructElem/S/Div/P 74 0 R/K[65 0 R 67 0 R]>>
+<</Type/StructElem/S/Div/P 89 0 R/K[65 0 R 67 0 R]>>
 endobj
 69 0 obj
-<</Type/StructElem/S/Span/P 70 0 R/A[<</O/Layout/Placement/Block>>]/K[39]/Pg 269 0 R>>
+<</Type/StructElem/S/Span/P 70 0 R/A[<</O/Layout/Placement/Block>>]/K[37]/Pg 323 0 R>>
 endobj
 70 0 obj
 <</Type/StructElem/S/Div/P 73 0 R/K[69 0 R]>>
 endobj
 71 0 obj
-<</Type/StructElem/S/Span/P 72 0 R/A[<</O/Layout/Placement/Block>>]/K[40 41]/Pg 269 0 R>>
+<</Type/StructElem/S/Span/P 72 0 R/A[<</O/Layout/Placement/Block>>]/K[38 39]/Pg 323 0 R>>
 endobj
 72 0 obj
 <</Type/StructElem/S/Div/P 73 0 R/K[71 0 R]>>
 endobj
 73 0 obj
-<</Type/StructElem/S/Div/P 74 0 R/K[70 0 R 72 0 R]>>
+<</Type/StructElem/S/Div/P 89 0 R/K[70 0 R 72 0 R]>>
 endobj
 74 0 obj
-<</Type/StructElem/S/Div/P 75 0 R/K[52 0 R 53 0 R 58 0 R 63 0 R 68 0 R 73 0 R]>>
+<</Type/StructElem/S/Span/P 75 0 R/A[<</O/Layout/Placement/Block>>]/K[40]/Pg 323 0 R>>
 endobj
 75 0 obj
-<</Type/StructElem/S/Div/P 241 0 R/K[51 0 R 74 0 R]>>
+<</Type/StructElem/S/Div/P 78 0 R/K[74 0 R]>>
 endobj
 76 0 obj
-<</Type/StructElem/S/Figure/P 77 0 R/A[<</O/Layout/Placement/Block>>]/K[42]/Pg 269 0 R>>
+<</Type/StructElem/S/Span/P 77 0 R/A[<</O/Layout/Placement/Block>>]/K[41 42 43]/Pg 323 0 R>>
 endobj
 77 0 obj
-<</Type/StructElem/S/Div/P 112 0 R/K[76 0 R]>>
+<</Type/StructElem/S/Div/P 78 0 R/K[76 0 R]>>
 endobj
 78 0 obj
-<</Type/StructElem/S/P/P 111 0 R/K[43]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 89 0 R/K[75 0 R 77 0 R]>>
 endobj
 79 0 obj
-<</Type/StructElem/S/P/P 111 0 R/K[44]/Pg 269 0 R>>
+<</Type/StructElem/S/Span/P 80 0 R/A[<</O/Layout/Placement/Block>>]/K[44]/Pg 323 0 R>>
 endobj
 80 0 obj
-<</Type/StructElem/S/Span/P 81 0 R/A[<</O/Layout/Placement/Block>>]/K[45]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 83 0 R/K[79 0 R]>>
 endobj
 81 0 obj
-<</Type/StructElem/S/Div/P 84 0 R/K[80 0 R]>>
+<</Type/StructElem/S/Span/P 82 0 R/A[<</O/Layout/Placement/Block>>]/K[45 46]/Pg 323 0 R>>
 endobj
 82 0 obj
-<</Type/StructElem/S/Span/P 83 0 R/A[<</O/Layout/Placement/Block>>]/K[46]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 83 0 R/K[81 0 R]>>
 endobj
 83 0 obj
-<</Type/StructElem/S/Div/P 84 0 R/K[82 0 R]>>
+<</Type/StructElem/S/Div/P 89 0 R/K[80 0 R 82 0 R]>>
 endobj
 84 0 obj
-<</Type/StructElem/S/Div/P 111 0 R/K[81 0 R 83 0 R]>>
+<</Type/StructElem/S/Span/P 85 0 R/A[<</O/Layout/Placement/Block>>]/K[47]/Pg 323 0 R>>
 endobj
 85 0 obj
-<</Type/StructElem/S/P/P 111 0 R/K[47 48]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 88 0 R/K[84 0 R]>>
 endobj
 86 0 obj
-<</Type/StructElem/S/Figure/P 87 0 R/A[<</O/Layout/Placement/Block>>]/K[49]/Pg 269 0 R>>
+<</Type/StructElem/S/Span/P 87 0 R/A[<</O/Layout/Placement/Block>>]/K[48 49]/Pg 323 0 R>>
 endobj
 87 0 obj
-<</Type/StructElem/S/Div/P 90 0 R/K[86 0 R]>>
+<</Type/StructElem/S/Div/P 88 0 R/K[86 0 R]>>
 endobj
 88 0 obj
-<</Type/StructElem/S/Span/P 89 0 R/A[<</O/Layout/Placement/Block>>]/K[50 51 52 53]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 89 0 R/K[85 0 R 87 0 R]>>
 endobj
 89 0 obj
-<</Type/StructElem/S/Div/P 90 0 R/K[88 0 R]>>
+<</Type/StructElem/S/Div/P 90 0 R/K[56 0 R 57 0 R 68 0 R 73 0 R 78 0 R 83 0 R 88 0 R]>>
 endobj
 90 0 obj
-<</Type/StructElem/S/Div/P 111 0 R/K[87 0 R 89 0 R]>>
+<</Type/StructElem/S/Div/P 295 0 R/K[55 0 R 89 0 R]>>
 endobj
 91 0 obj
-<</Type/StructElem/S/Figure/P 92 0 R/A[<</O/Layout/Placement/Block>>]/K[54]/Pg 269 0 R>>
+<</Type/StructElem/S/Figure/P 92 0 R/A[<</O/Layout/Placement/Block>>]/K[50]/Pg 323 0 R>>
 endobj
 92 0 obj
-<</Type/StructElem/S/Div/P 95 0 R/K[91 0 R]>>
+<</Type/StructElem/S/Div/P 133 0 R/K[91 0 R]>>
 endobj
 93 0 obj
-<</Type/StructElem/S/Span/P 94 0 R/A[<</O/Layout/Placement/Block>>]/K[55 56 57 58]/Pg 269 0 R>>
+<</Type/StructElem/S/P/P 132 0 R/K[51]/Pg 323 0 R>>
 endobj
 94 0 obj
-<</Type/StructElem/S/Div/P 95 0 R/K[93 0 R]>>
+<</Type/StructElem/S/P/P 132 0 R/K[52]/Pg 323 0 R>>
 endobj
 95 0 obj
-<</Type/StructElem/S/Div/P 111 0 R/K[92 0 R 94 0 R]>>
+<</Type/StructElem/S/Span/P 96 0 R/A[<</O/Layout/Placement/Block>>]/K[53]/Pg 323 0 R>>
 endobj
 96 0 obj
-<</Type/StructElem/S/Figure/P 97 0 R/A[<</O/Layout/Placement/Block>>]/K[59]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 101 0 R/K[95 0 R]>>
 endobj
 97 0 obj
-<</Type/StructElem/S/Div/P 100 0 R/K[96 0 R]>>
+<</Type/StructElem/S/Span/P 98 0 R/A[<</O/Layout/Placement/Block>>]/K[54]/Pg 323 0 R>>
 endobj
 98 0 obj
-<</Type/StructElem/S/Span/P 99 0 R/A[<</O/Layout/Placement/Block>>]/K[60 61 62 63]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 101 0 R/K[97 0 R]>>
 endobj
 99 0 obj
-<</Type/StructElem/S/Div/P 100 0 R/K[98 0 R]>>
+<</Type/StructElem/S/Span/P 100 0 R/A[<</O/Layout/Placement/Block>>]/K[55]/Pg 323 0 R>>
 endobj
 100 0 obj
-<</Type/StructElem/S/Div/P 111 0 R/K[97 0 R 99 0 R]>>
+<</Type/StructElem/S/Div/P 101 0 R/K[99 0 R]>>
 endobj
 101 0 obj
-<</Type/StructElem/S/Figure/P 102 0 R/A[<</O/Layout/Placement/Block>>]/K[64]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 102 0 R/K[96 0 R 98 0 R 100 0 R]>>
 endobj
 102 0 obj
 <</Type/StructElem/S/Div/P 105 0 R/K[101 0 R]>>
 endobj
 103 0 obj
-<</Type/StructElem/S/Span/P 104 0 R/A[<</O/Layout/Placement/Block>>]/K[65 66 67 68]/Pg 269 0 R>>
+<</Type/StructElem/S/Span/P 104 0 R/A[<</O/Layout/Placement/Block>>]/K[56]/Pg 323 0 R>>
 endobj
 104 0 obj
 <</Type/StructElem/S/Div/P 105 0 R/K[103 0 R]>>
 endobj
 105 0 obj
-<</Type/StructElem/S/Div/P 111 0 R/K[102 0 R 104 0 R]>>
+<</Type/StructElem/S/Div/P 132 0 R/K[102 0 R 104 0 R]>>
 endobj
 106 0 obj
-<</Type/StructElem/S/Figure/P 107 0 R/A[<</O/Layout/Placement/Block>>]/K[69]/Pg 269 0 R>>
+<</Type/StructElem/S/P/P 132 0 R/K[57 58]/Pg 323 0 R>>
 endobj
 107 0 obj
-<</Type/StructElem/S/Div/P 110 0 R/K[106 0 R]>>
+<</Type/StructElem/S/Figure/P 108 0 R/A[<</O/Layout/Placement/Block>>]/K[59]/Pg 323 0 R>>
 endobj
 108 0 obj
-<</Type/StructElem/S/Span/P 109 0 R/A[<</O/Layout/Placement/Block>>]/K[70 71 72 73]/Pg 269 0 R>>
+<</Type/StructElem/S/Div/P 111 0 R/K[107 0 R]>>
 endobj
 109 0 obj
-<</Type/StructElem/S/Div/P 110 0 R/K[108 0 R]>>
+<</Type/StructElem/S/Span/P 110 0 R/A[<</O/Layout/Placement/Block>>]/K[60 61 62 63]/Pg 323 0 R>>
 endobj
 110 0 obj
-<</Type/StructElem/S/Div/P 111 0 R/K[107 0 R 109 0 R]>>
+<</Type/StructElem/S/Div/P 111 0 R/K[109 0 R]>>
 endobj
 111 0 obj
-<</Type/StructElem/S/Div/P 112 0 R/K[78 0 R 79 0 R 84 0 R 85 0 R 90 0 R 95 0 R 100 0 R 105 0 R 110 0 R]>>
+<</Type/StructElem/S/Div/P 132 0 R/K[108 0 R 110 0 R]>>
 endobj
 112 0 obj
-<</Type/StructElem/S/Div/P 241 0 R/K[77 0 R 111 0 R]>>
+<</Type/StructElem/S/Figure/P 113 0 R/A[<</O/Layout/Placement/Block>>]/K[64]/Pg 323 0 R>>
 endobj
 113 0 obj
-<</Type/StructElem/S/Figure/P 114 0 R/A[<</O/Layout/Placement/Block>>]/K[0]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 116 0 R/K[112 0 R]>>
 endobj
 114 0 obj
-<</Type/StructElem/S/Div/P 128 0 R/K[113 0 R]>>
+<</Type/StructElem/S/Span/P 115 0 R/A[<</O/Layout/Placement/Block>>]/K[65 66 67 68]/Pg 323 0 R>>
 endobj
 115 0 obj
-<</Type/StructElem/S/P/P 127 0 R/K[1]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 116 0 R/K[114 0 R]>>
 endobj
 116 0 obj
-<</Type/StructElem/S/P/P 127 0 R/K[2]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 132 0 R/K[113 0 R 115 0 R]>>
 endobj
 117 0 obj
-<</Type/StructElem/S/Span/P 118 0 R/A[<</O/Layout/Placement/Block>>]/K[3]/Pg 270 0 R>>
+<</Type/StructElem/S/Figure/P 118 0 R/A[<</O/Layout/Placement/Block>>]/K[69]/Pg 323 0 R>>
 endobj
 118 0 obj
 <</Type/StructElem/S/Div/P 121 0 R/K[117 0 R]>>
 endobj
 119 0 obj
-<</Type/StructElem/S/Span/P 120 0 R/A[<</O/Layout/Placement/Block>>]/K[4]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 120 0 R/A[<</O/Layout/Placement/Block>>]/K[70 71 72 73]/Pg 323 0 R>>
 endobj
 120 0 obj
 <</Type/StructElem/S/Div/P 121 0 R/K[119 0 R]>>
 endobj
 121 0 obj
-<</Type/StructElem/S/Div/P 127 0 R/K[118 0 R 120 0 R]>>
+<</Type/StructElem/S/Div/P 132 0 R/K[118 0 R 120 0 R]>>
 endobj
 122 0 obj
-<</Type/StructElem/S/Span/P 123 0 R/A[<</O/Layout/Placement/Block>>]/K[5]/Pg 270 0 R>>
+<</Type/StructElem/S/Figure/P 123 0 R/A[<</O/Layout/Placement/Block>>]/K[74]/Pg 323 0 R>>
 endobj
 123 0 obj
 <</Type/StructElem/S/Div/P 126 0 R/K[122 0 R]>>
 endobj
 124 0 obj
-<</Type/StructElem/S/Span/P 125 0 R/A[<</O/Layout/Placement/Block>>]/K[6 7]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 125 0 R/A[<</O/Layout/Placement/Block>>]/K[75 76 77 78]/Pg 323 0 R>>
 endobj
 125 0 obj
 <</Type/StructElem/S/Div/P 126 0 R/K[124 0 R]>>
 endobj
 126 0 obj
-<</Type/StructElem/S/Div/P 127 0 R/K[123 0 R 125 0 R]>>
+<</Type/StructElem/S/Div/P 132 0 R/K[123 0 R 125 0 R]>>
 endobj
 127 0 obj
-<</Type/StructElem/S/Div/P 128 0 R/K[115 0 R 116 0 R 121 0 R 126 0 R]>>
+<</Type/StructElem/S/Figure/P 128 0 R/A[<</O/Layout/Placement/Block>>]/K[79]/Pg 323 0 R>>
 endobj
 128 0 obj
-<</Type/StructElem/S/Div/P 241 0 R/K[114 0 R 127 0 R]>>
+<</Type/StructElem/S/Div/P 131 0 R/K[127 0 R]>>
 endobj
 129 0 obj
-<</Type/StructElem/S/Figure/P 130 0 R/A[<</O/Layout/Placement/Block>>]/K[8]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 130 0 R/A[<</O/Layout/Placement/Block>>]/K[80 81 82 83]/Pg 323 0 R>>
 endobj
 130 0 obj
-<</Type/StructElem/S/Div/P 149 0 R/K[129 0 R]>>
+<</Type/StructElem/S/Div/P 131 0 R/K[129 0 R]>>
 endobj
 131 0 obj
-<</Type/StructElem/S/P/P 148 0 R/K[9]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 132 0 R/K[128 0 R 130 0 R]>>
 endobj
 132 0 obj
-<</Type/StructElem/S/P/P 148 0 R/K[10]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 133 0 R/K[93 0 R 94 0 R 105 0 R 106 0 R 111 0 R 116 0 R 121 0 R 126 0 R 131 0 R]>>
 endobj
 133 0 obj
-<</Type/StructElem/S/Span/P 134 0 R/A[<</O/Layout/Placement/Block>>]/K[11]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 295 0 R/K[92 0 R 132 0 R]>>
 endobj
 134 0 obj
-<</Type/StructElem/S/Div/P 137 0 R/K[133 0 R]>>
+<</Type/StructElem/S/Figure/P 135 0 R/A[<</O/Layout/Placement/Block>>]/K[0]/Pg 324 0 R>>
 endobj
 135 0 obj
-<</Type/StructElem/S/Span/P 136 0 R/A[<</O/Layout/Placement/Block>>]/K[12]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 160 0 R/K[134 0 R]>>
 endobj
 136 0 obj
-<</Type/StructElem/S/Div/P 137 0 R/K[135 0 R]>>
+<</Type/StructElem/S/P/P 159 0 R/K[1]/Pg 324 0 R>>
 endobj
 137 0 obj
-<</Type/StructElem/S/Div/P 148 0 R/K[134 0 R 136 0 R]>>
+<</Type/StructElem/S/P/P 159 0 R/K[2]/Pg 324 0 R>>
 endobj
 138 0 obj
-<</Type/StructElem/S/Span/P 139 0 R/A[<</O/Layout/Placement/Block>>]/K[13]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 139 0 R/A[<</O/Layout/Placement/Block>>]/K[3]/Pg 324 0 R>>
 endobj
 139 0 obj
-<</Type/StructElem/S/Div/P 142 0 R/K[138 0 R]>>
+<</Type/StructElem/S/Div/P 144 0 R/K[138 0 R]>>
 endobj
 140 0 obj
-<</Type/StructElem/S/Span/P 141 0 R/A[<</O/Layout/Placement/Block>>]/K[14 15]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 141 0 R/A[<</O/Layout/Placement/Block>>]/K[4]/Pg 324 0 R>>
 endobj
 141 0 obj
-<</Type/StructElem/S/Div/P 142 0 R/K[140 0 R]>>
+<</Type/StructElem/S/Div/P 144 0 R/K[140 0 R]>>
 endobj
 142 0 obj
-<</Type/StructElem/S/Div/P 148 0 R/K[139 0 R 141 0 R]>>
+<</Type/StructElem/S/Span/P 143 0 R/A[<</O/Layout/Placement/Block>>]/K[5]/Pg 324 0 R>>
 endobj
 143 0 obj
-<</Type/StructElem/S/Span/P 144 0 R/A[<</O/Layout/Placement/Block>>]/K[16]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 144 0 R/K[142 0 R]>>
 endobj
 144 0 obj
-<</Type/StructElem/S/Div/P 147 0 R/K[143 0 R]>>
+<</Type/StructElem/S/Div/P 145 0 R/K[139 0 R 141 0 R 143 0 R]>>
 endobj
 145 0 obj
-<</Type/StructElem/S/Span/P 146 0 R/A[<</O/Layout/Placement/Block>>]/K[17 18]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 148 0 R/K[144 0 R]>>
 endobj
 146 0 obj
-<</Type/StructElem/S/Div/P 147 0 R/K[145 0 R]>>
+<</Type/StructElem/S/Span/P 147 0 R/A[<</O/Layout/Placement/Block>>]/K[6]/Pg 324 0 R>>
 endobj
 147 0 obj
-<</Type/StructElem/S/Div/P 148 0 R/K[144 0 R 146 0 R]>>
+<</Type/StructElem/S/Div/P 148 0 R/K[146 0 R]>>
 endobj
 148 0 obj
-<</Type/StructElem/S/Div/P 149 0 R/K[131 0 R 132 0 R 137 0 R 142 0 R 147 0 R]>>
+<</Type/StructElem/S/Div/P 159 0 R/K[145 0 R 147 0 R]>>
 endobj
 149 0 obj
-<</Type/StructElem/S/Div/P 241 0 R/K[130 0 R 148 0 R]>>
+<</Type/StructElem/S/Span/P 150 0 R/A[<</O/Layout/Placement/Block>>]/K[7]/Pg 324 0 R>>
 endobj
 150 0 obj
-<</Type/StructElem/S/Figure/P 151 0 R/A[<</O/Layout/Placement/Block>>]/K[19]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 153 0 R/K[149 0 R]>>
 endobj
 151 0 obj
-<</Type/StructElem/S/Div/P 170 0 R/K[150 0 R]>>
+<</Type/StructElem/S/Span/P 152 0 R/A[<</O/Layout/Placement/Block>>]/K[8 9]/Pg 324 0 R>>
 endobj
 152 0 obj
-<</Type/StructElem/S/P/P 169 0 R/K[20]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 153 0 R/K[151 0 R]>>
 endobj
 153 0 obj
-<</Type/StructElem/S/P/P 169 0 R/K[21]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 159 0 R/K[150 0 R 152 0 R]>>
 endobj
 154 0 obj
-<</Type/StructElem/S/Span/P 155 0 R/A[<</O/Layout/Placement/Block>>]/K[22]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 155 0 R/A[<</O/Layout/Placement/Block>>]/K[10]/Pg 324 0 R>>
 endobj
 155 0 obj
 <</Type/StructElem/S/Div/P 158 0 R/K[154 0 R]>>
 endobj
 156 0 obj
-<</Type/StructElem/S/Span/P 157 0 R/A[<</O/Layout/Placement/Block>>]/K[23]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 157 0 R/A[<</O/Layout/Placement/Block>>]/K[11 12]/Pg 324 0 R>>
 endobj
 157 0 obj
 <</Type/StructElem/S/Div/P 158 0 R/K[156 0 R]>>
 endobj
 158 0 obj
-<</Type/StructElem/S/Div/P 169 0 R/K[155 0 R 157 0 R]>>
+<</Type/StructElem/S/Div/P 159 0 R/K[155 0 R 157 0 R]>>
 endobj
 159 0 obj
-<</Type/StructElem/S/Span/P 160 0 R/A[<</O/Layout/Placement/Block>>]/K[24]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 160 0 R/K[136 0 R 137 0 R 148 0 R 153 0 R 158 0 R]>>
 endobj
 160 0 obj
-<</Type/StructElem/S/Div/P 163 0 R/K[159 0 R]>>
+<</Type/StructElem/S/Div/P 295 0 R/K[135 0 R 159 0 R]>>
 endobj
 161 0 obj
-<</Type/StructElem/S/Span/P 162 0 R/A[<</O/Layout/Placement/Block>>]/K[25 26]/Pg 270 0 R>>
+<</Type/StructElem/S/Figure/P 162 0 R/A[<</O/Layout/Placement/Block>>]/K[13]/Pg 324 0 R>>
 endobj
 162 0 obj
-<</Type/StructElem/S/Div/P 163 0 R/K[161 0 R]>>
+<</Type/StructElem/S/Div/P 185 0 R/K[161 0 R]>>
 endobj
 163 0 obj
-<</Type/StructElem/S/Div/P 169 0 R/K[160 0 R 162 0 R]>>
+<</Type/StructElem/S/P/P 184 0 R/K[14]/Pg 324 0 R>>
 endobj
 164 0 obj
-<</Type/StructElem/S/Span/P 165 0 R/A[<</O/Layout/Placement/Block>>]/K[27]/Pg 270 0 R>>
+<</Type/StructElem/S/P/P 184 0 R/K[15]/Pg 324 0 R>>
 endobj
 165 0 obj
-<</Type/StructElem/S/Div/P 168 0 R/K[164 0 R]>>
+<</Type/StructElem/S/Span/P 166 0 R/A[<</O/Layout/Placement/Block>>]/K[16]/Pg 324 0 R>>
 endobj
 166 0 obj
-<</Type/StructElem/S/Span/P 167 0 R/A[<</O/Layout/Placement/Block>>]/K[28]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 169 0 R/K[165 0 R]>>
 endobj
 167 0 obj
-<</Type/StructElem/S/Div/P 168 0 R/K[166 0 R]>>
+<</Type/StructElem/S/Span/P 168 0 R/A[<</O/Layout/Placement/Block>>]/K[17]/Pg 324 0 R>>
 endobj
 168 0 obj
-<</Type/StructElem/S/Div/P 169 0 R/K[165 0 R 167 0 R]>>
+<</Type/StructElem/S/Div/P 169 0 R/K[167 0 R]>>
 endobj
 169 0 obj
-<</Type/StructElem/S/Div/P 170 0 R/K[152 0 R 153 0 R 158 0 R 163 0 R 168 0 R]>>
+<</Type/StructElem/S/Div/P 170 0 R/K[166 0 R 168 0 R]>>
 endobj
 170 0 obj
-<</Type/StructElem/S/Div/P 241 0 R/K[151 0 R 169 0 R]>>
+<</Type/StructElem/S/Div/P 173 0 R/K[169 0 R]>>
 endobj
 171 0 obj
-<</Type/StructElem/S/Figure/P 172 0 R/A[<</O/Layout/Placement/Block>>]/K[29]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 172 0 R/A[<</O/Layout/Placement/Block>>]/K[18]/Pg 324 0 R>>
 endobj
 172 0 obj
-<</Type/StructElem/S/Div/P 196 0 R/K[171 0 R]>>
+<</Type/StructElem/S/Div/P 173 0 R/K[171 0 R]>>
 endobj
 173 0 obj
-<</Type/StructElem/S/P/P 195 0 R/K[30]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 184 0 R/K[170 0 R 172 0 R]>>
 endobj
 174 0 obj
-<</Type/StructElem/S/P/P 195 0 R/K[31]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 175 0 R/A[<</O/Layout/Placement/Block>>]/K[19]/Pg 324 0 R>>
 endobj
 175 0 obj
-<</Type/StructElem/S/Span/P 176 0 R/A[<</O/Layout/Placement/Block>>]/K[32]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 178 0 R/K[174 0 R]>>
 endobj
 176 0 obj
-<</Type/StructElem/S/Div/P 179 0 R/K[175 0 R]>>
+<</Type/StructElem/S/Span/P 177 0 R/A[<</O/Layout/Placement/Block>>]/K[20 21]/Pg 324 0 R>>
 endobj
 177 0 obj
-<</Type/StructElem/S/Span/P 178 0 R/A[<</O/Layout/Placement/Block>>]/K[33]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 178 0 R/K[176 0 R]>>
 endobj
 178 0 obj
-<</Type/StructElem/S/Div/P 179 0 R/K[177 0 R]>>
+<</Type/StructElem/S/Div/P 184 0 R/K[175 0 R 177 0 R]>>
 endobj
 179 0 obj
-<</Type/StructElem/S/Div/P 195 0 R/K[176 0 R 178 0 R]>>
+<</Type/StructElem/S/Span/P 180 0 R/A[<</O/Layout/Placement/Block>>]/K[22]/Pg 324 0 R>>
 endobj
 180 0 obj
-<</Type/StructElem/S/Span/P 181 0 R/A[<</O/Layout/Placement/Block>>]/K[34]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 183 0 R/K[179 0 R]>>
 endobj
 181 0 obj
-<</Type/StructElem/S/Div/P 184 0 R/K[180 0 R]>>
+<</Type/StructElem/S/Span/P 182 0 R/A[<</O/Layout/Placement/Block>>]/K[23 24]/Pg 324 0 R>>
 endobj
 182 0 obj
-<</Type/StructElem/S/Span/P 183 0 R/A[<</O/Layout/Placement/Block>>]/K[35 36 37]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 183 0 R/K[181 0 R]>>
 endobj
 183 0 obj
-<</Type/StructElem/S/Div/P 184 0 R/K[182 0 R]>>
+<</Type/StructElem/S/Div/P 184 0 R/K[180 0 R 182 0 R]>>
 endobj
 184 0 obj
-<</Type/StructElem/S/Div/P 195 0 R/K[181 0 R 183 0 R]>>
+<</Type/StructElem/S/Div/P 185 0 R/K[163 0 R 164 0 R 173 0 R 178 0 R 183 0 R]>>
 endobj
 185 0 obj
-<</Type/StructElem/S/Span/P 186 0 R/A[<</O/Layout/Placement/Block>>]/K[38]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 295 0 R/K[162 0 R 184 0 R]>>
 endobj
 186 0 obj
-<</Type/StructElem/S/Div/P 189 0 R/K[185 0 R]>>
+<</Type/StructElem/S/Figure/P 187 0 R/A[<</O/Layout/Placement/Block>>]/K[25]/Pg 324 0 R>>
 endobj
 187 0 obj
-<</Type/StructElem/S/Span/P 188 0 R/A[<</O/Layout/Placement/Block>>]/K[39 40 41]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 210 0 R/K[186 0 R]>>
 endobj
 188 0 obj
-<</Type/StructElem/S/Div/P 189 0 R/K[187 0 R]>>
+<</Type/StructElem/S/P/P 209 0 R/K[26]/Pg 324 0 R>>
 endobj
 189 0 obj
-<</Type/StructElem/S/Div/P 195 0 R/K[186 0 R 188 0 R]>>
+<</Type/StructElem/S/P/P 209 0 R/K[27]/Pg 324 0 R>>
 endobj
 190 0 obj
-<</Type/StructElem/S/Span/P 191 0 R/A[<</O/Layout/Placement/Block>>]/K[42]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 191 0 R/A[<</O/Layout/Placement/Block>>]/K[28]/Pg 324 0 R>>
 endobj
 191 0 obj
 <</Type/StructElem/S/Div/P 194 0 R/K[190 0 R]>>
 endobj
 192 0 obj
-<</Type/StructElem/S/Span/P 193 0 R/A[<</O/Layout/Placement/Block>>]/K[43]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 193 0 R/A[<</O/Layout/Placement/Block>>]/K[29]/Pg 324 0 R>>
 endobj
 193 0 obj
 <</Type/StructElem/S/Div/P 194 0 R/K[192 0 R]>>
@@ -584,240 +584,402 @@ endobj
 <</Type/StructElem/S/Div/P 195 0 R/K[191 0 R 193 0 R]>>
 endobj
 195 0 obj
-<</Type/StructElem/S/Div/P 196 0 R/K[173 0 R 174 0 R 179 0 R 184 0 R 189 0 R 194 0 R]>>
+<</Type/StructElem/S/Div/P 198 0 R/K[194 0 R]>>
 endobj
 196 0 obj
-<</Type/StructElem/S/Div/P 241 0 R/K[172 0 R 195 0 R]>>
+<</Type/StructElem/S/Span/P 197 0 R/A[<</O/Layout/Placement/Block>>]/K[30]/Pg 324 0 R>>
 endobj
 197 0 obj
-<</Type/StructElem/S/Figure/P 198 0 R/A[<</O/Layout/Placement/Block>>]/K[44]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 198 0 R/K[196 0 R]>>
 endobj
 198 0 obj
-<</Type/StructElem/S/Div/P 217 0 R/K[197 0 R]>>
+<</Type/StructElem/S/Div/P 209 0 R/K[195 0 R 197 0 R]>>
 endobj
 199 0 obj
-<</Type/StructElem/S/P/P 216 0 R/K[45]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 200 0 R/A[<</O/Layout/Placement/Block>>]/K[31]/Pg 324 0 R>>
 endobj
 200 0 obj
-<</Type/StructElem/S/P/P 216 0 R/K[46]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 203 0 R/K[199 0 R]>>
 endobj
 201 0 obj
-<</Type/StructElem/S/Span/P 202 0 R/A[<</O/Layout/Placement/Block>>]/K[47]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 202 0 R/A[<</O/Layout/Placement/Block>>]/K[32 33]/Pg 324 0 R>>
 endobj
 202 0 obj
-<</Type/StructElem/S/Div/P 205 0 R/K[201 0 R]>>
+<</Type/StructElem/S/Div/P 203 0 R/K[201 0 R]>>
 endobj
 203 0 obj
-<</Type/StructElem/S/Span/P 204 0 R/A[<</O/Layout/Placement/Block>>]/K[48]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 209 0 R/K[200 0 R 202 0 R]>>
 endobj
 204 0 obj
-<</Type/StructElem/S/Div/P 205 0 R/K[203 0 R]>>
+<</Type/StructElem/S/Span/P 205 0 R/A[<</O/Layout/Placement/Block>>]/K[34]/Pg 324 0 R>>
 endobj
 205 0 obj
-<</Type/StructElem/S/Div/P 216 0 R/K[202 0 R 204 0 R]>>
+<</Type/StructElem/S/Div/P 208 0 R/K[204 0 R]>>
 endobj
 206 0 obj
-<</Type/StructElem/S/Span/P 207 0 R/A[<</O/Layout/Placement/Block>>]/K[49]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 207 0 R/A[<</O/Layout/Placement/Block>>]/K[35]/Pg 324 0 R>>
 endobj
 207 0 obj
-<</Type/StructElem/S/Div/P 210 0 R/K[206 0 R]>>
+<</Type/StructElem/S/Div/P 208 0 R/K[206 0 R]>>
 endobj
 208 0 obj
-<</Type/StructElem/S/Span/P 209 0 R/A[<</O/Layout/Placement/Block>>]/K[50 51 52]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 209 0 R/K[205 0 R 207 0 R]>>
 endobj
 209 0 obj
-<</Type/StructElem/S/Div/P 210 0 R/K[208 0 R]>>
+<</Type/StructElem/S/Div/P 210 0 R/K[188 0 R 189 0 R 198 0 R 203 0 R 208 0 R]>>
 endobj
 210 0 obj
-<</Type/StructElem/S/Div/P 216 0 R/K[207 0 R 209 0 R]>>
+<</Type/StructElem/S/Div/P 295 0 R/K[187 0 R 209 0 R]>>
 endobj
 211 0 obj
-<</Type/StructElem/S/Span/P 212 0 R/A[<</O/Layout/Placement/Block>>]/K[53]/Pg 270 0 R>>
+<</Type/StructElem/S/Figure/P 212 0 R/A[<</O/Layout/Placement/Block>>]/K[36]/Pg 324 0 R>>
 endobj
 212 0 obj
-<</Type/StructElem/S/Div/P 215 0 R/K[211 0 R]>>
+<</Type/StructElem/S/Div/P 242 0 R/K[211 0 R]>>
 endobj
 213 0 obj
-<</Type/StructElem/S/Span/P 214 0 R/A[<</O/Layout/Placement/Block>>]/K[54]/Pg 270 0 R>>
+<</Type/StructElem/S/P/P 241 0 R/K[37]/Pg 324 0 R>>
 endobj
 214 0 obj
-<</Type/StructElem/S/Div/P 215 0 R/K[213 0 R]>>
+<</Type/StructElem/S/P/P 241 0 R/K[38]/Pg 324 0 R>>
 endobj
 215 0 obj
-<</Type/StructElem/S/Div/P 216 0 R/K[212 0 R 214 0 R]>>
+<</Type/StructElem/S/Span/P 216 0 R/A[<</O/Layout/Placement/Block>>]/K[39]/Pg 324 0 R>>
 endobj
 216 0 obj
-<</Type/StructElem/S/Div/P 217 0 R/K[199 0 R 200 0 R 205 0 R 210 0 R 215 0 R]>>
+<</Type/StructElem/S/Div/P 221 0 R/K[215 0 R]>>
 endobj
 217 0 obj
-<</Type/StructElem/S/Div/P 241 0 R/K[198 0 R 216 0 R]>>
+<</Type/StructElem/S/Span/P 218 0 R/A[<</O/Layout/Placement/Block>>]/K[40]/Pg 324 0 R>>
 endobj
 218 0 obj
-<</Type/StructElem/S/P/P 241 0 R/K[55]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 221 0 R/K[217 0 R]>>
 endobj
 219 0 obj
-<</Type/StructElem/S/Figure/P 220 0 R/A[<</O/Layout/Placement/Block>>]/K[56]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 220 0 R/A[<</O/Layout/Placement/Block>>]/K[41]/Pg 324 0 R>>
 endobj
 220 0 obj
-<</Type/StructElem/S/Div/P 229 0 R/K[219 0 R]>>
+<</Type/StructElem/S/Div/P 221 0 R/K[219 0 R]>>
 endobj
 221 0 obj
-<</Type/StructElem/S/P/P 228 0 R/K[57]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 222 0 R/K[216 0 R 218 0 R 220 0 R]>>
 endobj
 222 0 obj
-<</Type/StructElem/S/P/P 228 0 R/K[58]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 225 0 R/K[221 0 R]>>
 endobj
 223 0 obj
-<</Type/StructElem/S/Span/P 224 0 R/A[<</O/Layout/Placement/Block>>]/K[59]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 224 0 R/A[<</O/Layout/Placement/Block>>]/K[42]/Pg 324 0 R>>
 endobj
 224 0 obj
-<</Type/StructElem/S/Div/P 227 0 R/K[223 0 R]>>
+<</Type/StructElem/S/Div/P 225 0 R/K[223 0 R]>>
 endobj
 225 0 obj
-<</Type/StructElem/S/Span/P 226 0 R/A[<</O/Layout/Placement/Block>>]/K[60]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 241 0 R/K[222 0 R 224 0 R]>>
 endobj
 226 0 obj
-<</Type/StructElem/S/Div/P 227 0 R/K[225 0 R]>>
+<</Type/StructElem/S/Span/P 227 0 R/A[<</O/Layout/Placement/Block>>]/K[43]/Pg 324 0 R>>
 endobj
 227 0 obj
-<</Type/StructElem/S/Div/P 228 0 R/K[224 0 R 226 0 R]>>
+<</Type/StructElem/S/Div/P 230 0 R/K[226 0 R]>>
 endobj
 228 0 obj
-<</Type/StructElem/S/Div/P 229 0 R/K[221 0 R 222 0 R 227 0 R]>>
+<</Type/StructElem/S/Span/P 229 0 R/A[<</O/Layout/Placement/Block>>]/K[44 45]/Pg 324 0 R>>
 endobj
 229 0 obj
-<</Type/StructElem/S/Div/P 241 0 R/K[220 0 R 228 0 R]>>
+<</Type/StructElem/S/Div/P 230 0 R/K[228 0 R]>>
 endobj
 230 0 obj
-<</Type/StructElem/S/Figure/P 231 0 R/A[<</O/Layout/Placement/Block>>]/K[61]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 241 0 R/K[227 0 R 229 0 R]>>
 endobj
 231 0 obj
-<</Type/StructElem/S/Div/P 240 0 R/K[230 0 R]>>
+<</Type/StructElem/S/Span/P 232 0 R/A[<</O/Layout/Placement/Block>>]/K[46]/Pg 324 0 R>>
 endobj
 232 0 obj
-<</Type/StructElem/S/P/P 239 0 R/K[62]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 235 0 R/K[231 0 R]>>
 endobj
 233 0 obj
-<</Type/StructElem/S/P/P 239 0 R/K[63]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 234 0 R/A[<</O/Layout/Placement/Block>>]/K[47 48 49]/Pg 324 0 R>>
 endobj
 234 0 obj
-<</Type/StructElem/S/Span/P 235 0 R/A[<</O/Layout/Placement/Block>>]/K[64]/Pg 270 0 R>>
+<</Type/StructElem/S/Div/P 235 0 R/K[233 0 R]>>
 endobj
 235 0 obj
-<</Type/StructElem/S/Div/P 238 0 R/K[234 0 R]>>
+<</Type/StructElem/S/Div/P 241 0 R/K[232 0 R 234 0 R]>>
 endobj
 236 0 obj
-<</Type/StructElem/S/Span/P 237 0 R/A[<</O/Layout/Placement/Block>>]/K[65]/Pg 270 0 R>>
+<</Type/StructElem/S/Span/P 237 0 R/A[<</O/Layout/Placement/Block>>]/K[50]/Pg 324 0 R>>
 endobj
 237 0 obj
-<</Type/StructElem/S/Div/P 238 0 R/K[236 0 R]>>
+<</Type/StructElem/S/Div/P 240 0 R/K[236 0 R]>>
 endobj
 238 0 obj
-<</Type/StructElem/S/Div/P 239 0 R/K[235 0 R 237 0 R]>>
+<</Type/StructElem/S/Span/P 239 0 R/A[<</O/Layout/Placement/Block>>]/K[51]/Pg 324 0 R>>
 endobj
 239 0 obj
-<</Type/StructElem/S/Div/P 240 0 R/K[232 0 R 233 0 R 238 0 R]>>
+<</Type/StructElem/S/Div/P 240 0 R/K[238 0 R]>>
 endobj
 240 0 obj
-<</Type/StructElem/S/Div/P 241 0 R/K[231 0 R 239 0 R]>>
+<</Type/StructElem/S/Div/P 241 0 R/K[237 0 R 239 0 R]>>
 endobj
 241 0 obj
-<</Type/StructElem/S/Document/P 4 0 R/K[16 0 R 17 0 R 18 0 R 49 0 R 75 0 R 112 0 R 128 0 R 149 0 R 170 0 R 196 0 R 217 0 R 218 0 R 229 0 R 240 0 R]>>
+<</Type/StructElem/S/Div/P 242 0 R/K[213 0 R 214 0 R 225 0 R 230 0 R 235 0 R 240 0 R]>>
 endobj
 242 0 obj
-<</Type/Annot/Subtype/Link/Rect[501.8625 953.5635 570.24 961.6785]/Border[0 0 0]/A<</Type/Action/S/URI/URI(mailto:sid_26@outlook.com)>>/F 4/StructParent 0/Contents(Email sid_26@outlook.com)>>
+<</Type/StructElem/S/Div/P 295 0 R/K[212 0 R 241 0 R]>>
 endobj
 243 0 obj
-<</Type/Annot/Subtype/Link/Rect[501.285 944.1825 570.24 952.2975]/Border[0 0 0]/A<</Type/Action/S/URI/URI(https://linkedin.com/in/f0rr0)>>/F 4/StructParent 1/Contents(https://linkedin.com/in/f0rr0)>>
+<</Type/StructElem/S/Figure/P 244 0 R/A[<</O/Layout/Placement/Block>>]/K[52]/Pg 324 0 R>>
 endobj
 244 0 obj
-<</Type/Annot/Subtype/Link/Rect[515.2125 934.8015 570.24 942.9165]/Border[0 0 0]/A<</Type/Action/S/URI/URI(https://github.com/f0rr0)>>/F 4/StructParent 2/Contents(https://github.com/f0rr0)>>
+<</Type/StructElem/S/Div/P 267 0 R/K[243 0 R]>>
 endobj
 245 0 obj
-[/ICCBased 294 0 R]
+<</Type/StructElem/S/P/P 266 0 R/K[53]/Pg 324 0 R>>
 endobj
 246 0 obj
-<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 245 0 R>>/XObject<</x0 296 0 R/x1 298 0 R/x2 300 0 R/x3 302 0 R/x4 304 0 R/x5 306 0 R/x6 308 0 R/x7 310 0 R/x8 312 0 R>>/Font<</f0 248 0 R/f1 251 0 R/f2 254 0 R/f3 257 0 R/f4 260 0 R/f5 263 0 R/f6 266 0 R>>>>
+<</Type/StructElem/S/P/P 266 0 R/K[54]/Pg 324 0 R>>
 endobj
 247 0 obj
-<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 245 0 R>>/XObject<</x0 314 0 R/x1 316 0 R/x2 318 0 R/x3 319 0 R/x4 321 0 R/x5 323 0 R/x6 325 0 R>>/Font<</f0 260 0 R/f1 263 0 R/f2 251 0 R/f3 254 0 R/f4 266 0 R/f5 257 0 R>>>>
+<</Type/StructElem/S/Span/P 248 0 R/A[<</O/Layout/Placement/Block>>]/K[55]/Pg 324 0 R>>
 endobj
 248 0 obj
-<</Type/Font/Subtype/Type0/BaseFont/QUGPQN+Literata-Regular/Encoding/Identity-H/DescendantFonts[249 0 R]/ToUnicode 272 0 R>>
+<</Type/StructElem/S/Div/P 251 0 R/K[247 0 R]>>
 endobj
 249 0 obj
-<</Type/Font/Subtype/CIDFontType2/BaseFont/QUGPQN+Literata-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 250 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 500 1 1 608 2 2 360 3 3 659 4 4 204 5 5 578 6 6 575 7 7 686]>>
+<</Type/StructElem/S/Span/P 250 0 R/A[<</O/Layout/Placement/Block>>]/K[56]/Pg 324 0 R>>
 endobj
 250 0 obj
-<</Type/FontDescriptor/FontName/QUGPQN+Literata-Regular/Flags 131076/FontBBox[22 -14 664 773]/ItalicAngle 0/Ascent 1177/Descent -308/CapHeight 710/StemV 95.4/CIDSet 271 0 R/FontFile2 273 0 R>>
+<</Type/StructElem/S/Div/P 251 0 R/K[249 0 R]>>
 endobj
 251 0 obj
-<</Type/Font/Subtype/Type0/BaseFont/HJCPUH+SourceSans3-Semibold/Encoding/Identity-H/DescendantFonts[252 0 R]/ToUnicode 275 0 R>>
+<</Type/StructElem/S/Div/P 252 0 R/K[248 0 R 250 0 R]>>
 endobj
 252 0 obj
-<</Type/Font/Subtype/CIDFontType2/BaseFont/HJCPUH+SourceSans3-Semibold/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 253 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 672 1 1 431 2 2 262 3 3 564 4 4 500 5 6 513 7 7 875 8 8 549 9 9 556 10 10 361 11 11 271 12 12 522 13 13 275 14 14 462 15 15 843 16 16 560 17 17 507.00003 18 18 344 19 19 317 20 20 513 21 21 373 22 22 520 23 23 558 24 24 563 25 25 501.99997 26 26 516 27 27 200 28 28 558 29 29 564 30 30 282 31 31 538 32 32 582 33 33 275 34 34 576 35 35 510 36 36 639 37 37 546 38 38 625 39 39 536 40 40 597 41 41 748 42 42 275 43 43 481 44 44 540 45 45 495 46 46 745 47 47 545 48 48 642]>>
+<</Type/StructElem/S/Div/P 255 0 R/K[251 0 R]>>
 endobj
 253 0 obj
-<</Type/FontDescriptor/FontName/HJCPUH+SourceSans3-Semibold/Flags 131076/FontBBox[-69 -217 826 718]/ItalicAngle 0/Ascent 1000/Descent -326/CapHeight 660/StemV 144.2/CIDSet 274 0 R/FontFile2 276 0 R>>
+<</Type/StructElem/S/Span/P 254 0 R/A[<</O/Layout/Placement/Block>>]/K[57]/Pg 324 0 R>>
 endobj
 254 0 obj
-<</Type/Font/Subtype/Type0/BaseFont/AEPXTK+SourceSans3-Regular/Encoding/Identity-H/DescendantFonts[255 0 R]/ToUnicode 278 0 R>>
+<</Type/StructElem/S/Div/P 255 0 R/K[253 0 R]>>
 endobj
 255 0 obj
-<</Type/Font/Subtype/CIDFontType2/BaseFont/AEPXTK+SourceSans3-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 256 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 653 1 1 544 2 2 555 3 3 255 4 4 246 5 5 496 6 6 555 7 7 200 8 8 263 9 9 486 10 10 504 11 11 547 12 12 419 13 13 542 14 14 347 15 15 292 16 16 544 17 17 311 18 18 338 19 19 456 20 20 495 21 21 504 22 22 719 23 23 544 24 24 829 25 25 553 26 26 467 27 27 249 28 28 588 29 29 467 30 30 249 31 31 534 32 32 494 33 33 350 34 34 569 35 35 249 36 36 480 37 39 497 40 40 566 41 41 647 42 42 664 43 43 249 44 44 615 45 45 446 46 46 536 47 47 425 48 48 497 49 49 513 50 50 527 51 51 571 52 52 786 53 53 727 54 54 249 55 55 247 56 56 555 57 57 249 58 58 497 59 59 664 60 60 594 61 61 579 62 62 476 63 63 497 64 64 515 65 66 497 67 67 652 68 69 497 70 70 609 71 71 617 72 72 497 73 73 645 74 74 497 75 75 824 76 76 577]>>
+<</Type/StructElem/S/Div/P 266 0 R/K[252 0 R 254 0 R]>>
 endobj
 256 0 obj
-<</Type/FontDescriptor/FontName/AEPXTK+SourceSans3-Regular/Flags 131076/FontBBox[-167 -224 790 724]/ItalicAngle 0/Ascent 1000/Descent -326/CapHeight 660/StemV 95.4/CIDSet 277 0 R/FontFile2 279 0 R>>
+<</Type/StructElem/S/Span/P 257 0 R/A[<</O/Layout/Placement/Block>>]/K[58]/Pg 324 0 R>>
 endobj
 257 0 obj
-<</Type/Font/Subtype/Type0/BaseFont/NOTHBP+Literata-Regular/Encoding/Identity-H/DescendantFonts[258 0 R]/ToUnicode 281 0 R>>
+<</Type/StructElem/S/Div/P 260 0 R/K[256 0 R]>>
 endobj
 258 0 obj
-<</Type/Font/Subtype/CIDFontType2/BaseFont/NOTHBP+Literata-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 259 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 500 1 1 662 2 2 603 3 3 660 4 4 565 5 5 541 6 6 364 7 7 693 8 8 543 9 9 658 10 10 676 11 11 578 12 12 437 13 13 624]>>
+<</Type/StructElem/S/Span/P 259 0 R/A[<</O/Layout/Placement/Block>>]/K[59 60]/Pg 324 0 R>>
 endobj
 259 0 obj
-<</Type/FontDescriptor/FontName/NOTHBP+Literata-Regular/Flags 131076/FontBBox[5 -216 669 772]/ItalicAngle 0/Ascent 1177/Descent -308/CapHeight 701/StemV 95.4/CIDSet 280 0 R/FontFile2 282 0 R>>
+<</Type/StructElem/S/Div/P 260 0 R/K[258 0 R]>>
 endobj
 260 0 obj
-<</Type/Font/Subtype/Type0/BaseFont/QXCZXR+Literata-Regular/Encoding/Identity-H/DescendantFonts[261 0 R]/ToUnicode 284 0 R>>
+<</Type/StructElem/S/Div/P 266 0 R/K[257 0 R 259 0 R]>>
 endobj
 261 0 obj
-<</Type/Font/Subtype/CIDFontType2/BaseFont/QXCZXR+Literata-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 262 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 500 1 1 839 2 2 578 3 3 997 4 4 566 5 5 723 6 6 987 7 7 624 8 8 542 9 9 695 10 10 605 11 11 746 12 12 677 13 13 660 14 14 365 15 15 499 16 16 200 17 17 747 18 18 544 19 19 690 20 20 784 21 21 362 22 22 439 23 23 326 24 24 649 25 25 820 26 26 768 27 27 490 28 28 691 29 29 710 30 30 778 31 31 759 32 32 589 33 33 648 34 34 612 35 35 1111 36 36 841 37 37 665 38 38 658 39 39 614 40 40 672 41 41 786 42 42 623 43 43 428 44 44 756 45 45 654 46 46 745 47 47 329]>>
+<</Type/StructElem/S/Span/P 262 0 R/A[<</O/Layout/Placement/Block>>]/K[61]/Pg 324 0 R>>
 endobj
 262 0 obj
-<</Type/FontDescriptor/FontName/QXCZXR+Literata-Regular/Flags 131076/FontBBox[7 -230 1100 802]/ItalicAngle 0/Ascent 1177/Descent -308/CapHeight 700/StemV 95.4/CIDSet 283 0 R/FontFile2 285 0 R>>
+<</Type/StructElem/S/Div/P 265 0 R/K[261 0 R]>>
 endobj
 263 0 obj
-<</Type/Font/Subtype/Type0/BaseFont/XTONHV+SourceSans3-It/Encoding/Identity-H/DescendantFonts[264 0 R]/ToUnicode 287 0 R>>
+<</Type/StructElem/S/Span/P 264 0 R/A[<</O/Layout/Placement/Block>>]/K[62]/Pg 324 0 R>>
 endobj
 264 0 obj
-<</Type/Font/Subtype/CIDFontType2/BaseFont/XTONHV+SourceSans3-It/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 265 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 628 1 1 510 2 2 249 3 3 299 4 4 535 5 5 514 6 6 707 7 7 480 8 8 342 9 9 535 10 10 200 11 11 531 12 12 237 13 13 402 14 14 325 15 15 537 16 16 282 17 17 476 18 18 525 19 19 410 20 20 799 21 21 248 22 22 242 23 23 569 24 24 522 25 25 501.99997 26 26 756 27 27 242 28 28 705 29 29 242 30 30 448 31 31 523 32 32 536 33 33 550 34 34 505.99997 35 35 435 36 36 473 37 37 448 38 38 462 39 39 561 40 40 588 41 41 480 42 42 622 43 43 633 44 44 496]>>
+<</Type/StructElem/S/Div/P 265 0 R/K[263 0 R]>>
 endobj
 265 0 obj
-<</Type/FontDescriptor/FontName/XTONHV+SourceSans3-It/Flags 131140/FontBBox[-62 -220 812 724]/ItalicAngle -11/Ascent 1000/Descent -326/CapHeight 660/StemV 95.4/CIDSet 286 0 R/FontFile2 288 0 R>>
+<</Type/StructElem/S/Div/P 266 0 R/K[262 0 R 264 0 R]>>
 endobj
 266 0 obj
-<</Type/Font/Subtype/Type0/BaseFont/FWNBCE+SourceSans3-Bold/Encoding/Identity-H/DescendantFonts[267 0 R]/ToUnicode 290 0 R>>
+<</Type/StructElem/S/Div/P 267 0 R/K[245 0 R 246 0 R 255 0 R 260 0 R 265 0 R]>>
 endobj
 267 0 obj
-<</Type/Font/Subtype/CIDFontType2/BaseFont/FWNBCE+SourceSans3-Bold/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 268 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 690 1 1 300]>>
+<</Type/StructElem/S/Div/P 295 0 R/K[244 0 R 266 0 R]>>
 endobj
 268 0 obj
-<</Type/FontDescriptor/FontName/FWNBCE+SourceSans3-Bold/Flags 131076/FontBBox[61 -12 610 660]/ItalicAngle 0/Ascent 1000/Descent -326/CapHeight 660/StemV 168.6/CIDSet 289 0 R/FontFile2 291 0 R>>
+<</Type/StructElem/S/P/P 295 0 R/K[63]/Pg 324 0 R>>
 endobj
 269 0 obj
-<</Type/Page/Resources 246 0 R/MediaBox[0 0 612 1008]/StructParents 3/Tabs/S/Parent 1 0 R/Contents 292 0 R/Annots[242 0 R 243 0 R 244 0 R]>>
+<</Type/StructElem/S/Figure/P 270 0 R/A[<</O/Layout/Placement/Block>>]/K[64]/Pg 324 0 R>>
 endobj
 270 0 obj
-<</Type/Page/Resources 247 0 R/MediaBox[0 0 612 1008]/StructParents 4/Parent 1 0 R/Contents 293 0 R>>
+<</Type/StructElem/S/Div/P 281 0 R/K[269 0 R]>>
 endobj
 271 0 obj
+<</Type/StructElem/S/P/P 280 0 R/K[65]/Pg 324 0 R>>
+endobj
+272 0 obj
+<</Type/StructElem/S/P/P 280 0 R/K[66]/Pg 324 0 R>>
+endobj
+273 0 obj
+<</Type/StructElem/S/Span/P 274 0 R/A[<</O/Layout/Placement/Block>>]/K[67]/Pg 324 0 R>>
+endobj
+274 0 obj
+<</Type/StructElem/S/Div/P 275 0 R/K[273 0 R]>>
+endobj
+275 0 obj
+<</Type/StructElem/S/Div/P 276 0 R/K[274 0 R]>>
+endobj
+276 0 obj
+<</Type/StructElem/S/Div/P 279 0 R/K[275 0 R]>>
+endobj
+277 0 obj
+<</Type/StructElem/S/Span/P 278 0 R/A[<</O/Layout/Placement/Block>>]/K[68]/Pg 324 0 R>>
+endobj
+278 0 obj
+<</Type/StructElem/S/Div/P 279 0 R/K[277 0 R]>>
+endobj
+279 0 obj
+<</Type/StructElem/S/Div/P 280 0 R/K[276 0 R 278 0 R]>>
+endobj
+280 0 obj
+<</Type/StructElem/S/Div/P 281 0 R/K[271 0 R 272 0 R 279 0 R]>>
+endobj
+281 0 obj
+<</Type/StructElem/S/Div/P 295 0 R/K[270 0 R 280 0 R]>>
+endobj
+282 0 obj
+<</Type/StructElem/S/Figure/P 283 0 R/A[<</O/Layout/Placement/Block>>]/K[69]/Pg 324 0 R>>
+endobj
+283 0 obj
+<</Type/StructElem/S/Div/P 294 0 R/K[282 0 R]>>
+endobj
+284 0 obj
+<</Type/StructElem/S/P/P 293 0 R/K[70]/Pg 324 0 R>>
+endobj
+285 0 obj
+<</Type/StructElem/S/P/P 293 0 R/K[71]/Pg 324 0 R>>
+endobj
+286 0 obj
+<</Type/StructElem/S/Span/P 287 0 R/A[<</O/Layout/Placement/Block>>]/K[72]/Pg 324 0 R>>
+endobj
+287 0 obj
+<</Type/StructElem/S/Div/P 288 0 R/K[286 0 R]>>
+endobj
+288 0 obj
+<</Type/StructElem/S/Div/P 289 0 R/K[287 0 R]>>
+endobj
+289 0 obj
+<</Type/StructElem/S/Div/P 292 0 R/K[288 0 R]>>
+endobj
+290 0 obj
+<</Type/StructElem/S/Span/P 291 0 R/A[<</O/Layout/Placement/Block>>]/K[73]/Pg 324 0 R>>
+endobj
+291 0 obj
+<</Type/StructElem/S/Div/P 292 0 R/K[290 0 R]>>
+endobj
+292 0 obj
+<</Type/StructElem/S/Div/P 293 0 R/K[289 0 R 291 0 R]>>
+endobj
+293 0 obj
+<</Type/StructElem/S/Div/P 294 0 R/K[284 0 R 285 0 R 292 0 R]>>
+endobj
+294 0 obj
+<</Type/StructElem/S/Div/P 295 0 R/K[283 0 R 293 0 R]>>
+endobj
+295 0 obj
+<</Type/StructElem/S/Document/P 4 0 R/K[16 0 R 17 0 R 18 0 R 53 0 R 90 0 R 133 0 R 160 0 R 185 0 R 210 0 R 242 0 R 267 0 R 268 0 R 281 0 R 294 0 R]>>
+endobj
+296 0 obj
+<</Type/Annot/Subtype/Link/Rect[501.8625 953.3525 570.24 961.4675]/Border[0 0 0]/A<</Type/Action/S/URI/URI(mailto:sid_26@outlook.com)>>/F 4/StructParent 0/Contents(Email sid_26@outlook.com)>>
+endobj
+297 0 obj
+<</Type/Annot/Subtype/Link/Rect[501.285 944.1825 570.24 952.2975]/Border[0 0 0]/A<</Type/Action/S/URI/URI(https://linkedin.com/in/f0rr0)>>/F 4/StructParent 1/Contents(https://linkedin.com/in/f0rr0)>>
+endobj
+298 0 obj
+<</Type/Annot/Subtype/Link/Rect[515.2125 935.0125 570.24 943.1275]/Border[0 0 0]/A<</Type/Action/S/URI/URI(https://github.com/f0rr0)>>/F 4/StructParent 2/Contents(https://github.com/f0rr0)>>
+endobj
+299 0 obj
+[/ICCBased 348 0 R]
+endobj
+300 0 obj
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 299 0 R>>/XObject<</x0 350 0 R/x1 352 0 R/x2 354 0 R/x3 356 0 R/x4 358 0 R/x5 360 0 R/x6 362 0 R/x7 364 0 R/x8 366 0 R>>/Font<</f0 302 0 R/f1 305 0 R/f2 308 0 R/f3 311 0 R/f4 314 0 R/f5 317 0 R/f6 320 0 R>>>>
+endobj
+301 0 obj
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 299 0 R>>/XObject<</x0 368 0 R/x1 370 0 R/x2 372 0 R/x3 373 0 R/x4 375 0 R/x5 377 0 R/x6 379 0 R>>/Font<</f0 314 0 R/f1 317 0 R/f2 305 0 R/f3 308 0 R/f4 320 0 R/f5 311 0 R>>>>
+endobj
+302 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/QUGPQN+Literata-Regular/Encoding/Identity-H/DescendantFonts[303 0 R]/ToUnicode 326 0 R>>
+endobj
+303 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/QUGPQN+Literata-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 304 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 500 1 1 608 2 2 360 3 3 659 4 4 204 5 5 578 6 6 575 7 7 686]>>
+endobj
+304 0 obj
+<</Type/FontDescriptor/FontName/QUGPQN+Literata-Regular/Flags 131076/FontBBox[22 -14 664 773]/ItalicAngle 0/Ascent 1177/Descent -308/CapHeight 710/StemV 95.4/CIDSet 325 0 R/FontFile2 327 0 R>>
+endobj
+305 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/TAVORV+SourceSans3-Semibold/Encoding/Identity-H/DescendantFonts[306 0 R]/ToUnicode 329 0 R>>
+endobj
+306 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/TAVORV+SourceSans3-Semibold/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 307 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 672 1 1 431 2 2 262 3 3 564 4 4 500 5 6 513 7 7 875 8 8 549 9 9 556 10 10 361 11 11 271 12 12 522 13 13 275 14 14 462 15 15 843 16 16 560 17 17 507.00003 18 18 344 19 19 317 20 20 513 21 21 373 22 22 520 23 23 558 24 24 563 25 25 501.99997 26 26 516 27 27 200 28 28 558 29 29 564 30 30 282 31 31 538 32 32 663 33 33 322 34 34 582 35 35 275 36 36 576 37 37 510 38 38 639 39 39 546 40 40 625 41 41 536 42 42 597 43 43 748 44 44 275 45 45 481 46 46 540 47 47 495 48 48 745 49 49 545 50 50 642]>>
+endobj
+307 0 obj
+<</Type/FontDescriptor/FontName/TAVORV+SourceSans3-Semibold/Flags 131076/FontBBox[-69 -217 826 718]/ItalicAngle 0/Ascent 1000/Descent -326/CapHeight 660/StemV 144.2/CIDSet 328 0 R/FontFile2 330 0 R>>
+endobj
+308 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/SJODJH+SourceSans3-Regular/Encoding/Identity-H/DescendantFonts[309 0 R]/ToUnicode 332 0 R>>
+endobj
+309 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/SJODJH+SourceSans3-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 310 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 653 1 1 544 2 2 555 3 3 255 4 4 246 5 5 496 6 6 555 7 7 200 8 8 263 9 9 486 10 10 504 11 11 547 12 12 544 13 13 419 14 14 311 15 15 542 16 16 504 17 17 347 18 18 719 19 19 338 20 20 544 21 21 467 22 22 292 23 23 456 24 24 829 25 25 249 26 26 467 27 27 249 28 28 495 29 29 553 30 30 534 31 31 494 32 32 588 33 33 350 34 34 569 35 35 249 36 36 480 37 39 497 40 40 566 41 41 647 42 42 664 43 43 594 44 44 615 45 45 446 46 46 497 47 47 513 48 48 527 49 49 571 50 50 536 51 51 786 52 52 727 53 53 555 54 54 247 55 55 497 56 56 476 57 57 425 58 58 539 59 59 249 60 60 579 61 61 497 62 62 515 63 64 497 65 65 652 66 66 497 67 67 609 68 68 617 69 69 645 70 70 497 71 71 824 72 72 577]>>
+endobj
+310 0 obj
+<</Type/FontDescriptor/FontName/SJODJH+SourceSans3-Regular/Flags 131076/FontBBox[-167 -224 790 724]/ItalicAngle 0/Ascent 1000/Descent -326/CapHeight 660/StemV 95.4/CIDSet 331 0 R/FontFile2 333 0 R>>
+endobj
+311 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/NOTHBP+Literata-Regular/Encoding/Identity-H/DescendantFonts[312 0 R]/ToUnicode 335 0 R>>
+endobj
+312 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/NOTHBP+Literata-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 313 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 500 1 1 662 2 2 603 3 3 660 4 4 565 5 5 541 6 6 364 7 7 693 8 8 543 9 9 658 10 10 676 11 11 578 12 12 437 13 13 624]>>
+endobj
+313 0 obj
+<</Type/FontDescriptor/FontName/NOTHBP+Literata-Regular/Flags 131076/FontBBox[5 -216 669 772]/ItalicAngle 0/Ascent 1177/Descent -308/CapHeight 701/StemV 95.4/CIDSet 334 0 R/FontFile2 336 0 R>>
+endobj
+314 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/FFRKZO+Literata-Regular/Encoding/Identity-H/DescendantFonts[315 0 R]/ToUnicode 338 0 R>>
+endobj
+315 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/FFRKZO+Literata-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 316 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 500 1 1 839 2 2 578 3 3 997 4 4 566 5 5 723 6 6 987 7 7 624 8 8 542 9 9 695 10 10 605 11 11 746 12 12 677 13 13 660 14 14 365 15 15 499 16 16 200 17 17 747 18 18 544 19 19 690 20 20 784 21 21 362 22 22 439 23 23 589 24 24 841 25 25 665 26 26 710 27 27 658 28 28 614 29 29 1111 30 30 672 31 31 786 32 32 623 33 33 612 34 34 428 35 35 326 36 36 649 37 37 756 38 38 778 39 39 654 40 40 648 41 41 745 42 42 329]>>
+endobj
+316 0 obj
+<</Type/FontDescriptor/FontName/FFRKZO+Literata-Regular/Flags 131076/FontBBox[7 -230 1100 782]/ItalicAngle 0/Ascent 1177/Descent -308/CapHeight 700/StemV 95.4/CIDSet 337 0 R/FontFile2 339 0 R>>
+endobj
+317 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/ZFSMHF+SourceSans3-It/Encoding/Identity-H/DescendantFonts[318 0 R]/ToUnicode 341 0 R>>
+endobj
+318 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/ZFSMHF+SourceSans3-It/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 319 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 628 1 1 249 2 2 550 3 3 510 4 4 619 5 5 299 6 6 537 7 7 435 8 8 342 9 9 480 10 10 535 11 11 237 12 12 325 13 13 200 14 14 531 15 15 402 16 16 536 17 17 522 18 18 248 19 19 525 20 20 535 21 21 514 22 22 282 23 23 799 24 24 707 25 25 523 26 26 242 27 27 550 28 28 448 29 29 429 30 30 476 31 31 505.99997 32 32 448 33 33 462 34 34 561 35 35 588 36 36 569 37 37 594 38 38 496 39 39 473 40 40 534 41 41 756 42 42 242 43 43 480 44 44 622 45 45 633 46 46 705]>>
+endobj
+319 0 obj
+<</Type/FontDescriptor/FontName/ZFSMHF+SourceSans3-It/Flags 131140/FontBBox[-62 -220 812 724]/ItalicAngle -11/Ascent 1000/Descent -326/CapHeight 660/StemV 95.4/CIDSet 340 0 R/FontFile2 342 0 R>>
+endobj
+320 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/FWNBCE+SourceSans3-Bold/Encoding/Identity-H/DescendantFonts[321 0 R]/ToUnicode 344 0 R>>
+endobj
+321 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/FWNBCE+SourceSans3-Bold/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 322 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 690 1 1 300]>>
+endobj
+322 0 obj
+<</Type/FontDescriptor/FontName/FWNBCE+SourceSans3-Bold/Flags 131076/FontBBox[61 -12 610 660]/ItalicAngle 0/Ascent 1000/Descent -326/CapHeight 660/StemV 168.6/CIDSet 343 0 R/FontFile2 345 0 R>>
+endobj
+323 0 obj
+<</Type/Page/Resources 300 0 R/MediaBox[0 0 612 1008]/StructParents 3/Tabs/S/Parent 1 0 R/Contents 346 0 R/Annots[296 0 R 297 0 R 298 0 R]>>
+endobj
+324 0 obj
+<</Type/Page/Resources 301 0 R/MediaBox[0 0 612 1008]/StructParents 4/Parent 1 0 R/Contents 347 0 R>>
+endobj
+325 0 obj
 <</Length 9/Filter/FlateDecode>>
 stream
 xœû   
 endstream
 endobj
-272 0 obj
+326 0 obj
 <</Length 377/Type/CMap/Filter/FlateDecode/WMode 0>>
 stream
 xœm’ËnÂ0E÷ùŠéÂ,hž*BHˆ”5¨]{ –ˆmÙÎ‚¿¯l'PU]$Ñ™¹ö½c‡¼ËÁŠ«3F¯>ÐªÆ0¬w•NÙ(ÖÔ(Ý‘#ïºvÚ(fÑÁºØR¸„B²[Ã±Óü'yÇ«O÷€ucªBNÂÝp½X€	
@@ -825,126 +987,138 @@ xœm’ËnÂ0E÷ùŠéÂ,hž*BHˆ”5¨]{ –ˆmÙÎ‚¿¯l'PU]$Ñ™¹ö½c‡¼ËÁŠ«3F¯>ÐªÆ0¬w•NÙ(Ö
 O¸óî÷ñtÈ ýÚx
 endstream
 endobj
-273 0 obj
+327 0 obj
 <</Length 1547/Filter/FlateDecode>>
 stream
 xœ–]l[gÆç$MâØ>ÇqRçÄNŽ,¶ãcÇnâ~%ÍÒf„~,AÑJÝÔ‰³%u”8í
 Hë®¶&@¢C„zƒ&4qÃ*ª âb\ !Qí¢CÄ*CDô¾>]›tW;–ìÇïÇÿyþÏû¼ÒAÚ¸…+k7—xýÁKÀ7A{¥^«^íûö?&Aû7Pª×kÕ¶ûÊ?Á5Ö×›¯^\‹€¹ÖXªººÕÿ€«	t¯W_Û ƒ“àzKÌ_«®×¾öÑ€ë'àV7[M~Ìo ý§€ŠÊ=õ.^BÁ ­¼½»qT‰ªwwfÔ[;wÕF÷©GÔ?0	î„•ò&Så¸V°K¥ñ¢e¥²Úxñ¸V°u£\0¼Y5™ðDÂºnÄµHØ§*GKKCþ¢¢3eOZ…^sf|ôsGúÃ©É³cöY³3×3*M[¹Jb*›¿P1GÎ\ô%Oþ¹=u2ŽÆ“¹Á€oÐ>“8^‰öE‹tTÎ˜öh2cú–}z¬¼X‰ƒŠ	ÊyÍMˆÃP/—JãÁ¢•J•ËF0¬FDµŠ¥‚­GÂžD&x¨Ë°Üìj=÷û¢Ë‹-Sb=š»ÜÑ¶»j„]Þ‚úrælf4Ê bí=R¿¡îÑOŒ„eK¢ž1¾Å›JúÔ²0gÜ²’	4cçùËöÑÍs‰Šá¥Ü;;Â©ßu¹ü™cþøhO$ÊéFÎWÙ\øÒ­Ù@×wãÍ]òvîlA—§è]ˆ¥…ÞrêïàÈ—g§R(è{Ôaõ>ƒû´DÂ¯®Ë£‘½D¼O$ö|4qiÂéMGÃ]i£ßêîŠU^Ìvw½áš~®?ëïÑóý¾ø‰œòN,¢zJEîÛ½ýúNï'Ô yŽI>AW§ŸLx¼qUXúX‚‰„…‚²áñ$Vê±-'~yú|åõ•€eö|þ€ÇšM¹:=w9ß>î8¤OÊm¾áÉ˜>Ð­ôÆ}s'&N™î—†Ætg¨/äÕã‰¾¡“éôfFu—kXåÒ±täóáÁèÅÐpb(ŠH‚z[ª=£ðD¢aDä¤Ó†ÇL§ízÊ}¿Ë¥E/›˜êìÚýKðÏì=œµû^5SâfTs—:Û.'FÎ•öô æ.Øn-hüud,Ü[N} ‡T¯Bh±K?{˜ÿÞWýGÿ…¦ýM?¸·í¿úVßÛ»oî~ì¾ãÚ <¨b´µÏõÎîûà¾³ûæÎ×Ýwd¥§Ÿ6åclõ2£JSýïƒ:®žÀRßN¡Îm>äCEWÖ•Ÿ;zÚ8îð¬)þûxÅÕ¼+ÔK¬à]«øø…ƒ5l~ë`&ÿu°›I%æ`¦²è`/óJÓÁmD•_9¸{Êw0¢~ßÁQíà.%¡þÏÁ>J®8§h°ÁM6Ye…:MLlÆÈSÆd‘:5LæY¥IMª4©bržM¼B%¹gŠmšÔi°É&iY«É[L’#ÇŠ¬Qg›+dY¢ÁºmÐ`…5j,ÓàM¶È±v€qø/Rc…mÖ¨²I,yÆ(Pa‘E*Ï¬ÏØñlOûç¿(ç¶X•ªÌ}+,Ó”Ê×Øâ+Œ‘e‚,6¼ü˜W¥g5åèUj¬Ëµ¯bÒ`“ÓO9e2Ç5–È²ÈM6¨±(çjÒaQy^Ö^•Ê¯pÓéGô²Ê«’kšmyîU¹J|_ÅälIŽ–¨JÆ–5²RÇ&5jRY«òœó‚Eô¸$“°-×ŸrÒµ&ë,Ð#t<Ïu¶¤Ë¬Rã:U²Ÿä§•žò“Ý——Ç)úô•MÇ™Œ<©§½y¼O¤»åü¬“<Ñ³p»Éé¾è¨µ¢¥]t)¼>mK¿D=qj­{²Àó˜œ“Ì×öUžßWaôž$,/&<{¢l?ï“¤„§U®8‰¸áÜ¯VŽf™â‚ÄM&1Ÿ¹[,ÉSÙ÷-+U¬‘•÷w…ç˜eþ3îïòÙûxOú”§M¼¥1Ïi42Ìpþ›q¦`
 endstream
 endobj
-274 0 obj
+328 0 obj
 <</Length 13/Filter/FlateDecode>>
 stream
-xœûÿ  ÌÛ
+xœûÿ~  äó
 endstream
 endobj
-275 0 obj
-<</Length 563/Type/CMap/Filter/FlateDecode/WMode 0>>
+329 0 obj
+<</Length 570/Type/CMap/Filter/FlateDecode/WMode 0>>
 stream
-xœm”Iâ0Fïù5‡HôIì,Ð!±EâÐ‹šÖÌ9Ä‰8Q–ÿ~ÝÍ ç*»êÙqüïÇéÚÔ'žF?Cúà®Ú‚§Û—¼ñ|WCÅ¶e6lîÑnAM[÷´=ì¶ì=ß?Øâ:¾çü/eÃ—Ò~%Œ5h;t}]y¾ÿYöW^Ðäz¢ƒaÛ—ýÂ'Ï÷qÛ•µ]ò|oÍ¶®Ææ:/¼·uqäžÎ¥5­T¢ÓX×SšLYôBîYTyã&o]ÏÕÁžkŠe†F2‰ˆ‚¾”]ßÞhâ{"ÃgDÞZÃmi/4¹7û-xšæÊc“ºQ¶Æý£ük^1"üKR_CŸ·†eà÷Kmî ÐbQîš¼à6·ö–a†+ZfY–­ÆŠÿÄã9¦ÎÅŸ¼uéjEË0œE+GÚQúŠ@1(v”d ÄQ¤A)(ÍÅ!hŽUdÞ3ê% 5H*l¹mAÐÎ‘ÞƒöˆI×hçH†)2üRÔSðÓèE‰ºVð‹Ðµ‚ß~
-~é¿t?É„_¿Tà§¥üb‰Áo&1øÅ8¿~	25ü4êiøÅØ¿~~Z(Á*Øy¿X~‰dÂ/†Ÿ–óÃNhøEküfØ¿Dbâ#-~81¿]Gr~)Þ¶FÞÖñuoíãþCÛ²íÝ¥u—e¼¥åÇíoêfœå~î³qÿô–ý<‘Jù
+xœm”Iâ0Fïù5‡Hô‰ílÝ!±EâÐ‹šÖÌâ‚‰N”åÀ¿Å_ÑÝÍ ç*»ê%¶ÃoûéÒÖGžÆ?½sWmÉÓõó¡	ÂpS—Ã•]ÿÂlÙÞ£ÝŒš¶.;îi½Ûì\Õa¸såe°|Ïù_ÊŠÏ•ûJkÐzèúú„áGÕ_xFï‰v–]_õ7RAþâ¶«j7#„áÖÙu}›ë‚HjPôÖÖåž{:UÎ¶R‰ŽcÝ@²UÙùgy=4~òþÖõ|Ý¹SM1²ìÐH&QôÎçªëÛM|cdù„Èkk¹­Ü™&÷f¿÷CÓ\xl’”egý4Ê¿®L‘ŽŠ%é¯¡[Ã²@ôû¹¶wÐh±¬-wÍ¡äöàÎÌ•RjAó¢(ŠÅXñŸxª0íx*ÿZŸ®4W*žŒ§ì	ƒPâ)-@©§Ø€2PÊ=%
+ôˆUdÞê¥ %H*¬¹­A+ÐÆ“Ù‚¶ˆI×hãI/@©™~êiøô¢Å]køÅèZÃ/‡Ÿ†_–ƒà—=‚ÄO2á—ÀAÃ/Ó ø© ¿DbðË%¿ßAÃ/ƒ_‚ê~î~)V1ð3èÅÀ/Á;3ðKànàg„r¬‚¯bà—Á/•Lø%p7ðËñ–üâ%Hü¤kø¥ƒ_ÛXü`Ã/E×±ìÏ{†•<nõñDž­rh[v½?Ðþ §¦rüy34u3Îò?¥Üo§‘^‹¿&ePY
 endstream
 endobj
-276 0 obj
-<</Length 8342/Filter/FlateDecode>>
+330 0 obj
+<</Length 8432/Filter/FlateDecode>>
 stream
-xœ­zp[Y™æwÎ½ºzÛ–%Y¶åÇ•¯%9Ö•ìX~Å±Yò#vlÇ±ó’t,ù‘Äé¼:vÝMÓiz²¦Ç,C–Ý†j–-¦8J3L``=Ãn±ÍÀ4°3P¥	;µ¡›š%öÖ9Wrìtša§Æ)çü÷žÿœó¿Î÷ÿç\ƒ °ã:$´Î_YQ§+ð€´ž¼xêÜ\‹ý òK Äqêì“'Ï½üÞ¿ JÔ¼pz1·Ìÿýý9 §O/æ¬?6ý5 @ãés+×æ®X ú|ýì…ùÜ—º¿ºD?àô¹Üµ‹ä×¥7€˜€z>wnñÞþqˆµÊÅ‹–W¾$¿
-´Àû/^Z¼øÝ?sèèˆ	ÿ?WqYd© ¾{¸‚+8t w~zsãycãÞFçƒ¾{ôerwãÞÆ$ï¥¯ˆþIÂ!$‘”¦éWÉ;ðÏRš¾BžÄo¬ÁW¨¯´qo“'yÇæ˜]äÉÍq[dáë¥¡_ëµa3H!…¿ÛÃ÷7ú7çkØœï¾Ô°9ß}]e8”Ê¨ê¾Û(9°)3GÓ¬ÝÏš2Ù“êê¡4£ÁÜç,°`~^›ó†”6x©l2ÊˆÎÔìÉ(£ºÐQ&éêÂK’Ç‹dŠ¹Sj6›ÌSO*™J)FS¯©Ì¡1šJå˜<uí¥4•M²ÀbM€¿½Uâ%É•Ñ”–¼å&îT6©1L¥3·*çŒ2YgR„ySi¾«H¥
-~uAew¦˜:z«‰8SCóCLJ˜ÌLK´€5­²©©t€%2~•usª;“Qówn5M¥…'•µòþVÎyg*­žTWWs*³M¥³~•©¼ÏÆ©NNufýÙL&ãg4È©y†é4Ã>Î`Ž”«ãTÝ¾Üí2ÌsŽÛ&Ìe2¹#‘L¦ AF]`)-™‰2“®©LæTfNM¥™YK2‹–ôF²Q¦s3)¢.äÍsI•wruý†øüfÍÍ3Ss@e–”ºª®2É·š‚LHg§ü¹éLZË2*KÌ¤‰ø¹]
-¢D™YgÖTä¨áf‹Î¬ZRS´dŽÑ¹“ŒÌ3’eææ(³ê*—¶$5[ÆœÊg`‰l†³d…´6ý–µ©¡ds`3pìúö@r³ˆÆbr0«­j9îTalø¹C˜êg‰Mƒ1)¨å%œo1œ5N¥ùàÄ£•ðø×’/9†¦Ò¿È4¢¬TÏS:ÄrƒQV¦3’UUVšã¨¬TKfXšN«¬LøË¥«¬LE½-c~UË1W*«®fUæÒ’Z”•ëû¦óòÂ`¦‘9µkQæÖ÷Hï›1^ú™Fæï=zå©Cé|yyŠ‘\’¹"|Ë1LæKùe4˜d¤BS™œJç¹ù˜L®®ª|Ù²æ€ÆH®Hû~>„Å›+M°²ÔH–ÑíÎzæ·6ÈHŠ¡ÿ!DxË«#:t0ÍÊµ¤:ÄJ´$sjÌšMªÙ¿¬¬$pÁd2É-àÑ’ŒäòK„½;âoÈDY…ž‡7e>=Ox[©ç)o«ô¼ÄÛj=/óÖ¯çM¼­Ñó
-okõ¼™·uzÞÂÛz=oåmD×ŠögJvßÁ´¦ÆyŒï–(Ó·tVlv>atF·t†6;/ªVyK=Éý…¡*×s«~=5ezžðVÓó”·z^âmPÏË¼éyoÃz^ám“ž7óv‡ž·ð¶YÏ[yÓÕ^°-ºše•Y5¥1’å1‘ã›0Æc¶Ug-ÖÒe;uUQßÂ›Z®[ãÀþ{9ü\û¶¢‹ó%Ê8¶³9o"Þ¡tkFhßbž·âi×Õ!y‡ŽÏÐ›×d$òHYø{T|FäåÁ~­;ßN¼\×N]íUGÞB~†T®;Êºô˜¯7Êºÿ%VFRóÝQ¶KÏSTÕ˜:Â!Ñàèêêˆ6¢åÔôœŸ£®–¼ÕMˆ×Óe=:CóiI&™ly’ÌžŠ,®Æ4Uí]íŽ²ÝÛÙÔ˜1S´d‘[eYŽ)‰é—dÕ¤ú_’C¦êL’#­-¥®jb„6œeJêáíšåhgd%9•]Ð˜)•[˜J39•ó3S*Ë‘îá19MU™Ò†sÝ~ÙRÃ<cÙRb•¬ú¨E4S•T–;ÃÌ1Ó›ferˆäBHÁìBI¬•‰²Þ¢-TUe¦PÁZow”õmv1›èÖFø¢Ü‹ý›&äÊ–f8˜Ž©½Z@äÛÂK•ËUpS‚ÌÝZ»N|T´¼¥ñß³E’TÑ]Y^à<¬rÑÅ	]ScÜŠÃÌ—JOù§3iµ7Ë·O$Ê¶õNû§¶õ&9ö÷Hé¬'òûÔÙîÈªªöò[í~kV¦¤b¬5eCBeŸ!Ãò9æÐ’†ê<@5µWiÝ…ù‡õ¼M&‹Cþ?Czäß*Š¹NÇzµn`K¼29Gô<z"E«ìÕóØ	pŸqAÚlš`TgðÛþøwÇXgs”½Åû}zÄãf]ÍQ6®³]ÍQ6Á­8¤©1uxUË­5©ó€f‘(Û¯ß†#Q6¥ßáÄýo¦õ[D¼™á<#‘(;Èy8qˆópâ0çáÄý% ©H”¥õ—xé‰²Œþ1ÞÕ_"Æ»cœpê8çÔcœOP'8Ÿ fùšC‘(Ëò59‘ãkrbŽ¯É‰yÎ³7eœ‡‹œ‡'9'N	¹#QvZÈÅ©%!§Î¹8õ¸‹Sg…\œ:'äâÔy!§.èyôn:ð¢xb‰H”=a‘(»Ä.ž’‘([Öó¤À³bœç²à!ž+z}›³^ObÄ5ƒä#ž4HÎþ”ž'†§’3¼Í 9Ã3zý›ó½]<	ög’³_7HÎþ=O
-ï4HÎðGÉžÓóØ³9ß»Ä“`Þ 9û$g¿¡çIáß$gX5HÎðný–]T¶Lñß’©4”Öþ@&“Œ0Ë"“§®“u&è8}?$XQŠrxÑ™ˆ{=îrW™ÙL%2@¢NB€R2+BÉ~ Äi’!Ar™_$î
-¸‚ñpX3wÅ»º4ŸÔ&.óAòÛõ›ßêŽÉ--r¬õË;ŸºpÌœ§ï¿vßé……œÈdÖ?ðo®gÉG¾Éó=AåÆ=ò^òBèJ´ûˆD+eJ$‰€Hã$š¥ÏL€äd<I•×mQ"!“³"âk…»**âmí¡pŒv´wÆÛ*|æÖ x=¾:êõ(ßŠÏ7ÆÕ¡PS¨‡¶'œn;Xoï	6¶ÇBMsŽPCÒ_ÙPU¯–:ƒ]áé@õ@°Þç¯-swEöd ll ÀßÒ¯ÐÚ ˜±ïä{D6î‘»ôe¸Qö1ïT:Qj#&â« ²©Œ@–ÆýÛÞH²4ž1kAé•	˜L$Bž™0YFNR¨ÐÕŸ<ÔIº\`R{d>¯‡ÅSï­/-q:,
-ÜÄm1LÓÑÞ)Ìîˆ»´°¦(á¶®ŽPÁ6¿9~~w¶£yw¼<k‘ý{]­UmU-©Ç'§Vúk«ößºßßáÍvýÔW~hbÿAÃgŽ§ÉÏ7î@B(¯,&üàþ9Âûf)!à±"âDrú"yƒ¾Ž€×A¾ÿ®¡!1^È«ôüØ™ˆ9ì”¢‚P‰R{BÍ•	P*ÍÊD’.K“ üð7Ã&gU$ÞÑO;Ú¹üæ°ÐÌëQsgg<î¥ß1ÒöU÷GN$ŽŸ8Ÿªîñ½82ýüÅÖ¶ÞæÚ¾ÖŽ3éÝ+×©iN\È@ß¸G¾GoÀŽ&ìKìõYª$&¹žÀ$y&…ð+§%È²”ƒ$­ðH¤93¡ôi:éthšj¯ÛÑäl2›`'vnvÒ ˜‹)5„6}`vÒr‡¿×oMÄšº:šúÏì¹4Ðs°¦ßÕUÛ”Ü!ÕŒ7Ìœê:J:M‡Æ÷ôtïZÿëäêãoûÐÞæºa¯_?•Öšr{N´º´m—zèû0€Ilìc¾©tÂ§›<L[?±Ð=yÜK²Ï/zLÃÄúpOÆ66E¶-9¬T‘µ(ô,va6>2Oú÷±Ú©t"“l“M¶ëa³òQÄªPk¿oh¢ý£ Q«´o5,“IRI‚Ñ‘ädj²·'¾3²#lP«+Ý.»dÀé¬ˆ˜8
-ôÓx[…0³Öâ‘¯ñÝÀßúâ]q³ÂÄ=ÒJ¨×#ÖåS©­³«K8Êë© {îdÏÐµÿ”^úÐÁÄ|<Ò§Pï` {¬®sLo¯¦ÎÑf[eCmGC÷Ê±=Wg»Ç¯O6ïÔÇN$ËÃÕîÆ@kuýÇc­;õ‰k‰#ÿñä±§úššBSÃú¡‘æöæWÛc-‡zö^‰gŸŸ9ñì€§loe5	ùüïSw7„ßîØ¸G~GÞ@)üˆ&š!I00J7qÑUFàó–ù]~«¥¤T–ØŒ>a‰°ˆIcó“ò¾3Éä™¾~þggg_Ÿ£oùÀôr_ßòôå¾GGÇŽ=ÊsýÆ=òcrœ6€Ëæ ”¸(÷dJ‹¸æ–!Wù>Æœl*¢™¯ðV–/]¦"†¹ÊJKœ6‹I†‡x”z¹â.pŒ« _ßÛ¿w¹±IÝY³|Â*©ãŽ“‘öõïõµ©djÝ»7gãurŒ¾^ìIô–…¸	ÊÓÉÊ„‰BgeBéÕ	(
-æÌÅ¬â*u:ì6«Å¬˜dx‰· ZGWWÜ÷j^O¼GÈë‡F†ÇK²Ï<3TãóºÛmsû_;lºyóØk‡m,#G7^Çëôe”¢9vP2J@(®ƒ+RqY+×¸””ÊkìS”ÏõÅ—Ël²Y)µÕÛÆ4yÿvE!‡eÅX ”¾_Ãn3K2%"_á0uuB–(¥—)Pån— PWÜÅãß­…ÍÞÑKÒgžýÄígÞ>N_^ßû£ÿ¶þƒoy»˜{ÏÆ=¼Š÷ÀŽê„O¤_Z”Ø :i3¿`¶Z¯ëõjs³CohÐù¯a»Ÿ%oÀÏó»PRé ­"¤q^\lfµ-ù½ÂSVb5ÃOü¦í1\@Pï¦HåàÙ=ƒO´ŒTw•í¨îë©{Zêâ¸®j¤¤œG°·|¤¦¡`3ÉBÞ@ Ç›De¨•T’é¸¶ŠH­”Pàê„Ål’D
-ò'ªùWƒ	ÞKr”p™7;3‰2 ´rÍÝØè²:k¹•}qCfí]š‹o<óf;:k‘ëGc.m"69¶Åv-Ã±]än*kÙj;ùØú×I°¯­oý“…ÆŸü’¼$l‘àæ©³ ½[Ø‘.ªI6œïOø„è[P£Ð“I8xàÑÜ.ÅY½Eè¢¸Š!g`²o»êÎzr7©ÆŠ’Õ×­M÷ÈwÈPP‡T"á'&¹†Pl"ò)^©ˆüù¯d6ó§ÅLP]Yá-+1×Yêd	
-QŠù3¾-uVx=æ Gháô’Æû·Z‡.$’§{RG£Êú×mâ}MGÈ‡wtô­§û–§§–û{—þÔž†±Ê£nÉ’ý*$T%*D¡ò<ß,˜ÜR®øÜqÉñÚäk‘Nþî&Ç€¥¯À‹\Âf'u"ì½So…
-õmÈD¥L®N˜‰¢\V&ý	?($B¥¥Gôf¥ ¼ðºÊ5—Ëâ¬‰Ä]ZG×–òÕËAÇõØèèø‘êÖ²JU6KÞsØŸ˜·™g¬3ÇÖ/¢`ÿÿ)ê˜mùae{~àÕŠ×íð;ýÆ.ä‡ÍÞL‡"óUÌ_¾<Ïë[ýþÖúºÖššVÇ§>úÑ_üèG?u´åÌÑ£§#‘ÓGži)ÄåUò\x¼PK„¢Ì&ê:+Á˜?QjåU}ñíf\ÎA!hŸ?QaÄì&@:2	¯.¸‹`fDlŒp­mÒ¼>‡§¬6á#w´Æms’í^š6ÂäŸÉˆc&ðã„#ä¤²2ªP«©¸‹:íDlRä%Qy»]µ@šLÖ¬Ö§'ÄbAÎF€gÁ«¡èTšƒÜÖÑEx£³)ç-Æ&vns‹m[ÝóÈñV^i‰Žv‚½C‰‰‰Ý»Ú÷tì‰EüÕU•ÄIœWC>±xÑßÑÞYhDˆñŒö @N
-SiKà6h­!ÌŸîõ<Ö1ì®
-x«Â™¸'XÊŽ—”µl/kpÙZôHæXâÊ˜Ö¶³±±­­u÷X´9ÕäþCÍ®HŸ.;šêj[Je÷`d×ä³é\®î)f›Çå­Ü•hÝ#_loiikkii__k­¯õ˜kÁ"îÑ—áág™HÄÀ=#Ù½	ÚÞ„k^ó›pmY®ß„5úòggk£áÚèÆ=j¥/£u›ç:+1I5~*›hñ\·åyÄ¹®€{Æ‘¼ù\WÄEBÞ|®ó¸9@ºë<uN»(KÊI9HSCX3k´ÚRÙ™½¤k8!ÙŽ-KõcÁã'{g÷ïL¶u·wWÇ‰vúòg§ý7ž8xuÏìá™±é®ŸV¸96Î ä»t&Ô'j '¬DŠö4ÁärÉÎJQ@¼3+¤Œ®Ýu±{äoÈ¨‚†çõ]NBh]­C‘eRQ°Ôöw[ÎÀ•âP%úFú•6Æš]âäkôoV^5Aµæ×¼W©Í‚*ReÞ¬KºB[‰ÅÓogW‡õ;‰éw„Û‡Í;Nõ?6k‘Æ,uqÿÂd“c*1s¨,ÔYí™¬ž;½þƒÎšÐ‰ªªÓŽX¨ÞÏkòu€¶Ò5XáB$ÑÄÏ‰›w'§ð-Ä¢ÍfsÙ\.W•ˆE·9‰ãˆäŽ»µ°fþß'|eµ%²³öî·o|û©ø÷ãäøÔTûùÎ®sëéÚýKù¼ˆÅ~j%oˆ;†'8¸šP[Ce“‹PY* W-L¦"’òP†{zB!’ô$Õ€ªÛî¶ód¯…»¸á6º,ÎªˆïAeP€Ÿ×½%âD13Ñt|±w¶KMÔIóFÄùÛ^¦Þ^ºqéàÕþÚªé›ÄûPÌáoéš‘EÌq€½L¶æcm3+ÜF=ÉãôÑ5ØÑ’Ðyz•©tŠ×§³FÐÊ²iV!&ÓeŸÅ»‹ÿ˜~~aåˆ2>à!«ë¿¸{—¨tmîs_.ÜÌ ´Ž®Á÷)$*‘SåÂì¦ânð”—:yM
-(ÆŽ(ž45¯+Þ&àræ•ÑKÉäÅ‘‡Þ³oô ]¥Ç÷žˆýo2qµŸçË–1üïA9|	áøÆkl —1Ù8H•_¸³3ÜÐ N­Ëï­ÚÙÁ«Úh¬~Gtú³{ÜÁ`ƒîï=‚÷h#½‰šb­]ÅkíêmµöSÕÚ>¯¨µkHÍ£kí­ÅöÑ™?ÞàÆt¶¾¿ª/Ô>Óºx¨9U½»iÁ1ùÁ³è@«6\åï93zñÙ@Í`¬uÓ_?ûdG"ôf™ˆ,_–¹«¬°rOx]ð”k†¼{ýµ_ýŠ®Í}nný×<*j6îÑóô&l"ƒ&†)‘Ð×mn¸Í²´S`pŒQH!É×¹gyŒ?Åcƒäøùïi2é°ww6…ýUö¸#Vœ¾ˆÛãåÖ ¸FèÚ´…¸cªà¥|W\æO˜aÃ4‚þ»ê¦îÊÚº°–Èuj»žŠcm©‰u“;üçm"°§¢68µ#xâÅTÌßQ™Rk4òÛX[ug¨º1vÿ;±™®è`{EhoCtLŸè¤ºªš&TíHüé%wµrÂªU«¡/íìð–êmÜ¶Õ µÐ5˜HÔñã™ÈóàÞÌ³ËU¨”´Ž€Ws}÷‹äW_¤úÜÜýW7c>A×`áD#ŽÂN*ÜüûÑUj·ÂsÀdìIa-lÜqiÚÌ§?ð_^|ß@|þìÙù8]ûØÇþì'–Ÿ¼v^ìÙß´†®ÁÉåTç µ2ñ »8á¬2²‹wWTp°érÇ¥¯|íét©¿L.«*›½úº¶þ—ÝÝÝÝdÔÀIÈÏqØ…jhØ•è´“8kÃ$SÓ©-úÈ2™UŠúhZu¥§.”ÌE¸RÎÄV–ŠÊ¹6µüæàR_‹Þ“¸´÷üÌ`"qhnïäøØ]«ém›(•£©t3¹ÞÖÜÚ´êèjowÜ }•ÜE€[¸¦L‘$ñÂÓ$Ó¢³¸ªŒ,—â¾‚º¶P’VÈfóÍw^é±8L²Ùiî½Öo)1Ëf»¹çü3ÿ¾ÍìTdÅai#w7Cº>Ø(¶ëÞŸR­­©ÀOŒûlqÆ'?£a8r˜(¼…5r›f.{	@þžÜEB	ÍSb&rÑ}ÛîªPU^U.ÍÞ"±Ù÷@ä’¿ïm]vŸ]¶z¬-Wßûá·õ:ªœ²­ÂÞNp÷1OÄã‰xûíÿÉUè^oÄÇ±M y]àGKBY–oŠguSl…µÜeÒA/	x›HïúÈ§×ÿ†ì&?›^¯æ€ÏÏƒâN«­‰¨Ë.ó£¿¢çqyU|t˜ã@ù¬ Ê
-q³^Mª·tèêÚê+IQÎxêJ*le–p‹ÃúåË‡ì^»lu[Ç.ÜªOÿwE9,Ñ–`=ùé?©#ZÃHàŸîoÌä
-8I?@×PX"Rå6bGLzÝØ-[ŠÛzÔW
-Š¸kË†áåmgg—f–4)¬ÕQ¯kæÝíåVÙê²]\}Üd‘åö3“gÚdÙl¢këwêûûêIâþ%Ò\?µ¿îÅõï“ÆëöOÕ¯Ç°hã¹Oo¢™ç”J"Ñ*‰‰nû>óÔCßgjý³	Í¤ÙÈ)[>Ïßg¶ßåTø|Æ–#å/d÷hµt÷ìÒª}áî…Äî¥`_ýH(¶«¶ÕŸÙ=Ú½äÈŽ7c¡îpIt°¥}f§Þ8^]»£±*à³«Œt¤;¸Üž{t™¾‚&üyá˜Y8¼›êˆõÄj‘Çý¿´[äbMáß $¹Î=`¢Ò’ÍLyÌ)üŽ­u‹uÎa§Vk»uÒŸhùýÜb··c FdD½Ó„¦pH4¸\Æ€ÓRÿ¨;€—"ó‚ ãÁµ@…ßßÿÉ’Ù·¿}ØYcóxâu‡†ÿló’à°c¦ãùçýâ°Y>d¶ÏïÿÅúE¿¢¢_añý¦<wdŠ·|¶^òñ8®-EH}(T_
-ÑÆºÚÆÆÚ:~I-Îgø¹»YË]}‹Znt™Ü]÷±HÎýÞ«×>8[Úû˜¥Ÿó×?Ü·ëÑ]½¿ºþËyéëbZøÛ]~—ôóõÏ–?½¿ºÞm9/fÚú§ÁAòiT}´rJ Q]zm4ˆTÇ Y‚‡”b”Ú0JÜØC^ÁiFi+FÉÿEIÃAúà¡Mä2F©M4†QÇ(y3TF_hlc¶c”Tc†òßaÌ7Zh;É:fè³¨¡¨¦O`†VnüŽÂý%*Åš?B	­Aù5ô5ÌÐ BôüÞiã¯ˆ"ìºÿÿ•4$yžü’þ£T#]’>#ýLöÈÝòuù‡¦fÓÛMjú…¢+×ÍÇÍ°8,Í–[>nù¾uØšµ®Y¿bý•­Û–µýÌn±÷ØOÛ?ïP•Ž´ãyÇ×•Î•Z¢—+ÆÁ«ßEXA±ÏáO ü¯¤D’þ¯‰e+ î#ƒ&ÐñB¦(Áí-a_-ÐòÒ¤¬@+h"§´ ï)ÐØh¨@[QI[´mtovJ*}ª@— ÝtŸ„Š6´¢q¨À.`‹PÑ„ÓXÁ
-.¢-h›}1ä6yb˜ÇœCv@‡Š«XÂ
-NCÅ4±ŒE\Â,b*†qç±“Èá_A­Ä.à2.a‹jÕÖ'¨˜Aç±UH6ƒEœÃæpg± V8…Ë8‹.!ŽZÑ6ìÆ ‘Ä~ìÞ6_q¶8¢ošË³Iá°zKB^uÛÌ§q+Bçó¸;¿­ØsÈáq,
-Ž“XÄ5¡Cbè¨,Ûm°$ôÏAÅ
-.	Ësn®ñãPq'òÙ’™û€?ÂyáÃ3XAN<sžÇZp—ÄLÆNsý._]Â’àŽmYc
-9auƒˆAÅÞï++x±ˆƒ8]ÐïAlpíObW…Ž,pKÂ"Üj†6|Õ…‚ÄE}g0Šq¨Ø/æ?¿mæñm3ðh}ØÓEoª[$Û¾î\AK"öæpVô<ˆ}î­aà€ WÐõ!ë,c^Øö"V„u¹g¾8…ìÇ0Æ’ä_¶Ñ‚h¯Íáò¦ßí¸¿ùŽÀTŒbF­‚Š¤xÅŒ°ÈŒâ öb?á xÀ4¦Å÷ñƒÅ»ÓP‘Â~LbPŒ´Ñ7,"r¨Ø‡QÁÃç^,ØÇðß…ôËBv#
-—p…Í¹ä\¾;ÿUVq²0kqì²3%œœÜ»Ü*Er8Uˆ
-ÎsIìÈåÍØx°_Œˆà½Æ^zÐ
-Ö]{ŽÏªâÉÂ^æÑjÈdìØ•?À«±UÌòýÆ+â¯mÞüpãA^q÷84Žÿ¹0Œ)À^”cnÂöa-„„F#Mˆ£!ì€]c‚8ŠZCŽ£„_-|W:9»b¾|~©5ÞÚ…}·ñµétžµ#ÆŸ^ÌÃœLØÿž9÷Ø¡XÑ,ÞxV-ï”/Yæ,‡•1¥Ç¢›e«­Ðõ>åyú”rF9.OÉI%nj¢¢«,9`o¸£Þ©¹SyÇ{§üNÉ{Âš€öæ<ª’v$Þôw~ŽgçÁ|#¹q Í7Òüya0ßÄŸo[`¼À`ÆŸóWŸ·\‘7æ;øOÂó‚ò]Q”´<.÷*1SˆZKšo“w1ùOòƒ/™øbÓÑ
+xœ­{p[Y™æwÎ½ºzÛ–%Y¶åÇ•¯%;Ö•ìX~Å±Yò#vlÇ±ó’t"ù‘Äé¼:vÝMÓ¡z²†q1ìlYvª¶fŠ£4ËvCÅ°»lój`f º x,M(f©v†Ø[ç\I±Óévjä’ÏÏùÏ9ÿëüÿþkƒ °ã$´Í_^Qg~-ð€´¸pòì\«ý òK ÄqòÌ“'¾Úø¡ Pú[ ¶æÔbv!˜ûöˆ@×©S‹YëM·È€ÆSgW®žØk}ˆ\ ðê™óóÙÿñÂ·+è€3g³W/_—^¢€z.{vñîk?D¿(.œ_^ü¦¼tÆ|èÂÅÅßûÈ37€Î¿ˆ	ÿŸ+¸‚2ÔPßÆ]\ÆeÃ1º;ÀÆ ½±q—ÜÛ¸»Ñõ`lã.}™ÜÙ¸»1ÅGé+b|
+p 	$¤úò.ü£”¢¯'ñ›{ð] jç;mÜ-âo'ï*ÎÙAž,ÎÛDß¯@ý²Ø¯³˜EI|cc?Ø(®×P\ï¾ÔP\ï>ƒ®2H§UuÏ-”ìÛÃ”ÙÃ)ÖágÍéÌ	uõ@ŠÑ`ösX0?¯Íù†4CRº	‚d&aDgjæD„Q]h“tuá%ÉãE"ÉÜI5“Iä¨'™È¥$£ÉýWUæÐM&³Lž¾z“RšÌ$X`±&À{o–xI¢Fe4©%nº‰;™IhÓ©ÅôÍ
+Â1#LÖ™fÞdŠïÇ*’É<‚_]PÙíi&‡ßl&Îäðü0S†S&Ó3GR-à_M©lz:`ñ´_e=êI§Õœ]`ÍÓ©@þIem|¼cÞžN©'ÔÕÕ¬ÊlÓ©Œ_e*³q¨‹C]&Nû2Grža&Å°‡#˜#éßÃê8T·'{«óã–	séôB6ÍH8ÎsVXERK¤#Ì¤«Ã*“ƒÙ•™“Ó)fÖÌ¢%ü@š‘L„)BÜL
+«9ó\Båƒœ]¿A>ÿÍ¬™áyfj	¨Ì’TWÕUFÂ¹6SÉ¡}©Ì´?;“Nié@ZeñÙ#a?—Kž”3ëÌšß5ÔlÑ™UKh*ƒ–È2:w‚‘yF2ÌÜaV]åÔ–$çoÉ˜Sù
+,žIs”Ì Ö¦ß´– 9œh	Ç®o5$‡±
+	kI&3êðª–åJÂ†Ÿ+„©~/
+ŒIA-;dlá|‹é¬q:Å'Ç5©„Û¿–xÉé€4<
+øµ@º%a¥zŽÒa¶Š°2‘Œª²Òä8_@e¥Z"ÍÊøÓLJeeB_.]eeB(ê-ó«Z–¹’u5£2—–Ð"¬\ß³?•“†ÒÌ¹¨]0·¾g_jÏ¬Ñé¤™[ô{ôÊ“R¹òò$#Ùs…ù‘c4˜È•ò_e4˜`¤BS™œNå¸ø˜L¬®ª|Û²–€ÆH¶ ûq>…EOš•&GYYr4ÃèVe½…
+s€[b$É0p“"´åÕ‘ÞŸbåZBf%Z‚95fÍ$ÔÌ_VV¸àF"‘àðh	F²9%ÌÞö7¤#¬BÏÁŽ0Ÿž#¼­Ôs”·UzNâmµž“yë×s&ÞÖè9…·µzÎÌÛ:=gám½ž³ò6¬kù3%³gJS£Œ<ÆOK„é›+ŠƒOƒ‘Mƒ¡âàEcPÕÁJÃoÉ'#Ùÿl°ÊùÜÌ_@ÏAGXƒž#¼Õôåm£ž“xÔs2oCzÎÄÛ&=§ð¶YÏ™y»MÏYxÛ¢ç¬¼êjŸ0ØV]Í°ÊŒšÔÉp›ÈòCå6Û¦³Ö0km‰°íºªŽªo¡M-Û£qÇþ¶~Î}{AÅ¹e˜[ÛÞ’3ïpª--¸ŒmÏ[átèj§ ¼SGgøÍ{2~$-¼Ÿqyh@ëÉu/çµKWûÔÑ· Ÿ!™í‰°n=êë‹°ž•‘ä|O„íÐsA5ªŽr—ÀhpluuTÕ²jjÎÏ½®–¸ÙCˆ×Óa½:Cói	&™h9Ìž/®F5Uí[í‰°[ÑÔ¨±S´D[eîSâûR/ÉªIõ¿$‡LÕé÷´¶¤ºª‰ÚH†)É‡k†{;#*ÉÉÌ‚ÆLÉìÂtŠÉÉ¬Ÿ™’îéž“ÕT•É!m$Ûã×˜-9Â#–-)vÉ¨ÚD3|ª’Ìpe˜‚YfzÓªLq"‚œ)˜YÈ{Ò{¥#¬¯ UU™)”—…Ö×aýÅ!fã#Ú(ß”kq (BÎŒ!i†ý©¨Ú§D¼Íwªœ®¼*˜d¦àØæÜÅPâ£¬=¯-›ü®M”$êÊðça–*ŽëšåRa¾djÚ?“N©}éh®xÂ6¸etÆ?½e4ñÈ¹o7#©³ÞðÛm8¤³áUUíã6¶ÚóÖ¨LIFY[8Â†ËÜ>C†ä³Ì¡%Ö¹jjŸÕzòëè9›L¦üšôè¿–sž¸ëÓzüMöHçéÕsè¤²[Ïag8ÀuÆ	ÍsSÁ˜Îà5ŽýMðîŽ²®–‹þ=zÄãfÝ-6¡³-6É¥8¬©QudUË¤5¥sƒf“áÛ«ßFÂ6­ßáÀ>ý&=3úM"zf9Îh8Âösà88Èq8pH	@2a)ý%ž:…#,­¿DŒ¾ÃúKÄè;Âñ‡Žr<=ÆñtŒã	è8ßs8a¾'²|OÌñ=90Ïqv‡#lãp`‘ãpàÇáÀIA×P8ÂN	º8´$èâÐiA‡tqèŒ ‹Cg]:'èâÐy=‡¾¢/ˆ'GØ8Ž°‹\èâ)Ž°e=Gò8+Èq.	’Ç¹¬çÐ_\õŠx3® Ÿñ¤rô§ôÉ#<m€áÈžÑs(®÷Nñ$ÐŸ5@Ž~Í 9ú»ôÉ#<g€á#¼[ÏaWq½÷ˆ'þ¼rô?4@Ž~]Ï‘<Â¿1@Ž°j€á½úM»Èl™â¿)Si8¥üt:f–E&5N_-ëLØÐ	ú'`E)ÊáEW<æõ¸Ë]ef3•¿ÃKÒIPBè!PJŽË„P²(qšdH\&ÅŽ¹®`¬©I3wÇº»5ŸÔÝD\æýä·ë7¾Õ•[[åhÛ—¶?uþ<™=Gÿäþ™=§^;–N¯¿ðõo®gÈG¿Éã=AåÆ]òÇäBèŽwøˆD+eJ$‰€H$š¥ÏL‚de<)•×mQ"!“³"ìk5uWTÄÚ»:;BMQÚÙÑk¯ð™CZƒâõTøê¨×£|+6ßS‡CÍ¡mÚ®¦ÌLûþºXGo°±#lžs„þÊ†ªzµÔìnœ	Të}þÚ2gpGxWÀÆúüý2¡€1<Ç/öoÜ%wèËp£ïÛÃ¼Ó©x©˜ˆ¯‚Ê¦2Yšðoé‘di"m Ö‚ÒË“0™H„<3i&²Œ¬¤PÁ«?xh’t)¤òHÇ}^Š§Þ[_ZâtX¸‰Ûbˆ¦³£Kˆ£©3æÒš4Eijïîåeó›£çvf:[vÖÈËÇ-²·£»­ª½ª5Ùë¸þäôÊ@mÕÞ›÷:ý¡ãÝ?õ•˜Ü»ßÐ™cãiòóÛÊ)Cq?¸~ñ±ã”p[v"9}áœ‚!_gÀë ?xÏð°˜¯äUz~lGvJQA¨D)·=ÁæÊ$(•ŽËD’.IS üð7›LÎªp¬s€vvpúÍM‚3¯GQÌ]]±˜7”z×hW,Ø_=>?zvð\²º×÷âèÌóÚÚûZjûÛ:O§v®\¢¦9Q¾q—|Ÿ^‡ÍØßí#²TILr=I"òL
+á%§%È²”…$­pK¤Y3¡ôi:åthšj¯ÛÑìl6›`'v.vÒ ˜)5„Š:0¹jº‰Ãßç·Æ£ÍÝÍ§w^ìÝ_3àê®mNl“j&fOv&]æ»z{v¬ÿ—Äêãïøðî–º¯_?™Òš³»ŽqSEûÆQ©—~ ƒ˜ÂÆæ›NÅ}±É#D±ÝE`‘'¼D!{übÄ4B¬¤‰M&"Ã¦È¶%‡•*¡…ž†ÅN`Á"ÌfCGæ)ÿV;ŠÇ`’m²Év2lV>‹XjMãí¦Æ;1µJKPðVÓÒéx ™ ML%§úzcÛÃÛBÁµºÒí²[1HÎŠ°©{k¯bÖBÜò5~x¯/Ö3+\A\C!­¡„z=BaÝ>E‘Ú»º»…¢¼ž
+òÑñwŸè¾úRKÞŸ…ûê
+ôŒ×uëÕÔ9Öb«l¨ílèY9²ëÊñž‰kS-{õÑc‰ò¦Šjwc ­ºþÑÇVœüäÕø¡âÈSýÍÍ¡éýÀhKGË«ÑÖ½»¯ŒÆ2ÏÏ{vÐS¶»²š„|þ¨ÛGšÝnÛ¸K~Gî¡~Dâ-¤¼30J‹~ÑUFàó–ù]~«¥¤T’(ZŸD“°Iãð“òþÓ‰Äéþþ{ k` ««¿ßÑ¿¼of¹¿yfßrÿ±Ãcã‡æ±~ã.ù1¹NŽËæ ”¸(ðdJ~Í-B®ðsŒ9ÙTðf¾|¯,_2†Læ"(+-qÚ,&âQòÞËsy„b\y÷õý½»—›Õí5ËÇ¬’:á8ñéXÿ~»ÚH¦×½»CQx6Þ Gè{àÅ®x_9Qˆ›@¡<œ¬Lš!ô¸L(½2	EÁœ¹U\¥N‡Ýfµ˜“/ñh§ÖÙÝóÆ¼š×kçòÆÑ‘‰’Ì3Ï×ø¼îÛÜÞ×šnÜ8òúAÛ>‹Ãð‘coàú2JÑorP2J@(®Ë“Ra[+ç¸””ÊsìS”ÏõÇ–Ël²Y)µÕÛÆã4qÿVE!eÅØ ”¾ßÃn3K2%"€_ænêÊ¤,QJ/Qî@p”»]Âºb.nÿn­Éì»(}æÙOÞzæôåõÝ?úoë¯}çÐ;ÅÚ»6îâU¼vTÇ}"üÒÅ†£“ŠñÅpf«õº^¯¶´8ô†9pÛý,¹?ïvBI¥ƒJ´Š@’&xrQŒj›â{…§¬Äj†ŸøM[m8ïA½E‘Ê¡3»†žl­î.ÛVÝ;1Þ[ó´ÖïËÛq]ÕhI9·`oùhMC^f’…ÜC Gã›De¨•T’é„a¶Š­”PàÊ¤Ål’DòÇ«ù[ƒI>J²”pš‹ƒéx€ Z¹ænltYµ\Ê¾˜A³áí]š‹<s±;n‘ëÇ¢]ƒ.m2:5¾Ew,›¢;Èd Úº-Ô~â±õ¯‘`{ÿú§òA?ù%¹öÅm‘àæ¡3O½[È‘NªI6”ïûé›¼F~$wðÀ£¹]Š³zÑrƒÎÀT;?vÛÔíõäNB(«¯[ÿ(š7î’ï’{PP‡d<î'&¹†P l"òIž©ˆøùÏdŠñÓb&¨®¬ð–•˜ë,u²…(…øÛ:+¼s€{h¡ô’ÆAû·Ú‡ÏÇ§z“‡#Êú×lûbýÍ‡ÈG¶vö¯§ú—g¦—ú–†þä®†ñÊ#oÉ$ý
+$TÅ+D¢ò<?,˜Ú”®øÜ1ÉñúÔë•Nüî÷% 9L_Ù¸ÍN$ê DÈ{»HÞòê;&¹#™2¹2i&ŠrI™òÇý •–1šŽ—ðÂë*oÔ\.‹³&siÝ›ÒW/w:®ÇÆÆ&U·•Uú«2òþƒ¦Øä¼Í<kí<²~yùÿ­Èc¶Ä‡•­ñg+^·Ãïô8Š¸©Eä« ˜¿tižëÛüþ¶úº¶šš6ÇŸìc/¾ø±ýùáÖÓ‡Ÿ
+‡O>|º5o—WÈ=¸ðx>–E™MäuV‚q¼ÔÊ³úBo1.ç o´ùŒÏ¯0l¶è òé8w¯.¸ÎÌ°Ø¼g0Ìµz¬Yóúž²Ú¸Ü9Ô³ÍIR¤gýUHhÞh"ÿHî!†]˜ÄãŽ“ÊÊ˜B­¦Â)ê²²I‘—Dæaœv!Ô<h2Y³°ZŸžt‹YžÏ†"Ó)îä6Ï.¸7z"ä¼ÅÜøöâ4±Ø¶ä=œoå¹6ïì Ø=ŸœÜ¹£cWç®h¸±Á_]UYáAŒÄx6äÇˆ'ý]ùF˜h$¡ôX>1•6å	nÖšøÓÝÞÇ:GÜUoUSW:æ	–²£%eíû;Ê\v§9”>¿<®µoollooÛ9iI6ûCCW³#Ü¯ËŽæºÚÖRÙ=Þ1µÍl: —6Uw‡³ÍãòVîˆ·í’/v´¶¶··¶v¬¯µÕ×zÌµ`ÁïÑ—ááw™HÄð{F°{“k{“_óšßä×–åú‰¢[£/öxmä!¿6¶q—ZéË(G]ñ^g%&©ÆOe-Üë6õGÜëò~Ï¸²‘7ßë
+~‘7ßë<nî Ýuž:§]¤%å¤œ;HSC“fÖpµ)³3{+*H÷H\²Y–êÇƒGOôß»=ÑÞÓÑSsÄ;èËŸñ7\bÿ•]ÇÎŽÏtÿ´ÂÍ}ã,@¾G×`B}¼€qÓÉH¤ OL.—ì¬	DÀ;»BÊèÚýWç@Ý¸KþšÜC4¼Û`ßå$„ÖÕ:Y&yImíÛt®—*qÑ7Â¯TLk‰›¯1^Ì½þj‚jÍ¯y=®R›U¤Ê\ÌKºC›¯‰…ÛoWw§0õÛñ™÷~4µ7Z¶ì=zä¸En·ÔÅüSÍŽéøì²PWµgª:xöÔúk]5¡cUU§ÑP½Ÿçäë m£k°Â…p¼™ß‹µ“S†óÍÛ¢ÍfsÙ\.W•°E·9Ö×ÉskMšùï|Ÿô•Õ–ÈÎÚ;ß¹þ§b?ˆ‘£ÓÓçººÏ®_ k÷/ærÂ¨•Ü5†'¸s5¡¶†Ê&¡²”w\µ0™
+ž”›’ÜÓ“
+‘¤'¹SNuK­a+N:îñz¯%Àw°ÑeqV…}2ƒ¼»ðyÝ›,N$3“ÍGûŽw«ñ:iÞ°8ûËô/:ªC×/î¿2P[5sƒx²9ü]3â±°9î`/‘Íñ˜[Ûì
+ƒ‘Or;ý_tv´Æu^e*äùéqÃheÙt\!&Ó%_Å»‹ÌN?/Xy"xgÉêú/îÜ!*]›ûäÜ—æŠkÓ!±vS¼‘ç.‘Oò´weR1ÑB-bëš¼si®€kv…XWVÖïÑµõÿKÌ÷/’†õ×Œu[ð-RIBP÷öµ’îÎ˜·åWßÚ/ê,TÐSG×à€‡Û$*‘“å<·¦Âéô”—:yŽ
+(Æ	-Ü|5¯+Ö.Ü÷ì+c‰£Ç¼ÏØ>ºJMì>ýßdòÊ ß­ãø	ÞrøâÂý-Ïù\ÂTãuV†}M]]Mâ·„ÝUÛ;y¢W‰Öo‹Ì|v—{0lP›zÆÎ‚`ûÆ]ÚHo ¦ûWñÜ¿zKîÿÔC¹¿Ï+rÿRóèÜsòxö÷î»>3©¨êuÌ¶-hIVïl^pL}ðÌãÞ×¦Tù{O]x6P3m+ÚÏkâÜn‹‡Þl?&"Ë—d®f+¬\ËFüÈ[Žk–¼wýõ_ýŠ®Í}nný¸âj6îÒsôl"£‹P"¡¿7ÒÒp›ei»ˆ	QBÆ A†$_ãšågî)n«$Ëï£O“)‡½§«¹É_e9bMŠÓv{|"Ów^ÝEYˆšW¿ZtÇ`ñ ÞdˆFÀß¨nî©¬­kÒâÙ.mGÀS±m¼=9¹m°±nj›?ì<­MvUÔ§·½˜Œú;«ÂÓjF~m¯î
+U7Fï7:Ûê¨ínˆŒë“ádwUó¤ªŠ=½ä®VŽYµj5ô_·wzËƒûõŠv.Ûj€ZèÌÄëø¹!Ç…'|PÇ3Ãìrå37­3àÕ\ßû"ùÕ©>7wÿÕ¢ÍÇé,p‰S(I…“¯DþÁUj·ÂsÀdø!­É¨¹iÚì§_ø³?0›?sf>F×>þñ?ýä±å'¯žçqãw ­¡kpr:BA&¸Ó\™|íœpVÑNŠ¹+*¸óëvÇ¤/õéT©¿L.«*;~åëtmý/{zzzÈ˜áŸ$A?.TCÃŽx—•˜ÄÝ&™šNnâG–Éq¥À¨õWWzÊáBYÀ\à‰3ÅÝ«8ÊR9W‘Ëo-õ·ê½ÉÁ‹»ÏÍÄãævOMŒÏÑµºÑ¾öÉRÙ16˜Lµkí-mÍë¡ÎîŽVQsè«ä\Â5eŠ$Lä¯¼&¹èè¸ªŒ¨“b¾¼º7A’–efóç.÷Z&Ùì4÷]°”˜e³ÝÜ{î™Ûnv*²â°´“;a]lÚuïOÉ¶¶dà'F}]ÔÈÏhœ 9HÞÂš¹E²Î0§½ ß&wP…P\ó”˜‰\Pß–zGªÊ«Ê…¡¹›6Qlö= ¹ä#xG·Ýg—­kë•?þÈ;úUNÙVaï ¸ó˜'ìñ„=ýöÿd+t¯7ìã¾Í yCøÖ¸.¢>)T®?ªrm…µÜeÒI/	x›IßúÈ§×ÿšì!?›Y¯æˆßO»D­mñˆË.ó«#/Mp»¼"^‚ÌqGù¬p”¢Ò_Mª·¾éîÞ¬+IQN{êJ*le–¦V‡õK—Ø½vÙê¶ŽŸ¿YŸúïŠrP¢­ÁzòÓ_«£ZÃhà×÷7f³…Xø]C=¢ñp•Û°HÜcÒkÆiÙ”l×£¾2ŸàÄ\›O·»ºº5³¤IMZõºfß{Á^n•­.Û…ÕÇMYî8=uº]–Í&º¶~»¾¿±±¿žÄï_$-õÓ{ë^\ÿi|±nïtýúwù‡6î’ûôZxL©$­’(‘è–÷EO=ô¾¨Ö_á1›ÐBZŒ˜²éu‘ñ¾hkm©Âç3Ž)_f—öXkOïý°ÚßÔ³ß¹ì¯EwÔ¶ùÓ;Çz–™‰†`4´­ÑÝTjí˜Ý®7NT×nk¬
+øìÁª}£©NN·gã.]¦¯ ‘¿öæ‹	¦:bA=±Zä	ÿÃv‹\È‘Ãü„d"×¸LTZ²™)·9…×üÚ&a±XçvjµvX§üñÖ·Çv»½Õ˜1#-ò¯f47…´@ƒËeÔ$œ–úGÕ$CEæ	Açƒ2E…ß?ð©’ãï|çˆ³ÆæñÄêŒüi±hqÐ1ÛùüóG~qÐ,0Ûç÷þbýÈÆ_ÑAÓ/ó¼K¼OªéBÕ‘`ßæ¢#¡äÚ”„Ô‡Bõõ¡l¬«ml¬­ãEsq_ÄÈbnyå-rË±ergÝkØ 9÷Æk÷üÓñÒ¾ßÀ,ýœwÿpÏŽ÷‰vßØêýÕõ¯[ÎI_kÐüßóÚÖÏ×?X>tu½ÇrN¬´ùÓI?ŠýäÓ¨$
+úiÂä.”@£ºô8ÚiÛ¨Ž!²)ÅµaŒ¸±‹¼‚mÒŒÑ6Œ‘B3IÁAúá¡ÍäÆ¨Í4Š1Ãy³TF_htcv`ŒTc–òï1Kh¡#˜%n´Ò8¶“uÌÒgQCPMŸÀ,­Üø=€YúKTŠ½„ZƒfòpÐ×1KÑçx=lã¯ˆ"ä»ÿÿ‰4yžü’þ½T#]”>#ýLöÈ=ò5ù‡¦Ó;M2ýBÑ•kæ£æ,K‹å–OX~`±f¬kÖÏ[¿ksØºl×lfÚ§íÏÙ™ƒ:¦ÇG¯8=ÎŒó%ã%+%kB¢à™ð"¬ Øwã üÏÏªDÀþ8Ïe+ ®/&Ðñ¾<LQ‚[yXÂ8¾’‡åM8&¤HYVÐLNåa3^ ïÏÃØh([QIÛò°ítwvJ*}*— ÃtŸ‚Šv´¡1¨ÄÎc‹PÑŒSXÁ
+. ­h7~Qd‹8QÌã<Î¢Û CÅ,a§ b‹XÆ".â2± #8sXŠ)dq–ï Vbçq	1EµjóTÌ"‹sX†*(›Å"Îb	s83X;œÄ%œACmèD;vbCH`/vnY¯°Z‘7­eÌÙ‹†qPP½Œ%A¯ºeåS8Áó9\†ŠíˆŠovâ,²x‹ãqUðÐŽ(ºÆïKËV,	þ³P±‚‹Bò›sü8TœÇ‰‡t¶$hæ:àOpNhÄÐÀ,VOÆšç°€VœÇE±’1‡Ãœ¿KBW±$°£›ö˜FVH]Å¢P±;ûûÛÊ
+žÄ,b?Nåù{`œûXÁÁã	œÁ’—šÁßu!OqßYŒa*öŠõÏmYybË
+ÜZÖtA›ê&Ê¶îû@—‘Å’°½9œ#lŸkkƒØ'àôB}H:Ë˜²½€!]NÃD….N¢{1‚‰‡(ùçe´ ZCks¸TÔ»Á×7?qƒ˜…Š1ÌªUP‘Ïc˜9„1ìÇnìÅìÏƒ˜ÁŒxw¿cs÷b*’Ø‹)‰c6ÆF„EN!{0&pøÚ‹yùãçã‚ ~YÐnXáÎâ‚9§œóÏOÇâ¿HÃ*NäW-Ì]sæ±„“k—K…{‘,Næ­‚ã\'r¹hÎ‹a|Ô8KÆOâ¼ðuÅ™ã«ªx2–¹µ4'vå÷Ðjô_d3ùØ¿ñ
+ÚùÿE b£HÀ+ê¢3HáÐŸ#˜Æ>ìF9ÆàÆŒc†ÑŠ!Hh6ÒŒ0ÊC)BØ+ºÑ„â0jqý8Š6t^jøžtâøŠùÒ¹¥¶X[7öÜÂWgR9BÖÒŒ{!s"nÿwxæìcû†;aE‹èñ¬Zž“/Zæ,•q¥×¢›e«-?ôåyú”rZ9*OË	%fj¦b¨,1ho¸­Þ®¹]yÛ{»üvÉm{Ü‡ö–ªƒvÄßôÃ?Ç#ôP®‘\ß—bñë)þ¼0”kæÏ·,0:0”öçšx×ç-×@äøõùý…þ‰{Þ§¼›®(JJžû”¨)D­%-·ÈÆ{˜üG9Š¡—L
+†ø?™ý?‘^ì¾
 endstream
 endobj
-277 0 obj
+331 0 obj
 <</Length 13/Filter/FlateDecode>>
 stream
-xœûÿ  AŠ
-·
+xœûÿ
+þ  6Ð	ô
 endstream
 endobj
-278 0 obj
-<</Length 675/Type/CMap/Filter/FlateDecode/WMode 0>>
+332 0 obj
+<</Length 655/Type/CMap/Filter/FlateDecode/WMode 0>>
 stream
-xœm•Moâ0†ïùÞC¤öÐ%ö8I[UH‰C?TªÝ36Rq¢|ø÷+û Zí¢×3ãyÛLÓo››G×~òýÌÔ;íÔ×|³|ÞvIš®Úz:°_˜»St¸W]ßÖj¹^­}3&iºöõ×äø”ó¿”ïI=ÔrÆö¤éG3~ñ½ºÂ‚ŠžÔÚ±›ñ¨²ë$Mq?4­¿W:IÓ'ï–í!˜’™ôP³·¾­7<ª]ã]/Ôgè›h£\S¢âßú°íbñæ8Œ|Xû]«Ynê$S)¥fï¼o†±?ª«hìZ9Þ!òÚ;î¿WW'³ß‚›©ë¾8˜TY\eïâ÷,À¿l¬f|^J¥/KÇŽeƒÙïçÖ„†Åºu<tÛšû­ßsòeY6WUUUóÐñŸxY ìsWÿÙö1]ÏÕC–Y=ÊDUfPU±„²PwP9TU@Y¨2*#»Ü¢ƒÔÝAÉž¨“î¨'¨%¼Ô
-±
-ê	1U!VD¥ÃdY	g|f%|ð©…´ð- „¯„_)
-|Å-ø
-é ¾Î4øJ°kððiðYÉ_)à38%¾>ø,2ðá\ørìiÀ·€k>û>’LðnÌ€p‚|¹ÄäþÀ`Àg¥;øH:ÎÚÎÌ€/—øJÔø1_Ž:Ÿ…3ŸÅ¹ørÐø,n…Àg$&÷'ýÀWâø¯€ÀG_.
-|Eq~OF+µÂˆ»'0¼Z0æ¸CF£#¡Î
-£ÄÀHà°`4²§0Êž`´’	FgŒ9NÑ
-£ÔÉ•Ø…1üºØ;™a´„	zžeõÔ÷ìÇ8@ãà
-Sªñ|žÄ]Û…ªø‰#üôß ¨×ê/E—é
+xœm”Koâ0…÷ùžE¤vÑ!¶óh«
+©@#±èC¥šYC|a"'ÊcÁ¿Åç@«Ñ, ßkßûù˜ÿxÛÜ<ºf'7ög¢Þ¥oÆ®’›åó¶âxÕTãQüð"âÄ£ý½j»¦êePËõjíë!Šãµ¯>G'çœÿ¥,äPû¯„©†ZŽýÐ£8þ¨‡O¹WWXP¡'µvâ‡z8©ä:Šã_Òõuãï•ŽâøÉ»esœšë£k¨Ù[×TÔ¾ö®c%µ›êFÚ(WWUø®ŽÛ6lÞœúAŽk¿o”E–[f*¥Ôì]u?t'u»VNöˆ¼vNºÚÔÕ¹ÙoÁÍØ¶Ÿ25©’°*Þ…ßÙÿ²=Ššø²JJ¥¿–>N­ð€ÙïçÆ…F‹Uã¤o·•t[è!I’d®Ê²,çSÅâ…Á¶Ý¾ú³íBºž«‡$Iõ<(T‘@Ù ò%T
+u•AeP9T
+UexÊ-*pßÏ|Ä>V_@=A-¡n¡VèÌB=¡Â
+ªDf”ž. Iò
+|…"cà+Ðµ_"¾]kòåPàËÑ‹_Ž^4ø4ø
+îŸ»&ß
+|9û_Æ
+àKqŠ_ŠL>v¾Œ1ð-@kÀ—>BÏ2|ŽðYÜ„_ÆýŸ_Êêô/¿Ü©cJEá¨£eŒb–ŒèÀòâ6,±Ï‚1£%#¼°ô¯ËÒCð[22FF¸mÁX0Œ=d=òÁC>Ë>é!\³à³àKÁgQ/%cà³¨‚Ïà””|Œ/Ã-¥ô™ü2Æ7šã‹wœ Óˆ˜&áe&Uc×‰Â hš6µ—ËDm›vÚ>aŸ§ú¤^Ë¿XŒì
 endstream
 endobj
-279 0 obj
-<</Length 10876/Filter/FlateDecode>>
+333 0 obj
+<</Length 10526/Filter/FlateDecode>>
 stream
-xœ­|	x[Y}ïïœ{¯öÅ²6ÛòråkY¶ue;–·ÄŽ-K^ã5²Hž,VlÇñL¶Iœd&³–YÂ .ÝæA Ðx@¹ÊÐa(-k3¯_i.<Ú×—ÒB¡“ºeÔïÜ+Év–úê|žû¿÷üÏ¹çü÷åz@ ˜ñ$8´.]\÷Pþe ÖãgWOk1?ï6ËêÉ‡ÿ‰ð½K€ý‡@ówO¬¤—Ÿùó¯}ÿ  óÄ‰•´qSø?@%€º§Özáoloú£ =yf)ý#×÷®Ñç üÞ©ôCg©Íþ0Ð
-@<>µò¢Ý[Ì º…³gÎ¯ÿù_7#ðÿÎž[9ûµ«½ýU€øïø9€Æ0Õ´4·‰yÌcƒt 7€\„^Ím’›¹Í\ËÖXn“^'7r›¹I6J¿ªŽO¢ýˆ Â¢JÞLwˆ~•<…o½ƒ½ :ö¦Üf¿‡¼¹8'Nž*ÎÛ¶ú©­ÝÐO©ï¢}l>þ"7¿ËÅ‹ëÉÅõ8N.¬G8²¨`>9”Åñ—aÛ?®èf’J»OiH-¯Ì'HÜ ––¤c>¿_AJA\¼‚øb,¬Y‡*K~ÉV8Y\~‘s¹‹+Î¸¸¸ËPW<–	pq…Æç‹¤Ðx<½¬ð3]£”ÆcŠ¥ÒÏž^³¹I¬RTh\Š]sg|1&)˜I®¤®yÃ+¼¬p!ÅO²÷)žx<à—Eå•…¯_¸Ö@¬ñ¡¥!E7”ô+\ •¸/é—ü¾+IQ™™Iú•hÊ'*ÝêN¥ÄŒ†^Vf’þü¨´²ñV†ùÊLR<.^¹’ÓLrÑ'*"31¨“A‹¾ÅT*åSh@±Ä—$’
-Æ²_±Ä}ãJ5ƒªÇÓ/—`‰a¼,àX*µœN)$”JåO—O\Š¥ÂŠ ‹C¢ÂÒË¢¢Ï$½SRÌç÷§²Vt*¹.$.gôÇb"dÇõiÛgÿUŒ‹CKŠÐäC\¼"^QH(Ó*¾~rqÆ—N¤’RÊŸ•èlR!!£K~+aE/+Æxè¨Æfƒ¬¥˜$*bi…;®%…,*ú¦°b”E¶[[|éeÇD¶‚]L1”ÅAu·&ùšÑ†øP¬É_³¼S,Ú*$$)ˆ+|`Qº"¥SUbÃÇ¢ˆ>%Z$˜Â¤ô ö
-ë=¦+u3I69z·I6&ÿRìE«ÜÐLÒï“ü©&X±ËJ‡”åô`X)‘²(ŠŠ=¾- *v)–RJØ]")*%*¿²¨”¨D_æ±tEJ+Žø¢xeQTRL
-+¥òø\2Ã/¦êëŠôPXqÊãû“ã³ÚCŸ?U§8Õç.9ƒÒø|2SZWH:¦8BLåˆeìì?%4SˆG.0“Ì0ò)| våŠÈ^[Òä—’.À>mœM¡õIJ±ÇG”’øÈ¢Bw2ë,Ì NiP!q}×!*·Ü22 CsI¥TŠ‰CŠMŠ)VI1.ÆÄÅ••8àD,cpI1…¤3.CHysÈW›
-+9w(¬xåa×29CÙµ\ÎpìZ!gxvõÉ]+åŒŽ]«äŒž]«åŒ]käŒ‘]C²T ¿¢[ŸKJb³B3m	+ò¶AOqðAm0¼m°¾8xNe(öÐ=Ï©ôhGeçÜ~>¿œ
-+µr†°«$g(»ÖÉŽ]r†g×z9#°kPÎèØµAÎèÙµQÎØµIÎÙµY{Um‘ÅE¥lQŒK
-Yd2‘fJØÌd¶UVZBJKSXÙ%‹âˆxnJén‰ö×Åð±Ó·Xœ±é†˜Ä)»š2q%[Sê)#ÛÈs/œvYìPwÞ!#3tç;ºë^Øsx>ªúåÁ>©;ÓNÜì¬²Ø+ŽÜcÿ
-âéî°Ò%7{{ÃJ÷ÏBUH|©;¬ì–3ž€Ø,Ž0“ ÐÀØ•+#Òˆ”“Ç|ÌêJ±kÝ„¸]Mae¬À£x¥˜Â> ¢e,ˆ)æxhåJ³$Š½WºÃJÏN4±Y[OÑI±¶¨,2›ÝŸ|‘Ñ÷"_/T¤bÌÒšââI!/*ºøíêºÈ¬æ•øøâ²¤ñôòLRáãiŸ"Ä™¥»}NZE…¯—†ÓÝ>I1Å‡™Ç2ÅÕ·,Šw{‰¤ÙT]|‘1C¤áŽU¾žm"À6Á—ó–të]©°Ò[ …(ŠŠPŸ§…ÔÛVö‡“:>,°—2.öIÈ£QZÁ\²Yì•üª¿Í?Ù¾ò¬PtEŒm]4&ÞMÚóÜ’˜È÷oÛI¼À®EàÜ~ä‹£²$63*+ÞxrÆ—H%ÅÞTs¦•¸Bae`ÇhÂ7³c4v×¹¯7#.+{B¯÷ÂAYé	]Å^&cWºïªèâÍJk(¬©GfòY¯Q>­X¤˜vt& ’Ø+6KÝùõ‡åŒ‰Ä
-S~A‘ùï’bv&fÇz¥nŸ›¼øSù}ŽÈì	¨2*gÐò3ž±æOS$Á˜¬À­©ý50w6+Maeß=žË—Séj
-+²²»)¬L2*Ib³8|EJ¨5%3V&CaeZ¾‡ÂÊŒ|„ûåkD}’¯õÉ,Ã	…•9†Ã€y†Ã€‡åÄCa%)¿ÈB§PXIÉ/íÙ‚ü"ÑžÝÇðƒ1<:ÌðTèÃS¡£ìC¡°²ÈÞÉ€4{'Ž±w2`‰áŒ†ÂÊ2ÃaÀ
-ÃaÀq†Ã€Uu_ƒ¡°rBÝƒÖÔ}1è~u_z@ÝƒNªûbÐ)u_:­î‹Agäz‹<«Þ)ÑPXyPBaå#ºz…•ór†äqÖ5á\PqHç¢œÁÞâª—Ô;uÆCÈf<¬ý²œ!y„G4!<ªá19ƒ¾âz«w*úÈÐŸÔ@†þKr†äÞ á)dOËô×{F½SÑŸÕ@†þFdèÏÉ’Gx“2„+ÈÞ,_3«‘­¢ó]ã)7””ü>*)†…«›y¨à¬ÃhýUp0ÂŽR¸Ñ¸]ÎRG‰^O92€£àVA	¡A)9ÊBÉ4`³
-<8pAçE~GÀJú®HW—äåº‚Ä¡O‘¿Én2ÖÎwvò»bß‰=üÄ$ù8ýÕ['÷<½ºúù#—.eßrãÛÙ6òåo³¤@«èŒp mÐâN€õI§”^ S&“Éar8åµ"äÔG‚õõAI§ãœ§”ô_¬ù|M©XÂÛÅ¿úæ‘o¦ú¾ßOÎ,/wÚ½ûTvnÜ:{ý:(¹ù	¹	'D|:jçˆ€ê*ÊBynb\1Î$£U¤	.Mê	ÏÓ4(}dRG8îanÊ7®˜g’Q?Ø0¤AÈcwGtþìÕ~Ž…R©TÔåv¾r—èá„3Pç0XËC^GÄéìŒ´yÜ.Nª­zÝÎ¶ÎŽöz©V§w{<‰A=çŸ9Ös´»6^K/õN÷Õô×ùû¾D_ì®lxãƒ‰‹}Õó¿Ct«3Kµb®Ò€ ‘û¾N¯Ã†`´ÎJ@É¹8	J‘æð¦Œ‡Øx«'ä­­ïpD.O¤­³Ë«û@scÂfâõ:s©qw;]¾õëÎBú¹\£/Ñzì Ãô#LÂ¹Mò¿ÈMè!"V¯&T  àÂ¯êÀ¥Áq1jÑ´žPú2|å^Ãn¢ÀCOô«'Dju:}¤½ž«­¯ïh/Iï÷ä7¨#¦êÝú[}¡úúWº,Qšý„îð^ioyµ8M>RmÙ—ê=?3}®ïÑÖ2KbÎåèô°2(Zr›äôº*IŸ–˜ˆ@¼Êt¢„ðd¼ J”^¼¹Hs:ª°(J;‘Àqò˜ìÌ¢óg¯ös,ÄDÉëv‘¼(ÙmV‹A'qòÔåvDÓ®`[WG=“&Ûåùá}§{Ò]M}"?;¨ç*'Ê£½5»«ƒýõÃ–gž>ßW]1û‰[Ý»+‡âÙJoËl÷Á%F+‚ ¦àPõ XŸ¤„dŠi:8ge%âX˜eŠZœCþ”n@@M”‘|}„ÐEŽ¨Ö € Ááà­eêL¿{a–ÔÐ[E$·I2ä&*À‡£6!´¦ÚkÕ	<¡y%/c«15{lR§‘QØÁ”Ê­q•Œ’°ƒ÷^ãõ§3.¸+}¾@eÀã.-1QA*ôEtµ«4×5±-°¢³«ÃFÝ.Ïgö&6®–†šöU‰µK{R3ƒz®nÚ+E¥Äbc›e4–˜sÔtJbi··áÔ}Ù¿ÜSÕ8(Ö<e›ÅIÕn€|Ü„ozÉÉQf÷5ª8ÁqcU0¼y‚0»p‰&/\Û†÷šyÏIŒV .¸$gjÑ#[¶Ì!94æ`öKšj›IÈ­ž ¹1,µ¤gÿ”4öÕ²ïAen“<En¢íÑ]e„£å<ÇŽN€ã
- i¾`´ª|—A‡FÒ(hv©6¡£½¾>ØL;ÚUÐ«p»<ÞjÊŒëŸu©­‡Â­­b[e]¬15žª¬/ïò7‡ö„ë‡BÓ–€¿µ¢2\Sî÷š¬RGCÏtMYK©«©Ò_[b­ë’ƒ±f7šs›ä_ÉMØáC8Ú´6„ÙÖü6%^w‰Ïá3êa'vÕ¶,™jïƒKïvyˆ½gµ¿µ§÷xÿñÞþÉÉþ¾©)Kï¹™Ä¹ÞÞs‰™s½ƒ«³s'NÌÍ®æù„Ü„¯j|·”˜8Ž£dÂH°/Ïp‹‘€hÏéDžË;ñv¢¤R)m±RÕIh¢ÀŽ»PtšL÷/1’?òÖ¨óóî5…	€Žº:‡`-ß’Ÿ<ë4á)mªò–šöšx9¹‘lî4s\[_öºjcÊ ÒO¿
-7ÒQ“™pÔB˜äŒ+^ÕÚæèâ$Ó[5"Ì‡ëttS¾¨…/„rkwMEí Üp;Jë$‡Ã`­ERGWQ¸¤Z·;â–‹££CcÞ¦’ÒêòÁÕUòÛ}Âä¾ƒF}¯ñÈd<{˜íq<·I¾LnÀ…·¼ä°PJŠºÊ©odD;Æï4^ÞüÏ_ÐÆwÚ­»Î¼ç$FjA‰Ýf51ï".ÝíþÞ‘wßšµÖ÷Ô2Ú×NXÒ‡I{ökƒ}ÁIe+&XËøkb'àPõ©çAöü(%,Ò,:…®Žˆ»ñÆ_÷÷kóÊr? Ãôðb-jrqè¿¤<¿Ö'B=ÊJ/MB§Ã1}þèlœrÏÜk<u”–X-f“Ñ ×	<¼Ä[ðŠŒu]•a…øF÷©½£¦¡§žò7Y+mg‹15FL}ÂÕ«ñì¦¼KÐï1™Ùž™¾„ÜD%º¢ífBI¹…r´‚€ã&¶ÄZµžEåu—ØŒzT’Ja§Þçe›i|!Šqœèx ¯u¨¼ÑÙ"††æâþ=žºêé¼ö‹åmOË|÷ìj…«­JÒ¢;Öç¢×aAS4h6é9ž‰€‹ÌV^šä9ÍL°ÀRê,(˜#ÒÑ;¥ ÞHÐ/ú­—Þº@¯gkrŸË~óŸïRe\8'’ï’›hC¦H j	X)¯ÓQ£Pð½f¢/èø5èõ$Íb•EPŒGa4^˜´ƒiž(
-wûÎÙòÑ£PyzÏ¹Îÿ7ÿ×^Ê4GŠö·GFû§¢S{º#}í}á¦ºZ_Ey™Ç…6ÒfÝòúõÛ.*»#nÉ­{©6¨±=ìsÛŒ>ägñ¿Šó©³õþÒòZgY°mn—«ÎúGYëL[°ÖZØud~¾÷ôDÓÞÞP¨woçð\¤eÎæ/©(ÿÖ`Ínon¨¬i¶ò®ÁPÇT“^èçKZý‘‰F‡ÙçòVwíO´LGGooGGö¹½õµ<ïlr›ó:
-Ð‘ð³Ì¡²DÇq ”Ð|` Zo ~øåZ.á"N‡ï.ç6ˆ“8-ÃÓs¿ùÆ#›Ž7Ø£cÆ=o°éGfžz`Àh3ðz»q€ÜÈþ£?Æü¤|TAøÚx(4èÏþ´÷Ðëp¡9ròjà£IýÊÁ‰[Gp’à¤ÉblB¯fÙ¿38)è}Ü„ïŒÅ2Çs|Á„{´°0Oƒ^à¶{Ë
-Õõ1”‚xnÇp¾Îü×›Ê„²Dc€T*9ëêFkÕ¶èË»ã˜úâ•Ytq"ÔÝo¯Ÿ’ÇÇrsç`BnéTƒ²]rc{áìãÙ÷ä/,ÞIä6ÉO´<‰X´cÛMDàÔ´›#à¹‰üy·?&ÚcçÝ°ï@,FÅ)Ÿ'j¹¹GºUH&	ùéÖÝWû9º-Ý²Y˜g)¤[Bm}PÒK[’µ=¤cÉ;i¬9},AýÓGõV³÷¨$ö[üUmôúg’UÁgœ½Ø7´=y%×Bþ„Ü@Z£áÏÂB'XötI‡1gó0s6·Å¬X²3çÒµ]-9](©²”–:;íæÏÎ/™ËÍ¼Ùe:8ó1GËÐŸéø¨®'\Gþ1ûo5£µþQ‘XoÝlƒ` ·‰—qfTD½j$NnN/ÀLÌ\Ñ jDx¬\’ÊË$É"ùª$©ÊÇ\8–Ò:º* aw´ÓHV• x*¬2zTKyžÕòKÉ_å«(s•Â¿^Ë3µøY_°¬œüK’£ ,|6¾²{WKßhÿÙ}§çöMN®œ›?røÀ9º!ï‰LÚyódlà`ˆ<¼§mwë­ÍþØÞÝ*Ý•îVø£Õ:BA&´pv+kµÂZ®e­;Èû‰Ì2{Í¼Ùk:´ÿCäFö»u£’4ZG\Y¦Ë hÉÀp¥¨ŠVðjŒŒ©pSuõÔZò;;ƒºZiEã®P+¡:Z&Õ•‹áÿÙêìo U•¾šöp4ÍÖnÊm’ïÓ«±+Úì«`ŠYÆ|ü{ù¶ª¦ªÌcÐA&r>:Ùž@iÔÎÊãõj¤&%ÃB-Rº}`´jWÍ‘š¾†ŽÃ½½Ëµáš}rWÜßVq¸g¢sÉÒÞÜhêi­m¨´5Úšb-mÓaYêôùÛåšÆ
-sCùäXû|[¡FðUµzØ­gá8O¹U¶YMÂóxFu#Œ‡#oÊýn¿Ê-ËÙoüøÇtcø›ÃÙ¿bë™r‹d?ý‚V§PƒÑg™{Àö:…—Dˆ‰˜{³ÿþîøOß¡Ö‚˜lŠt6x‰¶	åÉxPÂÓUVÿÓö£ãh^*½n‡6Ø^¿^­ò2é”8É±%‡_ŠŸè™|ß‘w_:=™HLž¦ÒþÁ‰ÃŽìßwö;$ÕhÏå0@8¼L~‰ÓƒEÓv3 /»ÒÒdÇŸÛ$oR÷×p”Uq¨ZRÙVÎ3uÛÊyšPc|î+uv7ŽvvÌÕ',÷†cäóÙÈî#ÝÚú€|Ž^ÉÅL)<„²œ2¿ºÎ2
-îh>yàƒ¯!TÃÊŽ>š·yùr‡K§c1ânX|v¸woÃ`esÃ}{SÇ‡šªè.¥íÈ/_Œt‡Åp¸su®ïò³3”Ñjrrn“|ž^Þí¹õúÎÜÚj!p:,^«W3@…l¦ .Ûóê-ž:µxôÔ©£ÝƒƒÝÝCC–¿ç½ïÿ{ßóáØÏ?ÿÈ#Ï?ÿ;yn“|š>÷G­BG	Ó!Ê^ßL2Z”t<ÏUó•ò­^àøÕ"â¶áTÔIPQÆªô6V®‰˜/m)žJ>§ß-i¾D%â?O,ûª&º{öïëó·TÉnÒÿ‡·¹ª+Õ¹÷˜¥ÓßYžŽÇö¹œ•$2òÇ[(94”n+È³™nÀ«Êƒs «àù¢fåí™«Ôfæ€_§Uâ´wKÛ…øûN÷={òä±³¡uó£«ËÙŸ’Ñá‘®b­†é¼¨‹úKu´`8×·g"^xå…LD5õjª…‰Û±pß?9¥ž×ÏÜ÷OÎº^ÐÑì	ÿh]äþ™¿u–¼à­Ûu¢#ûP´ç6é
-½
-;ª¶ËÊå;ë0ež’*GÕëÖa¶ÆC&OŒŒ<‘˜}|tôñÙžƒ­÷'“÷·&-sïX[ûýûcmíscñ‡—ßúÖË‰‡ã Ó_æ#É_Ó ª¿kDÇ®y-^SµXãI;Ý€YoówùfYv³èýBÁ×1v‹ÌøÞý®_›?þüùqºñ«ïúýÁ7?úè3l QÈ”£>*¹lzÂo¹°mœ(Gyiy©Ê‰®`Ä›÷b]½WÊ7eôzÛoþJjÀ\fåÍsÏ_ywjÄZaã­e–XöÛ8›\®&ç¯ýûƒÙíydu<€ü”n@Ï|'ÈQUu·l†z‡#/ R‡ß-9þþä[_ û†‡o½¤î¿ o#7`DKTV{I¤`…Øb—n·BFKÚA:[’øÝ5ÿ@&r ™\ŠËÙ7Å5Ûâ È_ÐÇa„sQ“@@­„  âœ"€œP-«ŽÂA-`QÐg¶Fó©¨Íd2¹L.‡£´¢Doõ…º",ùcÄsvø;K9$÷‰ë<á-¶HöïˆãÐÁƒ7?^1Zî•½Ùv¥“¼])ìÜv€Ü¤wáÛú=øæä¶ñsnñÍþ©k‡RV¯·¹-“/~êÐ¢ÕWÂÛ*,GÉ,Ùû~\U%{ÞŸýT6“)‹TWGÊ2y?üMÕ^´Då;ý0x^8š?·úå±™9c;tÑ»ýnÕÿèGdÝþòÈ÷T›NT=­ WQ¥Å&3Ïê…ÊÉåÛ*'eµrREªî]9)–NfoŸxz¶çpe¸"Þ¸÷p{äpóXM¨á¨eÿÜÿB¢¥6RY3p1‘x8&Õ¶†w±ýxúºq—üvý¿žß>—Š›J¼ÙcIÍ°”™yƒÃ44ÿ¦Žl^g7,Òì;;îïî~ ¬dßÙþ€Ý:K®Ô…BcõÙ‹;úÝ@ËoËÚÞÀ1ŽÐ'5qØ–ßÖ ¦,ßN-XTuc,åëìì’ôœÄ¥jêv,¬=jö˜y³Óòè‰)^GùÈ#{‰ðœŽ£Ù÷Öµäè­³d­jt¤êÝÙ“ÙwWŒVeCãáùÞO¯AÀÞ—xB	X`õd–œªRr‘Lù¢Ž;j©¨Ikõ”²ØËFôú¥.É•¼ïÐ¡÷ÙÏÜ×sÁ|Gqf[G±%!ßÐz½Ä˜Ï<íÅ6ÝŽÌÓNºó±ónØw nË<Y×MKµµÀ=ã|±hGÿî6DçÏ^íçXè.=cW ŽõŒ…Ž.µU\,1uEÜö.y–¯oÒZ}Q?5Ä¾Rló}éÃÉÊµÕWUÕ|k’è¶ú|¹œ–¡ìðbÕ·y1‚i€|Œ>fÿ@`ßäÍg%xR5ž,"åóá;ë"QBŸyfÇˆÖC²Àâpåc{Ö¶ìèììbÆsúíëò@EÿÓƒä/;Þ’[_T½þ}ô<½
-+šÐíú)By:!ž€¼Ž=X!jb™LÙm©¢ÌÖdo2è`%V€vø}–s-ˆÝ²4Å8€p÷]®9Ù«E{N{ç;<µÖ{Ûîø#s,(˜{$þÍTÜ”|û¢/ÙHYB²À÷ë…*ø&¢_E#™Î7\´Ö…ÀÕ“u_ìÛFÌÚˆósî†^”ðŽpy’Yrk&=ezªcµãÖIÆc35Ûyoyý)b6·hQ˜æüEßô¿„ik*5¢±!XW+9ZÆj¨¹[æö²?ÓÇ¶¾¯rðšiðé§k›¬Õ–W‹wjïïÛ8ý–#“Ï=ÏÞï2ò}zóÂ(±j]f©ûé,Ìckø»yìÛªï„Uß9½{a–#Ž#_ú—ÃŸ{nd?FÆ~œ½ŸÌ?ó¿UùÈå ò·tvHQÑ¦'ÜÖÒ[u;ìå¥j¢cG(àþÜçSó%5%¼£Ö>wðóYòö×ÃuÏžÎjòW‘Û$Ÿ¤WÐ„Áè@E9åx‰PŽ¹eÊ©Þ†pj¦#¤!;3‚êJ¯›µ’:4‘¦;ò˜z©£¨U[ù`¡TóÝ‰ãbSÕT÷ž}ÁÔÄàtmO¤!^%ºgOFÛ÷ÌtµtIÕÍÑŽúÝb¿Øéoé¬«j—Âó“{ö¹xël¬;!ƒýí(G7n¯Ò¬ÿì*Í—¿œZqT;xGeé©ù¯Òì»{–zz–zÈ1í«¹Mr^AdìFG´­Ýkà¶,,wÚ±4‡	Â»›w;jHM>U­ó¶F€jNÜZ'šÛnu´6@¾îÿãÞ#]RWµÔÙšˆÌ¦+\Umbä°C”ötÈ=ƒB÷Pëts}dÚžikØUÂ—¶íÚ×¸¸ÏßÓbçKä½¡–©09Q•ZbÝ-õmRöý»ÛëKË‡åŽ!5
-nÈm’WÔ»Ñ>¯Ž‚”Ž·ÊúY ÏgÙkù¬†¤Ó¾Ô±ZjE_¹«ÔÒ`m¨«Õ[ËBNM­T×ã,ŠAç¥žýBO8RcÝÛ<ŒLV4»ºªY¢z¦!±Ô>é_Þ=tšüqßXCøpzòÖƒ•íÞÊö‡Ž×ËKÇöj|nõÉ«,œÔô®MTYÅ|8áWY¶±>©ŠÁÛÎ•}êÆ‚"¿ca–ìš›Ë~…ndÿ…8o%Ù/j:!³Ê}VDÿÀ ç4¿æ(äEéòEíL)ÁjþI*jÖDÎáRE®vù;ün§ÿ ®aÿ@öÓä{ö5¹ù‡>ùäHdìéçþÇa•µjFÂª.5¸<®ÔÌ$£6#%…™`••ÿ×'íÊ’=;Ý¥É+5›/˜§|Ñzö„Žž¸sZ1­jª«*YÉ¦¢¼Ìëq»œŽâµ&é’:´ßˆ^ýuKê¯Ô%é‘.)Y>=_:»PÖ[öXYoÙÌçü¡²Þ²GËks>þjÿÛú?úÑ~´ÿmý¯¾ú*1¼é˜Û¤	zf´#ŠáhÜÅQ}=mÍ¡@­žçèD!c¬bŽgMÇB•’u;X÷2eµìîjVVXÚ­í::ºXgCSgAÁvê—ÇãíìŠh€^Õ©`A>ƒ:Ý;láx•? ·ôêì©uyë‡Â{åx@L6÷UO–în¨–{j'ƒ…M¶×öW¶¦¤ÚVJ}=UÕ¡ªPç­WÃ‰.y°ÓÛ8Y'7Žî	vûÚŽÖÏ<½Ô^Vc4*k?±;ZYÞ´ÜQ¹·ýÔÓ«îµ˜©@«™Á¥Às¿z["T´³U•¾Š|9_/ºw¹Cêˆ8t:rèÀ³SÏ<\Ù\k‹ëxpMŠ:ßüµšµ|>ÔVÓ^Q;p1ñè/»K?8”ý®_éjq‚|…Ê0CŽ6ªå«ƒ¬/C °ý©¹¦oS,õµª{uý¥—^zéÄgû>ûÙ¾Ï²5æ6i3Ý€›U„Ø‡	jc[¢ç(±˜tÜÄ]LôÔ¯T’/Z’xü¾ÙÆ¡<Ü8Ów¿¥ãò	òLöáÉ…@`a’¼1ûÈ‰Ë hÍm’Wó6m4:ä%<WF¾†£ÜVH ÖîX<¨}ˆVøü%e…ÛÉÌšVPÌ~¨Å;>A,P~«åC„šÑjÃÈÞ–hO{ßòž¡3ýíã¾fgwux_­ž	Î.µÏ“Ñùð±Éþ¾±ì‡ßtüÉ«#Áªˆ×¹´©N­"I¹MÎC¯"ˆI€˜Ä9=&É«Z$N_&¦bU˜ujÑ¯"ˆW´/^,U6*ðÕvÊ	tÂ§Þ
-·)¥Ö@O³„ãâ¤‰R€;jÔ©¦ÅbÖªÛ¾q%ÌLô0zÃØ¼~´¾ˆÊCàxaíîˆùÀ-ˆ`} Nª“œ¬ÊèpX­5!¿CbÿòÁ›»éÜîÈŸÛÇ¾˜Ÿh:ª¥º†/c8öíMö0Ü¢ÉÒ>k¤µ¯Á©â€2ú’IòvµºÌª¢%ìóŸ‚`¶ß¥¶l¸wmùåx"g¿õ­­õÁÖVËÉåc'O[>™žššœœšb’Kå6ñzšÇ•FÆ§íŸPúX†Lð»½¨¥Ë…V…žDÈûÈýÝÙ_·Ð÷ßJ²µ^¥ûÐE_bþ/£[dß)$UèËìßÞ–Ëè0èØ¶û²šš²²šº¯ª¼¬ºº¬¼JÝË¾—Ü€Q…},®õQl5²¤í	¦´³AÇª¨üÎ°OÕVÑ°:Œå–º²Dï7º½œ‘iÕ­ÿ»/™ï¢ãwÈâ¤—îñi"An:f gþ‡‘wÝÔÞûïÐsì‹s|k|7û;t|kÿØ•[ïÈ~Ãp†û¤ºÍÿm8ûÊøÛÙ?/ÜzGváŒ1nûIÐ· EEp4„rHà?0HþaB®«·@n`ü*!A~•´Íä>$HÊ¨ˆqÒ…F’@¹Žfò}$È¦_QÇÜ^$h#äÏaÁ0@'°‡[¨Mä{X G`¢»±ÀÆÉ·à'¯!@^ƒL^C9íÄ}#èhWç¯b|6Z†JòÔ×à vjÇíA;W
-/ýšºÖ~ûºzŽ¡…¼†i¶M ŒÆ±@þ&—#¯¡‚r yä54Ðç±o-MC¤khWágp¼†V®@9	r) ÷*{þCåé(ž$.#“äwií¡óô<ÇqkÜ§yŽ#ÿ!.>®ãt»ô»ôOè?nØmø7ãnãaãGŒk2›VMo3}ÐôÓOÌ!óó-NË¸åË-kµ['­g¬ï²~Ç²¥lïµ}ßÞcÀ~±¤¹$ZòdÉß;>ç¸YZ[ú†RÅ):Ÿt~ÈyÃ•p}ÝÝäžs_qÏ£ó¼ÛóW^x›¼‡¼ó²”Àó°`FPŒâi¼À—l„¨ÑÛo±.	ÏRôçUyb0AžÏÃ6ü^æ0Šæa~Ž€$~š‡u¨'syX_'—ó°&Z’‡(£yØŒ6Ú–‡­œH—ó°íÂÓø D´¡mˆ@Ä –qÇ°8u¬ã,ö -¸¤þkFºˆÓŒ%œÁ)´ 2D\ÂÖq"XÁy¬à.bË1Œ38uˆ˜B§ØÄ2Ìâ.à–°"–o¿ƒˆY¤qç!"¢®·Š8‰4Î!‚f´¢mèÁ Ã4zvÌ.Ì |Û\mÆ4bÂu‡ç±¦îMÜ±î	œÁºz¾Ó¸»Ð¬þ¶¢§ÆXQ1Žc©ûmC3:UŒŸo';O»¦ž4ë8§ÒxE}Ï9< gpü6î¬©;fÔfwó8­Ò^£õ,Ö‘Vï´5Oc-8ƒsêJÚ³Ó]P¹rk*vó¶wÌ ­îUÄ š!b4ûóKÅ:ÆY¬`'òçÛ’vúãXÇ%õŒ[8‰5•"ŒfÚiØ[—ó;.œwc˜€ˆiuýÓ;VžØ±“ËÛù\à¥¸mg;ß»Å‹HcMåØ1œTG¶¤œqkØ¯ÂëØñ6êœÇ’JÛ³XW©ËöpÍ*/VÑ‚icâ¶ül-«WkÇp¡ÈwítŒßL·0c˜Ë!"¦ÞaV¥ÈAŒa£˜Æ<æÔû$À ¦0‡1©s§‘`sƒiLaP1¦ÂÚØ°*‘SHAÄ8ÆT¶öJž>Ç˜vœUw^Ý»&…k8…³*ÍÙÎÙùg±¢žðç°ˆãùUsÏ«s–°†ã*&ã.£
-Ó½4VóRÁpÎá”JË‚llé‹&lTÓ¥­ñUœQ­Ú9UçØª"Îë2“VmOšÆ®ÿ\mþ/É‹;ÕŸÜ—Ñv×ÿ—ó¢u˜Å4&0ŠpÑ‚AìÇ$01$Q‚ƒÆöaã˜ÁÁ R°£(E>‹0Üp¢ìBªÄ}èÂaxÑƒÔcZaÂ$æPÚ	E3záÁnøP‰* ƒM°¡å0Žðø#"¾Æ?ºÎ?z\wyåÜ™æeý…Ók­‘Ö.õÚQ¿×É!oM)Dû“î³ècQó¯á±S‡÷u°ÅÕ'®+†7ðçÇtût{²¾Ž7šòCo×=K/ëî×âgø˜."4Pu¨$6`®}E|¥ò•²WÜ¯”¾b{Å5Fa„¹)ƒòØ€Ñ;þ±Á3ï>˜©#ÏíO*Ñç’ì~y0ÓÀî_6@{€Á”/dþÐð$}ni®0À~¢®çuOÓuÝ².ÉOð½ºf¡žmM/“Ü3
-ÿ–Åà‹Â²ƒìãþÛ	"n
+xœ­|	x×uîïö…b#	.AÄ€¤n7 7qHJ ­…IQ²µY¢$ïvã%Žâ¤Lºù%jš6m¿ÔÍ@n¥i7Müä¦q^¾ºuÒ6yißûÔ´I›ZmVï»3 HÊ’“ô•ú¤{fî¹ÛÙÏ¹C °à	ph[¾¸.îû¸ü> ¶cg×Nmµ<	ïvëÚÉí¶ïO%? B¥ÇWÓ+þÏÿå×€~#€®ãÇWÓ¦MÝßý õÇO­?ðþwÛ^úW ÒsòÌrúõä«A`à
+€J?p–šKžû ˆ§Ó§V_*ñT ƒýâÙ3ç×_¯|c¾àgÏ­ž}ãÊ£ Fžˆÿ?û±#¡z€–å6±€Ä§ ¹äÂôJn“ÜÌmæZ·úr›ô:¹‘ÛÌM±^úºÚ?…A"Œ0wþy7!ÜAú:y?ÚZƒ­P=[)·YÄï%ï.Ž‰‘'‹ã¶í…~nk7ôsêz`€Ç_åfð÷¹Xq>¹8ÇÉ…ù§@,$‡S¢8qö}Š~n1©tx•ÆÔÒ1ñòBR¡þô§0byY:êõù¤Ä¤øUÄ–¢!…ÈŠ¸t,¤PYòI¾ÂÉâÊKœÓ…hLqÄÄ¥¥h†:cÑŒŸ‹)46ÿ€¨X%…Æbé…Ÿ}à*¥4¶U|«U>ööªÝE¢U¢BcRôªƒ8bKQIÁlr5uÕMfHáe…*®X’­§¸c±<‚W\•—g¾añj#±Å†—‡ýpÒ§pþTâž¤Oòy/'Eev6éS")¯¨ô0¨'•3vzEiœMúòO¢ÒÆúÛæË³Iñ˜xùrZTÌ³É%¯¨ˆ¬ÏÌ .u-y—R©”W¡~Å[VH*˜`È>ÅóN(5ª™H_+Å2Ã¸¦ÃÑTj%RH0•ÊŸ %®(î˜M…,‹
+ïO¯ˆŠ!6›TRT1JQ¯Ï—RÈRHÑ«äV¸ ¸’1Š¬“×«mŸý«˜–†—]³OTŒ1ñ²xY!ÁL›Î¯ðû’K³Þt"•”R¾”¨Dæ’
+	z]ò[	)Y1Å‚WA56eÅ$E%QM+ôè1…,+dI14‡“,²ÝÚcË×xÙJd)ÅP–âênÍòU“±áh³¯(8y§ YµYHPRSxÿ’8|YJ3¦ªÄ†—1D½J¤H0…óKé¸¶„í.Ã•úÙ$¹Ó ;“)ú’Í
+nx6éóJ¾T³/¤”ÈJ‡••t<¤”Ê
+YE¥$¶—M *%R4¥”²§DRTJU~	²¨”ªD¯ñX¾,¥!¶$^^AŠJ!¥Lž˜Ofø•xª^±­J„‡<±/91§½ôúRõŠC}ï”3(‹-$3ee1…¤£Šd*§P4SÂþ)¥þ¨BÜ’¨pþÙd†‘OáýÑË—E¶li³ORHº {µ~6„úÕ7)¥$6ª”ÆF—º“YwaapHq…Ä\%„¨ÜrÉÈ€Ï'•2)*+v)ªØ$Å´—>U^N Àh4Ê(à”¢
+IgœÆ òî ·.RÜr®`HñÈÂÚr9CY[!g8ÖVÊžµ^9£cm•œÑ³¶ZÎX[#gŒ¬­•3&Öe©@E¿41Ÿ”Ä…bÚRämîbçýZgh[gC±óœÖ)ÊPJ‚w=§BÒ¨•sûù|rb0¤ÔÉÂZIÎPÖÖËŽµ~9Ã³¶AÎèX3zÖ6Êk›äŒ‘µÍrÆÄÚYìS¶U—”ò%1&)d‰ÉDš)a“Ù6Yi*­Í!e—,Š£â]¸)¥{$fØßÃËNß^`qÆ®f§ìjÎèˆk8Ù–ROÞFž»átÈb§ºóNyœá·®©à÷ÂÞÃýª_ŽH=™âbgí’Å>qô.ûWK÷„”n¹ÅÓRz~ªBbË=!e·œ¡pûÅq”™…úÇ/_•F¥´˜<êeVWŠ^í!Äål){dnÅ#EÞ¯ð~-cET±Ä‚«—[$Qì»ÜRzw¢‰-Ú|Š^Š°Ee‰Ù”È¾äK¼¨½/ñºÊT”YZsL¼,©#¤‘%E»]]—˜µÓ¼[Z‘],½2›TøXÚ«èbKÌÒÝ>&-‰¢Â7H#é¯¤˜c#Ìc™cê*Kâ‘4›ª-1fèüiE÷–Y¾mÂÏ6Áù—Vò–tk­THé+ÐBEE×§…Ô×Rú‹]ŠYí‘FÙ¢Œ‹E²Ãh”V0Ÿlû$Ÿêoó/E¶¯<+½_ÑùÇ·Ç.ï$íynILä·í$V`×pn?rÅY[GO,9ëM¤’b_ª%ÓFœÁ2´£7áÝÑ½ãØ·“•=Á·[0.+½ÁË¢ØÇdìrÏÝQ}¬Ei†”aõÈL>4Ê§«ÕŽÎTûÄ©'?ÿˆœ1óþhaÈÏ)Ò£ÿURÌÎÄìXŸÔãõm“_*¿ÏQ9ƒ=ÁUÆäzƒ>Æ3¶ÑüiŠ$—¸4µ¿
+¦áŽ¥«9¤ì½Ëû	9ât(ÝÍ!eRVv7‡”)FÅaIlG.Kéµ¦e&ÐÊT0¤ÌÈW‘`H™•¯‚0`Ÿ|•¨oòU¢¾™c8£Á2Ïp°Àp°Ÿá0à€ü€X0¤$å—Xè))ù%¢½[”_"Ú»{aÐA†§B‡ž
+fx*t„­9)KlM¤Ùš8ÊÖdÀ2Ã†”†Ã€U†Ã€c‡kê¾âÁr\ÝƒN¨ûbÐ½ê¾tŸº/T÷Å Sê¾tZÝƒÎÈôxV}R"Ár¿CÊ9Ftõ))çåÉã¬k Ã¹ â<ÎE9ƒþâ¬—Ô'uÄÈF<¨ý!9Còk CxDÂ£rÅùSŸTôÇ5¡?¡ýäÉ#¼CÂ“Èž’3,Î÷´ú¤¢?£ýÈÐŸ•3$ð.d—5!¼[¾jQ#[Eï½ÊSn8)ù¼¾T*TŒ«
+W?û@ÁY‡ C
+ ô—ÁÁ„”Á…®HØåt”	¥åÈ$ Ž‚[%„ ¥äO%3€Ý¦ãÁtzO0,ø¿/ÝáînÉÃuˆ`H‘¿Ën2ÞÁwuñ»¢ß‰>øøã$ùýå['÷<µ¶öÅÃ—.eßsãÛÙvòÚ·YR Õt&Fõ¤¸‡ã d}JÇSJ/Ði³Ù,˜A¨ô¶Ê Ã44$½žs„R@2|©ö‹µeb)_"þÍ735ð½Arfe¥ûÔîÝ§²‹tãÖÙë×A‘È…ÉÉM8 âO#%Ñ¡¦šò:Pž›œPL³ÉH5t:¤	.MÏÓ4(}xJO8îAnÚ;¡Xf“X7t:’!ÞÑñÓgû&J¥R§Ë	x+œ¢K„½`´U=BØîê
+·»]N½^ªkx\Žö®ÎŽ©Nop¹Ý‰¸óÍí=ÒS«£—úfz‡kë}_¦/õT5¾óþÄÅšÊ…ß&úµÅÙå:1Wå@È}_£×aG Ro# d„\œ¥HsxÓ&£Ž‡Øy›;è©kèÂ‚Ónïêöè_hiJØÍ¼Ao)3íî +·~ÕQJÈ€1—CÀUúIÚ€) zL<Ì$!”Û$NnÂ ±H¤šèøBut¼ŽðkzpipÜ£ŒZ4m ”>L§MFo…Ç-”E“¨ãa £Í$uz½!ÜÑÀÕ54tvˆdð¹óÔsÍî&Ã­àÐ}ƒ«=‡—)Í~F¨_ê¯¨gÈ'ª#£{³Ã}çggÎ<rÜVnMÌ;….w•ZÎAkn“|^W%é‹‘R3Ñ›ò::YJx2Q%J/ÞÆ\¤9=U	X¥Hà¸yLvfÑñÓgû&b¢äq9I^”Jì6«QqóÔå	t†‰iW ½»³I“ÞåtÿàžÓ½éîæ‘Ÿ‹¸ªÉŠH_íîšÀ`ÃˆõégÎÔTÎ}æVÏîª¦áX¶ÊÓ:×s`™ÑŠ`À‹t*"n ëS”rL3M'p6fPÂÂâSÔâòt:ÔFÉ×§@]âˆj è ÞV®Žô¹çH-Ý¸õ©QP„s›$Cn¢~¼±Û	¡µ5›^ÇšWòr6S³G§ôu;˜RµÕ¯’QCÒíàÇÝçxûáŒ®*/×_åw»ÊJ-&T’JC‘Ý*ÍMl¬èêî´S—ÓýùþÄÆ•²`cóÞj±nyOj6nàêg<RDJ,5µ[Ç¢‰y¡¶KËz<§îÉþõžê¦¸Xû¤Il%U»ò¹	'ÞõIG™Ý×¨â ÇŒUÁðæ	ÂìÂ%v˜¼pmëvÜmä]1
+Ø 8á”õªEoÙ2A4&0û%M·O&ä6¯ŸÜ‘ZÓ‡²Ašâþì‡g¡×áDK$èàÕÃ ¸x‡Uß² Ëð–œ4U\^ÿüŠoç‚ªlVå6É“ä&šÐÙUN8ZÁsáè$8®ÀuBæ†²Úëvõh"M:ÉnÕuv44Zhg‡ªu•ë.§ÛSC™Aÿjçáºq8ÔÖ&¶WÕG›R3¡éª†Šn_KpO¨a8Ø4cõûÚ*«Bµ>Ù&u6öÎÔ–·–9›«|u¥¶ún9mdûmÂß’R	5/ØÖ°s¡„€yö¢vw†]M7þvpP³q-¹Mòoä&JàE(Ò¼¢„ùüñ„R«Ô+xM”½ÍÔmY]Õ7
+^Éåt“’ÞµÁÁµÞ¾cƒƒÇú§¦¦§­}çfçúúÎ%fÏõÅ×ææŸŸ[‡PN$ß%7ÑŽLÄê·Q^?®§&]A—»,D^§çOÀ` if[Tµ+‚:éL¦SVb4"m&ÀãEMïØ9º`9éPzémÆ:þ?VþÏ-Ê´FŠv„	FãƒÓ‘é==áŽPs}·²¢ÜíD;i·mY‘Î†m*aa—äÒ"ÕT›ÎÜ6åCO¨8ÿ‘:Ûà+«¨s”Úçw9ëm/¬
+åm³í:[™×á……¾Ó“Íý}Á`_×È|¸uÞî+­,ŸøV|°v·›·4VÕ¶Øxg<Ø9ÝlÐò¥m¾ðd“`ñ:=5Ýý¡ÉV’ìììëëìÌ>ÛßPWÉóŽfW EÓ5¦ß‡ÉMxUã¶µÔÌq%“&‚½yZMD{O'ó¼Ù‰·%•Ji“•©f¶xÂqŠóS—X¼“çÎV¯ã.ãî6„±Í
+@€P_/èl[¶.¯òš¡+k®ö”Y%µ±
+r#ÙÒeá¸öìu•å ý¹‹ÈªJõ2I	Í\u% >ø„
+-Fsa‡ÛÍêvlƒ8‰Ó"g÷ïÜ?j´ëyc‰qlqÜTjàvÃèì“÷™ìFÞPb"7²ÿè‹Q©ØU¾.Æ}ÙŸ¨{Ë}ŸŒÐwÀƒ³“è‰‹@Ï´SR£Ž[ŸÒBèž¨â­×ã¨!ïJY?åž¾[*â"(+µY-f“Ñ ×ñðO!Z¤Îîî°+ì’Šq§þ;Óýc“æá'Ÿô5Ûªì‚£Õ”'æÝ•+±ì¦¼KgØc¶°=Oä6ÉkäœxÏ'+¥¤è9BˆÊFåwž|Ï_ÐúwÆwy×AL,‚Ò»ÍÌâh'qêo£…|ö­©±¹`[Co““ºIkúéÈ¾I*[9ÙØ¦éŠ5×Jþ¹J´EB¥fž#”# t’EM—TŸt”í™Or»¬ƒŽ[>‰­Ù½]l8;],­¶–•	M]%–?[X¶TXx‹Ó|`öSBëðWõ|Dßª'ÿ˜ý¿µcu¾1‘ØnÝl›iòJéëp!1[G­„yÈ	Å“—	ÕQ^œbÔPsLÂò#½þ‚~Úñ²ÔPîÄzS‘ .¸„²zIŒ¶ª`˜	BÑ‰Ju.U$–ÆÆ†Ç=Í¥e5ñµ5ò‘ÝÔÞ&CŸéðT,{ˆÑ‹ù·O›¨B7³È”TX)G+	8nrKÕÈ¦èÊ=®R»É€*R¥Ûéçòº¬Õ|†á:Þ7tß@ÛpE“£U7ÎÇ|{Üõ53yo'V´îÖ…ž¹µJg{µT°wôMr>|0bËÍÏñÑtkad^ë·ÝbUªæ‡¡ÜÏvÇÛŒ»¡LLK5Ã"•IŽúzÁd«Þ­yv„P†bË$Uœö–4LËã	¹¥+ž[»âj·Knê(ÄUÙçvþ¡Ü&®á,¨ŒxÔ(ŠHoÐÁB,\ÑÁi®ëÑ
+Iª(—$«ä­–¤j¯”×@Õ|‘=¡ “š¹ÞÊ l°UhÄ‘ÿÌ'Z<Þâ1Ü÷{äFö»õc’4VOœYF'´æöãœCª#•¼Z³ ãên\Àt}µ•=®®€¾NÚ¶Û˜3ØF¨ž–Kõ¢ä¿·9Iu•·¶#IüÝzV4G³ã™iÒ"Z¦<Wf­°–9
+Ew‡)`p%ôµƒ¿umñ½‹ôz¶6÷…ì7ÿùÞ'Ôx.‘Û$?ÖrVbÕDªÄLtœZáxn2/KÛ_íµãNØoA,zÖb²šÏÙµ<”Ü%õ-$ö„ü”Ô÷Î³ýÝ–úÚ­Ì›R_]]C@2H[Áö•RHSÝ¸È¢	ê›i<r´÷ÈˆZI‰Hâ ÕWÝN¯>Yxæþ¹‹ÃÛ) hÎm’ïÑ+±+Òâ­dÚÌ2”¼ý{è¶D¡¶ºÜmÔC&rÞºlO´Lagªàöx´€Ž”Ž\¶JéŽ¡±ê]µ‡k;õõ­Ô…j÷ÊÝ1_{å¡ÞÉ®ekGK—¿¹·­®±ÊÞdoŽ¶¶Ï„d©Ëëëk›*-Sãí…üûuµ2×i`æ˜§ÜÛì5×ž¿À3)4Á$B>¥ò¹|ªí]$e¿þ£Ñ‘oŽdÿ†%‹ ­§P		»#]&¢cU%
+OukÌÈj3ƒçÉ}¡> ùª½•åÎ2(õ´:–S
+‘,§ÑG’„°øg±ÕÝ»ZÆÏî},=¿wjjõÜÂáCûÏÑqdOxª„·LE‡Éƒ{Úw·ÝÚŒöïfg6ç–È>úŠV§P“£g˜âa{ÂCÂÄL,}Ùÿ0wì'PõŠM¤°Ãƒp¤ÍD(O&Áƒž®±úŸv2=Gó§ò¸„Øa<>ƒ¦¾ù39$N¶ÎñåØñÞÙøGèÒé©Dbê4ÝöÅ'	Ù ®ìwHj02Ô‘Ëaˆp¸F~3  %0e@®‘¥3¨É /·IÞ¥î¯1âç(%*á©ZRÙVÎ3›ôÛÊyZ8 Æ"zýWèêiëêœoHXïõD'É³áÝ‡{´ùý ù½/“q«…R¸	eq6ëeNtE>Ü‘|@Ào£? š®Îš×³|¹Ã©×3-»—žéëoŒWµ4ÞÓŸ:6üÀteOÅËí‡ßw1Ü=C¡®µù‡ž™¥ü¨–¯Ê¹MòEzx¶ç«ë;óU›•À!X=6æP
+QWÁDoÏU¸têÔÒ‘S§ŽôÄã==ÃÃÖ?ü›ûØo~øÅèãÏ=÷ðÃÏ=÷8;En“ü)}"îØÜ„ê„R¦ç”…;ÞÙd¤:P¢£'ÀóÜ5V)_°q‘*pàu¿VDÜÖŠ8*ËY•ÞÎÊu"ó¥¢-ã ’ÏásIšýR‰øÏ“+¾ÆêÉžÞ}{|­Õ²‹~_ð´Tw§ºúZ»|]U¡™Xt¯ÓQEÂ£bµ“ÃÃéö‚<[è,p²ª<8°@r<_Ôþ¼r–Ù­°Àâ÷éµJœ¶¶´]ˆ?³÷ôÀ3'OÝ?w`ÿaºQ¿0¶¶’ý	í.ÖúhˆnÀƒúˆ¯LOÎz}»·óÀ#T¼ê®ÔHYKgÜn—°xÏ?9¤Rž7ÌÞóOŽúR^§§Ùã¾±úð½a²pë,yÞ7V¿ëxgöPtä6é*½‚To—•‡ÞZÛ(w—VÕo[ÛØ7™L<>:úxbî±±±Çæz´Ý›LÞÛ–´ÎàÄ‰_Û·ï×NœøÀüxìÁÄCï}ïC‰cZn—Û¤Ãôu4‘™|ZªÌ:®–!“‘/8æÛz,Zã.cî„^ôÐAè8ÂéÈÌºë(wÂl ,ÚÖ³ˆ£m
+F£é¨ÕBM¦SÁ_·¾ý+±XZµ(sü¼+ýÜ‹0ÏÎRï&45êë$AÐ2›±öN™Áí	#‹Î„mÙ‚·*~Õê©ºf[µÔÙê™îÿýbò0h=<õì³±ìÍÐ.?`°,ŽË%4é 0B`ú6–¿CÓ,¿Pb1ÁƒOWðeL]Eeùíç?ôë¿²0qþüùótã…+¿þûñw?òÈÓšžØ¢¨@CDrÚ„ß
+k·iJ*Ê*ÊTMé„=ùÈ¶;lðHùK3ƒÁþ¿”²”Ûx‹ÛÒ»ÿ—>”µUÚy[¹5šýö}Žf§³Ùqß›ÿ~¿[v¹‚žûA! ä¯èc0Á‰ùˆYG@m„ `âÜ, $Dr\õ,z¢Ó]Ð©E
+úôVo¾#±›Íf§Ù)e•¥›7ØfÅ*¶9G§¯“°ò¬ä:~'¼µÒÎþ=8póÓ•cÙ“íPºÈóÙõ¨ÂèR›tãtY¿]Ü6ºpŽ-º”|îêÁ”ÍSÂÛ]ÖÉ—>wpÉæ-åí•Ö#dŽôÌ-WWËîe?—ÍdÊÃ55áòL>Vú¦j/[#ò[c%ð¼îHþÜê—×0	ìÐÅˆÉås©1ÓHvÑ‘×FÿUõiDµS•ô
+ªµøÑjáYM«>t[vZîV³ÓjR}÷ì´˜žÎ%Þ11ùÔ\ï¡ªPe¬©ÿPGøÐ`Ëxm°ñˆußó÷Ýû|¢µ.\U;t1‘x0*Õµ…v©µo€ü„nÀÀò*–š‘#ª‹Ýòí!o¨¥NŸKþáò­WèÞ‘‘[ŸTÏäèéÆjYëÿùZÖ³©˜¹ÌÈ[ÜÖÔü~k¹…7
+æá…wÝwØh7òúãÝÈ~°óÞžžû:Èjöƒ÷iÐ­³ärÃx08Þ½XðEÒÔ²û„
+‡¶7pŒ«ô	M¤¶Ý'Ô¢¶<%]ðJêÆXÜÕÕ-8‰H5Ô%,žxÄâ¶ð‡õ‘ãÓ¼žòá‡ûóœž£Ùß¬òû‡êÈ‘[gÉ‰ê±Ñêe_$sª«ÎþZá¾1L¾®Ý\S>w+)^:îÈÝJˆŽî|í¸ö[·ånìQ+hI€·Þ€çKÕ;n#oCtüôÙ~†‰îpîô×³p]g·fÁîî°Àm¿³$ÏðÕÍÚÅeÄGÑ¯/-¿üb²ªQ½¸¬®n¹5Eô[·–¹\îk¹@þ–z²xKM0OÑÇ`ÅÜêØwyóW	BA	žP‹¨ù¥|ŠÄnÁ(¡Oƒ€<½£G»³Â*8óù»víìêêfÆoæýëòPåàSqò×FOé­Wâ ¹@¾A7P)"Ú„Û2t[u”T”©uÎfÎõ…/¦JkKy¡®dþÀ³äýŸ®ñûGê?=Õ¬M-@~‘Ü€‰Y2õkRˆã™š_º=Ž7ÁT&h&µ“0e'>W-Áÿ!“9£L.Åäì»X‚@ÞT3Ê;Î½þ¶sû´¹C$•}…üVöwÉ¡vZ>²ëÖ·™™$˜%ŸÀÇèUèÐÿIžPÆ?»`r§Úá‹dÚÞrû•Š˜µËä2–Ý9°Á°\Ê%¹Rò‰<øÑ­unÀÊ<ŒV•¹“‡¹­"CXE†3¸ç8"þò¿úÂýt#û)2þ£ì½dáéÿ©Í]™Û$Ÿ¥—ÑŒxd¨²‚r¼D(ÇÌ<åTËC85sÐ¥¡ÓíÌjª<.VB6êÑLšß’4HÅèt+¿*¤Îß<&6WO÷ìÙHMÆgêzÃ±jÙ¿Ø3w2Ò±g¶çˆµ[êªi‰t6ìÅ._kW}u‡Z˜Ú³×ÉÛæ¢=	ìw‰@9ºq{¥mý§WÚ^{-µ*Ô¼PUvjáuº‘ýPïroïr/9ª}À¡)·I®ÓË¨…ŒÝèŒ´wxŒÜvÈr‘m°%DÚÝ²;àJPKjó¹j¶]„©9¦K»eå¶GïÚ5XþÞëG}‡»¥î©«-žKW5:«ÛÅð!A”ötÊ½Mq]ÏpÛLKCxÆšmoÚUÊWŒµïÚÛ´´××ÛZÂ—ÊýÁÖé9^‘Z£=­íRö•Á]Me#rç°jÕs›äe5cmÄPdÀ£§ ¥„ãKe5h€çÀ³l°À|V7Òk_¾Ø¬u¢·ÂYfm´5Ö×låA‡ÔªÆÏQƒ®&R=û…Þ^q´Ö8Öß2”OU¶8»kØ=\Ílcb¹c!<¸²{ø4ù“ñÆÐ¡ôÔ­ª:<Uk—öìˆ?»öÄ•Ñ¢^´«‘‹y™!ü‹
+Ö§ôº¢#ßñ°OÇ˜ƒô	‹sd×ü|ö+t#û/Äqë,éÌ~IÓ	™Uoéc°!ò‡FµÀªÙYaËZä¥Ë)a2H	ÖòoR‹&r‚S¹ÚÍ¬‡3|\ß¸o(û§äƒ{ö6»ø>ûBr4<þÔ³ÿí*kbn“&èXÐF"1'G9ô¶·ýuž£“­„Œ³L¯Tó<V5g÷W“i›uwwc ªÒÚaëhÔ3ƒâdrMÀAÜ)‡n·§«;¬Uö>ôú?ì¡XµÏ/·öìôï©sz†Cýq9æ“-5Se»ë"îº©€ñSSuƒUm)©®RoouÍP°:ØuëÕP¢[Žwyš¦êå‘¦±=Áx·ýHÃìý‘KåµÆ¸Ù_U×ô™Ý‘ªŠæ•ÎªþBÔÙ@¯@D$ÒoµP­a†‰NBžÓñk· E{T]å­Ì_‘äëw¿"é”:Ã‚^OîfrúÙñCU-ÑöèÑÎûOHÇ»ß¨=‘CÛk;*ë†.&yŸ«ìãÃÙïú‚lr›´…nÀÅªì’Mõ Û‚a¡ÔjÖëà"®b0¬Þ¬©J‘/l‘Xì¾¹¦á <Ò4;p¯µó¡ãäéìƒS‹~ÿâygöáãu‚¢-·I^ÍëéXdØCx®œèøZŽp“Ð1w¦ƒZßahíc¥Â'j¬à$ùª*]¦ªZÑ)ÿ‰š¡`¨¹·Ri«Mtµc5ÆÑþÖHoÇÀÊžá3ƒÞGOMho+­™Ì-w,±FùÐÑ©ÁñìïÅßuì‰+£ê°Ç¾´êªZärr›œ›^A ã 1#€½ä@'¯2Ÿ›½FÌÅÊ!»u>H_G /k7wÖj;Õñ5%”ÓÑI¯úh,<¦4”:#Ñéø4ã.N™)¸#&=å¸KSV‹VõN(¡Ùd¤uã	°xüHC•‡Žãu'îŒ˜/hð×Kõ’ƒU¢Áf«ú‰ýÉ—Ôj€Þå
+¿åÚ<ú¥ÄØØÄd{@¨‘ê¿T¬
+°;Äì!V
+ˆL&Ëlá¶bM@½Peô%Säýj’UÎ8JØ5fA0;îP4Þ½þx-–HÄØß†¶¶†@[›õäÊÑ“'®œÏLOOMMO³¯w@r©Ü&~L¯€CË„ÒÄø´ý3;/‹qžfµ€§PÎ60ù(¹·'û«Vú±[I6×«t/ºé'™MÏèWâì[6€¤
+wqû¶_ÅeôˆÛv_^[[^^[K÷VW”×Ô”WT«ûcÑôï(aTak÷Ò(^K³Àøq¦´V‹QÏ*müÎPFÕVÑí·	¦
+k}y¢ïëF}?§Ë´úÖÿÞ›Ìßœá·ÉâW†—îò•a"Annò Î6³° ß<RÒ÷ï0pì«d|kb÷³j»oüò­d¿n<Ã}Vƒæ˜}‰úíìÆço} »ÇxF‹‚¶ýLÓ÷ EEp4ˆrHà?'ÿ†¢×U[$7°H~€0• "ä#¨"Ýh¢5h!?@ˆÜƒý
+ÊIåTÄùKXI=ÊÉu´pýHà‡bïðC´’ï!A› n4“Å"Ä"93ÝEï[ð‘7á'oB&o¢‚va‘¾‹ôytP6ÿÉga'oB %´‹´´U\<ô,ª{ÿ~îkäMÌ¿ËåÈ¨¥^„ðCÌÒÉ›¨¤‹òÑDÞD#}N}'Ó4Dzôi o¢ëD‡PNÎ@Âþ\
+È½ÊæÅ¨<ÃÄI¢dŠüí¥½tžç8î÷îÇ¼‡OéRºoèƒú§õß3tÞiøªqŸñ‚ñ#Æ¯s¦O›]æ~ó/š?nþŽùÇ– åŒåãV‡uÂú´õK¶mÿË^m¿Ïþqû×K|%±’÷•|£ôWJ?\ú-¡TN
+W„?/k.K–]w4:æïu:ÇœW\p•»×wÝeî>÷i7“
+Æéi<+Ö`ÅžÂ{ |Ùneyü«˜ó& Ï©rÃ`‚J<—‡)ìøÝ<Ìa‡ùm8:$ñ“<¬G™ÏÃü*y(a¦¥yØ„rZ™‡-h§íyØÆ‰t%ÛÑ¡{
+/@D;ÚÐŽ0Dagp«ÑˆãXÇ:ÎbZÑŠKêŸ¤‹8-XÆœB+š CÄ%œÀ:ŽCD«8UœÃE¬b"Fp§±ÓHã[A,ÇÎàÎa«bÅö'ˆ˜C§q"Âê|k¸€“HãÂhA:ÑŽ^!Ž(fÐ»ctal¡ÛÆj#fÅ0ö«;<êÞÄóÇ¬«ç;‹±-êß6ôâÒ¸«*Æ1¬âu¿íhA—Šñ³ídçiO¨'MCÄ:Î©4^U×9‡û âŽÝÆêŽµÙÓN«´×h=‡u¤Õ'mÎÓXA+Îàœ:“6†ÁìtT®œÃ	»eÛ³H«{GDŒåqv©XÇƒ8‹UÌãxþ|[RÀNë¸¤žq‹'qB¥£™v¶êJ~Ç…óÎa“1£ÎzÇÌ“;f`ry;Ÿ¼·ílçº[ü¸ˆ4N¨;Š“jÏ–”3n`ûTx{ ÞFóXVi{ë*uÙN¢EåÅZ1ƒLÞ¶“ŸN£µÕ¸vŠ|×NÇøÍtks1Ž9±"¢êó8æTŠÀ8æ1†,`^}B	aóÇ°:v	öû˜Á4âêˆqÖúFT‰œF
+"&0®â°¹WóôÑ8Æ´ã¬ºûóêÞ5)<S8«Òœíœ«ê	~‹8–Ÿµ0ö¼:f'pLÅdÜeTaº—ÆZ^*Î9œRiY-}Ñ$‚õjº´Õ¿†3ªU;§ê›UÄƒy]fÒªíIÓØõŸ«-ÿ)™añ¥ú“{íwüMX¤S9Ì`c­ˆc&°¥H`/°ˆHâ Æ1‚YH¡ÓFšàG:ñgÁÊÆ.´Š î½hDº±m˜ÇœèÃ!ôÃŒ¸±^T!ˆJ˜ÐŒTÀH8Âã‰ŽèñwìÈ:wìÈ1ýC«çÎ´¬.œ>ÑnëVÛö°z<q×É!ïM)DûµÞ³¢Ë¯àÑS‡öw²©Õ7ÎËÆwðçŒGûõ{õ{Œ²¡ž7™ó]ï×?CÒß«?ÈÏòQ}X×HÕ®Òè¥îeñåª—Ë_v½\ö²ýeKÄ	–æ*¢CDÞò‡u~šyõx¦ž<»/©DžM²ç•x¦‘=_3B{xÊ›	°Wd|„<»<_è`?çsú§èº~EŸä'ù>}‹®šìÍ×Hîi…O†"þ’nE8ûå¨ÿÔW¿ª
 endstream
 endobj
-280 0 obj
+334 0 obj
 <</Length 10/Filter/FlateDecode>>
 stream
 xœûÿ üü
 endstream
 endobj
-281 0 obj
+335 0 obj
 <</Length 404/Type/CMap/Filter/FlateDecode/WMode 0>>
 stream
 xœm’Moã †ïþ³¤ô5ŽÓ¯(ŠÔ:µäC?ÔTÛ³“)ø¿‚ÁiµÚƒm=ó¾0ï`Ø¯·ÝüAš=ÎëßÞÑ›Ñ	œ7Ï½-Û1¨Ã¢D9©~Öá1@Óm;­BÁX§Åi”8yþgyÄ£Òß†ØšÑ3Œ}¨pÂÌ¨ )tuPáüª`ì:¯Œ^AU0ö¤ec†Îeîå›3b‡JK—;Á>ö-ªH%B¦ôCoÓâÝÙ:}0P“KŽ6; Êw<*Üf)ØH<òê$:¥0›Âþw£µ'Œ!§*j™¾eþ¥Ê<ð¥š§„ê»ôq¶˜7(?Ÿœ ¢ˆÂHô¶èz}ÄbÍ9çX·mÛnbÇôª¦eûƒøê]²WXs¾¼Þ$Z$º½#ª‰8Ñ2ÑMv^“¶ º!ížè–è‰èŽ¨&º'Z=Ð.yÏGÒ*¢†´ìÜ’FcåüqÀø/'*FçP‡ôÓñÅ³R/÷ÁW¥']¤éNFzmÿ·‹ë
 endstream
 endobj
-282 0 obj
+336 0 obj
 <</Length 2165/Filter/FlateDecode>>
 stream
 xœWmlw~îöã—³ûî'¶ÏowI_j;¶óž&Mœ¤õè[št£¸©›dKê(qÚµ›¢2eLÓ„&^…DùP*„&¤!4Ê4˜*¨býPñ©Ø4Ê&ÄKt_š6í§%ûwÿ—ßóüžßó¿“Á °á2X`~éâÙ?}ã®à« ÷îB¥|¦åz¾ ¿°P)ÛÞgþð_XX®½¹Æüà¯è^ªÎ•]UÇ« @x¹üâ
@@ -961,110 +1135,123 @@ tÊcT(³zæI:bÌ(FsÔ	ëtý~Ó]K4ÏÜ.>1œÇUâ,QÁy”¡?ôOÝ=èGÌ/Û.zúÊš©LŠvêQm¶÷î®+_4
 ì8,M¦›çîi¸;N1424-ã´éˆæùªû¨ˆa¡q½Pž8k˜£]Y¡çM§,– Óó;NB¥O¹ËxÐkë;Æÿ“§\€VÌâ&p%Aã8QÌà(ð‘ó9ü
 endstream
 endobj
-283 0 obj
-<</Length 11/Filter/FlateDecode>>
-stream
-xœûÿ ñû
-endstream
-endobj
-284 0 obj
-<</Length 559/Type/CMap/Filter/FlateDecode/WMode 0>>
-stream
-xœm”Moâ0†ïù³‡HôÀÆ1ùhB*Hú¡RížC<°‘ˆåãÀ¿_ÅïPªÕ =žÏ<&Žÿãý06Í‘ç‹ŸŠ>¸oÆ®äyöR´žïo›r¬Ù¯Ì†Í-Ú/©íš²ç²ývo«Áóý½-/£á[ÎÿR6|®ì=aêAÙØMíùþg5\xI3,›‰ö†íPWRžïÿâ®¯»¤Ðóý5YSOÃõ^ =(xïšòÀ*k:éDÇ©¯j2U9¹ï².ZW|¸ö×{{jh,3¶’ID|ð¹ê‡îJ37Ø>!òÖî*{¦ÙmØoÁÃØ¶ž†$åVÙ÷Lò¯EÍˆð×ªXRx_ú¼¶,¿_sƒ#–á¾-Jî
-{fo¥”RkZåyž¯§ŽÿÄ£eÇSù§è\z¸¦•RÑníH;JBÐ´E ƒ¥’'¬$ØI²SÄsÐ££Tƒž“žÏ ´qËžê¤ç¤@;ÔIfŽØÂQ8‚R™!ã$Ž’)Ž 8F8f ø¥²ü´Äà	‰_rÏ†cÇŽgÂ1ÂÙ„pŒd:8F²ãÄ‘†ã“k8&ØEÃ1ÅÙh8Æè®ÅQêàá„5ôÓpŒ1‹†c‚³ÑpŒ¥~©L¿DHüðLiøÅøg4üb™~zç]yF§‡xº«_·¦»Žíà®ª»"Ó}¨,Ýù¶i§*÷q/‹Û{g¢·ü/5ÜI%
-endstream
-endobj
-285 0 obj
-<</Length 5343/Filter/FlateDecode>>
-stream
-xœY	#Wyþßë–º%µZGŸjÝgëÝiî{5£¹öš½}ÍîÎfwgÙµYƒ‡˜ØØŽ10˜Ã6§+Ü¤°aBŒ¶Á8@a§œæ
-SN9¬&õZšk×•PhªF¯_w¿÷¿ï¿¾ÿ  `á  Žž8DxÉí€» ”æ±…ùÃ¾{ÿ³@½ ªÇŽ-Ì³O`/€úM ˆ;¹ô–ógÍ9 õ ðØ‰ÅCóïë{Ï9 Ï§ ààÉù·œ†
-Ð8 š?¹pÓËy@ë 0áÓ‹g—¾wôC× p'`( Çñ2PÀ aWXp…]%tOótRñò¥1|Ë¥e<Š ”/C ÜY«V;]•„®w†Q­=³YrEãeE‘Š7Ç‰)„‘Žíb™Ó÷ùæ°]H5XJô¡G4bMFÇ=Å6%ú.=‰~C7ßçuÒl C|å"Æ<”` @‰$:+Õj­³’HD#f&€%ÑmM–K²,I¢\.UkŠ™Ìê<®•ªÕÎÎˆÙ,‰ò×'¶÷ß²àŒ…”ÞÂ™ôX$Úsddòºœ[´ŠV»8-v3öt¯¬„…l¯ßÏOôŽ…èáx^ál¼âddÈ—J¤vÿ@–iªÇåËÅ•¸²Wˆ*£®ˆÏ@ žÁ<Ì¬¢ÔIÀ©Õ¥<€Ë%YY—TQ¤ðê#ä8æÿk2“tZ99É.;XÊUŽL:”½ÝÕñ'Ä›¿’ÝVÞ¯x2ÖémþQvYí~EK“«q–r{Rhó´Ýr œ×ª…|-3Sþä¢Ìãuå–ŸŒw¸ÕBâQI¢ÌõÖŒžq­Í-ÄV.bó AÀI¬#.š™p ·A§ÊÕjgÅevë¯ß¼mä`§ÙÜ|GzõìD¸¨ßô™‡1ŠÅƒ…^šÙa$»§_-«é¾ ßÓUDœÂ¥²á>‚e /S<ô¯Y\´³ÖÚyƒæk«8…×fü¢ÑÖD,#Øff‡ßº»{w—?é6ÎY
-Eª!´Ûasg›?Š¹­ïý9:ALÅvÿø©A!’óFS^Ý/06µšf›·yÊ2>ÁÐ‚÷·­ù¼ê4±€ @}/C¶-iM¨.!Ô„2qE×$Ó)ŠRe&3é´hC^l3ÈqýñfÞÁ£ ²I™æ7j{ñ'|ËÈ¬-Hè	ÙE|æ„	½»Á`Þ×Ršm4XÊ%£;éæQôºy^TÚÞCô6yp,/Ó›Y'ÎQÉa=Q–Qi×ù¡‰wìÞzÃèè…éXFrø“Z8çñ”ù¾ssW¿m ëìžýFö%fº+9)´¥gl®móXÂ<d®´yc7²YÛKk	¯ZtÊi±*)öQ§•òì(×EÝQ¬YÊÄ$«»At¡½ñPæ»å@±»¯Î*™uˆÖëF°u|uÿcžD¨7Ü_þSËs` g2fâÍŸ\V>¬²šÅÝìCÅîu÷1S.ùŸYQíL}A(¦8V4|…:ÌÁµõ6b–~ûËj5†¬ëf3ÓÒ¹ji¤l€ÇS-M%¢QcÚÝö1I”;tMÀWÄ#¾P<9|jÌ/JZoRKQ¯C±Ø,NVt_?¥e]6«+ }lÿ>wjâT_º'Ž¼ÇáêºZOé©XúeW¨0”ñÛ([Þ£e¼”´¥04—6ÛlÕÞ¯xÓ.»›ó»Ô¾lyg1Ù\6‡Ó<2è«•’ÊN1¦*ª=$„èöR¾RîÊvÔˆ^l øßñ2èkz¡k™BQÊµêÚCµ´ñTŸÛþ÷vÙ££™’ÀðçMgxÆ“CRÉ¥¸>Ë‰}‹þw¢œ¤ÑÌÔ$ƒ=Ê©šÉÒ˜´PŠ¿ù/wzDÌ6 ´rßYH¶²ÆªE¸ªFRXŸP‰Ñ£<^Ù¶ÓªÆ™ï;ø'”Q89Â=åàÝú3vZÈðû¶/è5L ùd"+x«‰÷ÆdÚ4c·4o÷Ë4Ó`÷xÓ*ñ:u%‰11((ë¹r=¬é¹ujª¥ß„a•²ì×v^L0_s2”TJ(tžÜRìâ Žå9=’SÕ&ÌXÔÐ7ã
-ežá,»‚žžÅ{ß1îà«¶ÔQ&±½¿6VËv7‘,€vQ4¸ÜWZ@P†›.É¹­œ¢3Ï:X1ûÉ\¥|M©s‚¥ï/ˆOÎÚØæ_H2mÇ²ÉD.«'³Dç©•‹èG˜‡
-€¢×ŒÌ@N¦ç¨¶Ù+µ²¢H,\	P«P0]ŽŽT% ëR1.û‹{{ôa‘µmsŽè±„XL¦Ç
-ZivLµñ_4ErrØçV+«Æj©ÊdBàÃ›ry¯×¥ºm6O¬S¯mïQ"—€ŸÅËà_Ï%3z-¬09j5S|­.qÑ@2 Ø¯‹à›Â×qª?é‹Û”-+ÖôêÉ
-Ï=ïÎö„¸¦_V)+±5e­˜‡Ä•1vsŠZc'(¶ýLÿÈ[w^UtÇü‘¤wFÔpÑ[‹Fò‰7óÃçfç.Ôƒq%.û½6ŸÇÊê“»(žþŽ^r? ¾¯¬Ç¼Usý	#¡;8Þcžu`u®»g*jcÍŸœœ#ää4k+äyÐ/#
-mš±Úšß¢S…ÌLù·¢“6¢žS}<ž•ÔÎÔçe‘D=Å•ßS¼=­ˆ§ëÌÆý72D©V%~_KFYcøÖP%v¾µÊ»;šßÈºí$+æ\öçm´ÍÞaCHçÑqÿEX±Šv^Üâà5Ýó½Ú¢&þÈR‚=âuSLküÌsVÁŽÍ“Ó,¶¸œü!sÑT¿[#ø Ð¼Âøb³n¯EÍÏ9lbf‚¥Ü>ô³ˆL›g¬Ü¥»T‘fÇ¶r}¼m½»¢¸VS¤²Ý kTMtT4Ó÷Ýw{"RZŒ„öòÑ-ä™6'§º9Ë§ö5c:ÏS€`de2Ã‡ˆdŠ>€kÑ–Iµóèé¤7.a^Œ)åt¹ýlEÔuÑöêùÞ||ç9[ ÏãeÐ.cê-‚^.àZ™)fŽR¨QùÝT@å¯ÑZ>ê± ÛÓôñ‘¾ìEÂÅV.RyŠ‡úf.¶Í.ãb$Æ^„q×)“,3³Ji{ou2OD¢6»U²È^ûÛª}ši§•’"þ=ýÕñðyel‚¡e!g±âžáX f¼
-§©ŒI.$Ä‡3œå½H‡mÀ×¯‘§ù¼"bv‚`’^¹ˆŸ&q©å£-6^++a@<–DÃâbÝV£:ÑõGÞ=U<pa¶º=hMÏ	•z>;–S}ÅQÝÛ·Ûä*$$Û>ÉÙµ•¿êcsï:Xñiµ?8{ÆÃ‘á«úG†,‚}VQ)fjŠ¡íÇ½|DÌÊ½èûT„Ô‚
-*#mKós§¨{þx€2ôx/^¤ z™.Ûñ…‘Úq†PÃÉÉŒÐÎ'Ñ¨$Ë«Š.\·Ô™Jîš¾å:9ÛõuDeÎgŠ•½r1³H«Ú'U™Þ(u§­&ÛŽéÁÅÝþÚ¶‚Bÿ¦P¿·‹tÈÏ"´ŠêñÓë‘o3ª$äµQUx
-Ý|ôýs…}7Ï”fƒÜˆ>'TFÓ½³z¨»‘ÊŒw‰ÝîêÄ>~÷ƒgvÜ6ß‚¯w<Ô{zk}a( ¦<£žbÒÈ®•ŸàePH-²’Lx­•pëø®õã÷¼j4Ñyüþcž­e%¿hÌØxd©0srrÿ×®Ù²ãDg“ÂT›Åü//oä/BYXc„¿ ý)«CÔÑLÅm³ÜaºËb‘‹4¢s.÷-ÜåwÑìäƒszÀ«R–©I–Â—ž
-Ä•ßã
-þ„ GjÕRËá©Ä¨vyœh‘vÝleYhëy•ÁKÓKÃþÑîŽª§rjïÖ£å@%Ö3¬e·³å½îxW"Ö¦¼~OÆëI{¤nGj{bK¯¤–ú“s]Éz6Þ—¼c‰ê¶š÷j5VA¯Ý7Z/¨h^í÷ânWÔ#'€[¹ˆãÐHõ£èëùg3Ã1Jðµô#ËßÊyI\¥„B_t`±ûäöüTàfƒÖ„ÂYÅU`h|<¬¶Ï·i_Bè9µ}ÿ_Ö5%§oènD|Õø7xXW4<
-«b{²™‘Iì1TUÛD5kF-ÆP<ug÷D: Ä˜µxÐåúœ•BVäOˆVî*Ó^++'¸G].þÓrº4ðr%Îk‚%(Qr9©£w’03i¢ßK/ª>Ñ,-…š§+Ó%OËbèév§ä2‹!«¬—Ç¥¢Ô/o7;•šÌ‹Ó~úöý-½×Ä
-Ed)rnÎtë£ï¢ÞŽ{<ÍNN’Ø<„Ã—^Dj"e˜d+H—žD¯5-íŠ—	ï¼2òKá¡mS­n%ëb†$ÝêÉ¸9d&M›î´ÛÎÉæ“i·½ùz«uC’¬Ñºi°”ä}ðëÍ›æ¸æjU£‚ÿó_n÷pZùh	/¯×‡m©ZÌ«+$1ÈÅÆì„‘VÉ—Íw«žÙR§í>O×ÙpÚ'X®ò´½W#	ÿQg4«Ù^´CæW¬á°í%»¯~µ¾	¯@ò†¬ò3åJ€V¿hÝ¡^ßr]±ïÍ³±^™÷&Ùóœ”x†£Ù~{°C•rÞX^Q²|ÿ™m{n©;í2mžbœ—îTœ4;Áló$”C®Ä×y§¾µ·k22+qþN‹'%t&ª×”Q‘¬²äjS]cÉ<Fõê|ˆ¯;·r±\w(šSCåìt-èŠvmë,NíCòVwç@(UfKÛ{‚©-{ùˆ¯ú"®ÆE1îñ§‚N>Zœ(ùzkY¯¦äèìÓ2	_"À;â¥z©:×Mˆ%V^ÅàðÝ‘x¤ë]ˆQäÕ¤ö„“¾|‡rû<vdìÍ¸Ëï>}A©ŒËÎKÃ—žëpÙìž˜ù9‡Ep|,ôUçNÆÌxƒ¡œÎÃÕ¼4Õ#hÜC¹½èçmzéE¤#—“žàïð2‰;„kn¦7«^kÒWr‰f3ºkÛâ°Ÿ“R¨7ãæüƒ•®?''ÿ'-pC7óÉÆá^Ô­‰m«Öšß©5âÉ©
-ª®Íùš/\ûöA²?€b ñoÂuß8Ìüæo+ÏÇ9H:ÌìÕ¦½VNØÿ-êrq÷ \’²ÌLš)ÉÓüoÕCÒK»Í¿jw¾Ðk¿ÖOúÿØ–´©Ó¥–wöuÍ¦ñPÌj·hvÕo¿óN‡<¶ÖÝŠ•öÅ‚ÕX8¥©œ¦š¥?°¯ù¼*l	“^p;ç×:Zå=,=Êý+ªLE™” X¿ûÐÓ6§mþCN`ï¯5†òw8ÙKM±´ìÃåKßö‰439e¦TuvR
-˜˜J a5Ÿßˆ—!¼á´ó9µ©NÞ”×íRåJ»êE-Tiy«]«öújVm‡•(ÐîÏ×ó•ÙZÄAá[½2Å6Ðµõz¦æm¾Ž°!ÅÊEü"^†nÂp[OÜ/òFeŒÑ}ä)Â´”õòm$]x_~ ÅÇY·We]§æ›_kË[ì?2•ög«¡kÐ©q¢&’RFn>•¬úƒÕXšù`Oê%"â/(ª©]Ë´Ï!¤Æ
-ñZÊç¢h6“¦Ešê<ènW"™—_FŒ®ü™á#`5âÝjéð±ŽÎJ6_îtfù¤N~  ò[¥]“Ç—Þ­£ï@Qäwxáñs&òý“¿öÝÓ¼­ùªé!ú4 ˜“ÙÖ{ô}Íï˜jÞvé­¦‡Œ•6~
-èU(QãPÄ#§~Q\…þ!„¨!OC Š¿Q|58ð+`Ã	¿Tt"è¿ Oà_‚CÃ_?å„"ºè+ ¡:ŒàwA‘ª@ˆH£W€Á_‚"~Ò”Šø5°áñíÀáÃ`¥÷€j@ßE|/ÄðÈàB€rC/‹þBøU`ðÝPÄ¿„"jÀ( H°>…4‹B¿Ã|šÊQ'¨‡©×è$½D/ÑÒÿjŠ™Þfú°éÛ¦WÌ¢yÉüæf‚Ì>æ=Ìã¬Ÿ½†}˜ý¹¥dy³å«ÍºßúëÓ6›mØv«íÛJÿ\Gøûjã‡\óðY  Ñ x˜hË#pÂÃí1¾ÚSP‚§ÚcBðz{l‚¤µÇf¡¹ö˜i´Ô³ ¢ÇÚc<Ž^hmÆh9èÂßlí(‚ÿØóP¥0
-‹pÎÃ8Gá,AJP€"Ô sp Óp–`ÎÀ<,Á<„`œE¸àñÎ0œƒ%8‹pÎB’ÆZKpÎBä!G5ŽÁ9898‹pÒ˜]„E8
-'`ŽÀ"œ‚%8y8qÙŽ©+dØpÎÁ	˜‡3P†¡ eè…9˜ƒÞ+žÏ^öÆ•gÚ|·qï,7¤
-mÚá(%Còp@rÐ9(A7\ýgì|ÜÀŒŒ–ŒÙÃ° 'gß!X„#‚ñH… §àä`ÎÃiX€9ãÞ‚0YyÚXû¸!ùA8¡öyÈYŽÃ›Œ½Fàœ¡÷yã)òÿ0„`á¬±ÇN8óÆŽ- gÈq`Á¬µrÃ˜!÷É.äŒ‡K8g<?Ú¶®Æ:‡.“‡È±n€³Gà8,À0¹5ûiYÏÆ_n“½¬ZÑ?¹ÔF&khj#6«ïën!_o[93A{	n4Ð''j=Ñ’œ’`Cp:gàEÖ#ZkùÉNhÀ4„`«±ó©M+OoZ¡cu+F0[—ló¾ë–B0"˜ÎÃÁ¶EÜØö¯–Õa¶ã%èÐÞxZ9mø[Îâäÿ=
-yØ
-u˜þ3ß"¹Ùø¬ÜO~«~ƒIdEƒm0AvÀ.Ø“Ð{a'LÃn  u˜‚l…=à€<Â7Ä!:tƒ¶ÀUÐHÂ8Taº`4Œþ}'¸Ø#×.åN?:ÿÍX½
-endstream
-endobj
-286 0 obj
+337 0 obj
 <</Length 14/Filter/FlateDecode>>
 stream
-xœûÿÿÿÿÿÿ ðú
+xœûÿÿÿÿÿ ÒÜ
 endstream
 endobj
-287 0 obj
-<</Length 543/Type/CMap/Filter/FlateDecode/WMode 0>>
+338 0 obj
+<</Length 534/Type/CMap/Filter/FlateDecode/WMode 0>>
 stream
-xœm”Moâ0†ïù³‡HôÐMbLhB‚@$ýP©vÏ!ØHÄ‰òqàß¯ìw Õj€žÌxfÇ&üñ~x\›æÈÓŸ1}pßŒ]ÉÙKÑa¸mÊ±f;¼26·h¿ ¶kÊžÊöÛ½­† ÷¶¼Œ†o9ÿKÙð¹²_	®ec?4u†ŸÕpáMð€üL´7l‡j¸Rü„á/îúª±J‚0ÜY“5µ®"éAÑ{×”èTYÓI':º¾A¢ÈTå ä¿ËºhýâÃµ¸ÞÛSCSd™±•L"¢èƒÏU?tWšøÁÈð	‘·ÎpWÙ3MnÃ~Æ¶½°’bÿ”­ñ¿‘“-j¦H„ïOÅ’’¯GŸ×–¥@ôû¥17H0bÙîÛ¢ä®°g–qÇ+Zæyž¯\ÇâZcÙñTþ):Ÿž¬hÇ:YyR gÐÔ“Ú‚´§yšyJsPŠØ4GlzBLžÓ 5:HÍbR%É,[T™‚v ©’#‰Û€8NSüÒ~é¿ù¿¶‰øe ø)Y?£Dü`›ÀOÁo£~JjÂOK?ø)É?q¿'OJüÐ]ÉûÃ¾(øÍ„à—
-ÁO£¦‚ß»«à§1™’÷—ÞwXÁQc:Ç)ö[ÁQËtpÔ8
-Ž³ÔF9uîXºÛw¿åØulùü¡w'¼²|¿ÅmÓºUþã¯ÿíŸÄÑ[þm@
+xœm”Ioâ@Fïþ5KäÀ¸ÝxIB
+K²(D3gã.K¸my9ðïGî¯ Ñh€^WuW½^ð¼æÏ¦9ò|ñSÑ÷ÍØ•<Ï^ŠÖóýmSŽ5Ûá•Ù°¹Eû%µ]Sö<P¶ßîm5x¾¿·åe4|Ëù_Ê†Ï•ýJ˜jP6öCS{¾ÿY^Òäz¢½a;TÃ•Ôƒçû¿¸ë«Æ.)ô|gMÖÔSs½H
+Þ»¦<ð@§ÊšN*Ñqªë…šLUBî»¬‹ÖM>\ûë½=5´@–[É$"
+>ø\õCw¥™kìŸyëw•=ÓìÖì·àalÛOM’r£lû&ù×¢f
+Dø>*–~}^[–‚ß/¹AˆËÆpß%w…=³·RJ©5­ò<Ï×SÅâ‘Æ´ã©üSt.=\ÓJ©h·v¤%!hÚ‚"PŠA‰RÉF¬$Ù)â9èÑQªAOˆIÍgP
+Ú8ŠeÍó¤æ¤@;Ì“Ì±…£pÚ¥42C8ÆH%SApŒ6 qÌ@ðKeø-dü"!øEè:„_$õà—È*ð‹%¿;ŠŸô¿kjø¥	~)vB‹ŸÄà§á ÅO~N[Ëù¡3¿;¨á—àü4üb!øé»pr³¦«7½°û]/Ç®c;¸æ.öt‹+Ë÷—Ú6í4Ë}Ü¿ý[Lô–ÿóq:‘
 endstream
 endobj
-288 0 obj
-<</Length 7465/Filter/FlateDecode>>
+339 0 obj
+<</Length 4898/Filter/FlateDecode>>
 stream
-xœ­zp[×yæwÎ½¸@ €$Hâ‚’¸ )‚$øð!ŠO=P/@$õpô`$Ê–k;Qìx×eâ„éx»MêNÛmÓMÚîö€j&NvÓqÒÎÔ³»ÎlfM2i3É4u<ñfâh·ÎFÀÎ¹ HÉrÚN©1ÎÏùÏ9ÿûq}A Xqº—[Wö×†Í þ+€_ž];wéL—ü€¼ÔØÎ]|âlìýßjÿ
-h;¿š_	žø_?ÚE ýçÏ¯æ-æo í# ç/­ß8—:€ö?óâ•åü'¿úï.Í r—ò7ÖÈ[µŸ:ž \Î_Z½sü;N ã%@º¸våÚú¾/‹çnNÓÇ×®®®ýòBÇu ûE ?Å¿ôosØ‹½t o ¥8}©t‡Ü.Ý)uÝ[+Ý¡¯“7JwJs|•¾®¯ÏaCèB—°Dÿù!Â}<‹_lÏ“m¯¥É³Ûë;î¤_¹w+ýŠ~nÃFzðÍÒ~PJoŸ§í8O»wƒ¦0ÍLdeæeÔœaÒá¥ëõ²ölî¬²q4Ãh0ÿ%3ÌX^VÏxý~†,CZßA:—Š2¢1%w6Ê¨¦úU”	š²rK¨w!•fÎ´’Ë¥
-´>*…4£é#7fSM§ó+L\¼±E)MçRÌ¿Úìç³[5.’jVM«©-'q¦s)•a1³šÝrŽe¢Æ„s¥3ü>æN§Ë^eEa¯,21´´ÕNªÓËLšÈø™Ì:žñ«~ïFFa‹‹?Kf½
-àÐ@6«ìü
-k_ÌøËO
-ëæëÝó•ÅŒrVÙØÈ+Ì²˜Éy¦ð5‡ú9ÔŸóæ²Ù¬—Ñ ³¥—ef8²ŸÙÒÞÖÊ¡Ö™üËv,sŒ—M8“Í®ä³ŒD²Ù2Ye…¹Ój*e&M™P˜Ì¯(LN/f˜¬¦˜YMyýþ,#¹(“tq3!¢¬ä3)…/rv½ùü—É¹‰efêô+ÌœV6”F"…nS‰¡ƒ™Ü¢7(›Q³þ¬Â’‡3ŒD¼\.eR¢LÖXU:²j¨Ù¬±*5¥*j*Ïè™³Œ,3’crg”Ui
-§¶&½ü²ˆ3
-?%sYŽ’×©µh[U5HO¤:ýÛ†cÕv’Í8…DT†4ƒ9ebCÍs¥êÂ†—+„)^–Ü‚j~Ü¸¢ú!ÛY`1Ã7'ßkS·5u«Úab1ã÷ªþl§?Êjµ¥l%?ev‘œ¢°Úô~€ÂjÕT–ÙùÓ¡ŒÂìº¾šÂìºP”—E,o¨yæHç”œÂjJ²:mæH¦ ®Œg¬zU½eNmæ`fæ°1éõgÌ©Ï×kÔ¥f
-uuiFò)æˆp—c4˜*Ôò;¦q«
-‚‹™ƒ©…_kïô«Œä+°×Xç[hPŸÉ²Úô³§§rŒîVÖCTX œê8#i†±-Bˆ®-—†èÄ‘«SSÊ«QS¬Zer.¥ä¾ØÐ@à€©TŠK ^M1’/Ô›#ìco[6ÊÜZ®H”y´ácƒV |lÔ
-›´‚ÈG¯V0ñ±Y+H|lÑ
-2[µ‚™>­PÅÇˆ¦VäÏ¤ÜÌ‘ŒªÄ9É½%Ê´‹îíÅ‹Ñ‹¡íÅ«Æ¢¢ÕFÊ'#ù/¬r>wòç×
-P"QÖ¦U­@ùÐ
-ƒZAäcH+˜øÖ
-Ûµ‚ÌÇ­`æc§V¨âcLSFtƒíÒ”kÈ)i•‘·‰<wÂ·ÙnuEXWg”íÑeJyˆ6Õü€Êûûbx9÷=j¤	nqlOgÁD\™î¬Îe|‡x†Ó«)}:å}Ê8ÞÉHä=iáópÿ¹žoÇÇÔB/qq^û5eD™zýéü@”%´˜g$Ê~*#éå(Ô
-î S¦xH`48½±1¥N©y%sÆË£®šÚ ÄUßeCƒ›yÔƒLêhRÌšŽ¬nÄTEÙˆ²áÝhJÌ8Ijª‚­°)Éƒ™[¢bR¼·Ä©)›â‘Ö’V6T}‡:™cRú~wÍñhgd%1[Q™)_YÌ01÷2S:Ç#Ýý{òª¢01¤Næ¼*³¤'yÆ²¤õ[rÊ{]¢1UJç¸2LÁ<3=p*Cœˆ 'BæVÊ‘ôÞ]Ù(©ÈBQf
-•e¡ŽDÙèö³èë“ê¿”kql[„œCÒG21eDõëù¶<©pºÊª`R™‚Ó;kC‰ïeíem©Üä÷î $]QWŽ8÷³\QqRS•—â$ó¤3‹ÞCÙŒ2’ºI}$ÊöíZ=ä]ÜµšzÏ½ï·#­±¡Èû]8®±áÈ†¢ŒpÛx8*“Ò1Ö‰²	enŸ!CòyfSSëÜ@UeD‰©åó'µ‚E¦*[þ™&=õ¯eÅœ'ÇFÔ¯‡½ø³e:§´†"©ì×
-Žø¹Î8¡en¶E0­1¸·ß÷pgŒõwFÙ‡ÌÏhz'KtFÙ¬Æ;£lŽKqBUbÊä†š¯Hk^ãÍæ"Q¶ m“‘([Ô¶@8pPÛ"úÌ!m‹è3‡9ÎT$ÊŽpå88Æq8ðˆv@:eí/"Q–ÕncnI»EŒ¹ãpèÇÓ¡“O‡Nq<:ÍïœˆDYŽßÉ<¿“gøXæ8û#Q¶Âq8°Êq8p–ãpàœN×x$ÊÎëtqè‚N‡ÕéâÐtº8tQ§‹C—tº8tY§‹CW´F¶¸¦?±d$Ê>h€û"Qv•]JE¢ìšV eœuä8×uRÆyL+`tûÔÇõ'}Çä;ž0@ŽþkZ”ž4@Žð”r„§µÆ¶Ïûþ¤£Ø 9úMäèÑ
-¤ŒðŒr„g#|T+`ïöyÏéO:ú¿1@Žþo£?¯Há×#l Gø˜¶eÕ+[&y·D*LdT¿×ŸÍ¦"Ì¼Ê„ÀâJ²ŽÂ„ @/Ó! 
-µ¨ƒ½É=®ú:GµI d @ÏA Dx‚@N‹„d°ZÌ2“ä‰Ä~Aˆ'ªGˆ‡Ãª,'ÂN§x†¼úÌgÄôÒß·ÿÞ»šOœúÈçgþOîOè‹w/’›'?üáâñçWWyë­b'ùßoñ|OK¯ä›tUp ’l—ˆN…@!œ!Ks&‘RzœÎ[,‡Åáp4:$kSÄ)ÇÃ¡PX•$BâN5¬Ê7ô—Ñ"ŠMñâ×É™¥Ùƒuo^ O¬­õ>:0x®xnÞ]{í5 *€;t“n Ks”rœÌó{!8+g0.¨ÏÎ?Ë·{¾G,¤Z“^€<ÂÏ:M	—ÎöÆD".«¶ïVox˜ó÷N)NÞ&·áB Éäh[ ˆ&Ã“s0™H„,ÏÉDi”æç$"§…yðµ¸ž \p…³µ1";ãr¼¿?ÞãvÕ×Pµ-Ä%ïì£}½!µM’e·Û²±WƒGbÉYíÀ©žÐˆ“Öù>H÷µvw´Tcõñ×è­¤/züèä'âaßùß%¤súd|l´3ôfÐ¯ëáÒò]rµhA4ÙÉ­À ÓD(E^$@ó;AƒÛÞâh©’QKj%«;âiõõŽÑ2ážþ~ƒ2ÉUï~}áTtæäžÅSÑ™SÑƒñþþc;|âÚÑ˜ñ›L­§¦Òkã©I.ó	€þ5ùü'ÍvI@f)¡\v&‘
-Âq«Ì¿£Ñ°Š¸wºÝžxÂ¹T!Ôß§J’,\ÌÕRBÄšæê§Ø	‡šj>4ó·ËVzí×ÈŠß÷MµµMùˆ²j$r`¦³s&P|W—Q°t‡¼BnÃ‚v¤“É 1‰!BMt¢‰ˆç$yÂ2×3ÍË„Ò<·Y	T¿·©¾ÎÚnk7‰°‹ÙêŽ6Iâºíë	ÛBt»ê%Ù/Õ»êÝîxOÂ#IDñíë«ù¥@;.gÎœèHµZ¥â_‘¶‘’ð´´Ì“?ŒwÛœÕ©bòÑüøi±Åž–ž:“UJ{]Žn·>€<EnÃîd´Š€X*PZ6LJËIEÊ8‡ÉÚÈ]Ã°BÒÍNðå÷ZÅ–ÙhsWvÕf}£ä“ÚhUÚD÷_+ÛÓWu?XûbSUwƒ]Ì$ý ôÄo€ ×]y.Å<æ½‡ÐçÞ'›ôxÜ­ÍÜiöÚš*.â2ï2KO<‘ˆjB•¤pO"Á¨¡®z÷-Ýaâá¡:ÁšÛÜkÕL]h>¨¹zšé>ß[Ùe”Óqw`°+ëúN¨­súdÏÞQPÐR€Ü&·áCÉÙ@£U0I¢@	—©(žœƒ$•ÍÁL¸=€Òãs<Žäe¬bÞ¯´‡”˜?Öìõ¸j«Í|ÄWeN$u'3qA’„]ŒüI,£ªÞ©ðØšÆÐ‘®ÑÅÈô‰=¡1‡àÜ{ÖymP=ØqïiV÷Å[»þÆß¶ÇÓ:›<ÒŽM¯g{Úý£EáôYâtþÏP[Çd¦{x¸Tâ¶‚wé!@Bt
- ¥béŽnAaìIÆ<¢ ÌBtÞ–ÞÊ±‚ ¹Éå4K“°iG}½¡p(Ô×«Gµ²A¹êÝÝö¥?Øs¢¡Ó“wŽvÄµi-z ¹£>¡„öì	Žõv²íéT}˜êùšÆ"É ªtx£-ÍíõþQ-:ÁHéH†~^\HZˆD	$:;Ãü‹™daiÎD¡§EB©®'C%ºÙµ@ Âs[Ï&]—½¶¦ÚfµT™ex‰wÛàúNu/ËqY8OñîÀ_ëèà”m¦}ŸïIÛÓƒB³¯¥¡ÎÞ]µ7VÓXMìƒ¦ßþí±âOêêZ[«ãUµ÷"ò?’Û¨‡Ê£M£Ãpè½O¸]-^—êV9U2êIýñ¾þ0êcù²;,îwn1M÷{A /Ð×áÆ©¤ÅJ(±\f˜k1“l®„—sÜ<„Ó„“s1™Ž›æ½É&PÐ.f“5 Üp;œ C¶z#q.âŠíè)K;rtÜ6a¯mÒìMn¿¿Ãì8c[>J>7h:xàpµµ¯¶'rx¬˜Ñ«	B_…S_´È‚@I%.Õ8Áíøäœ(Eˆ—O<·k2›´°ÁVç¬HI§–eß'ærôÝÌ×®ÏŸ\k¢¯[ùïÅ¿ÿÉÕ'+w›ÜFÏ³¡Üô |/å–« hºFžÛQÈ‚êäy£‰e1|$6Ög›ÅýÍûcäéÀž}¾@ñ¿­¾¡z¦3Vüç½ô@þ3yU&ÛôzFg”
-§ï…þ*TÕ9ê8gj‚¨	¿Lâ²ÅLÒ[MFÍÅ¯myj,Z|n¬"Oúcr¼²äYE,3%Q$y^j-Ï™e“P9¾AgÐ8ª¬-;Xó””vqx?³¡Ã¡¡=¦®Lp´_ÇæFEqÊµ_›àÌOº÷GæíZ|ß€£µ~§vËZéðú*ê0þ;­XC·TðÊG¨„%ÏíœË&«	lVÉ„:R'ê.Ö×ËK^û”s÷Ú¸ôäÜÓ„ØI’¬žª½Žzáî‹æ*“ÑÄ}ÀSºƒçqV4%=z¥• *›`%Va;Àâ™t7†›ÝA[³»Ikq7jüW¹ÔG7á@T&û«ˆ‰Wø&‘šÎApZ/~!Šä´T©€U‹·©¡¾Øý²Q	ë×H²ËÊª`Ämõ >ûg§?IãS¿6?têÔÒÄã¸zêòÜô:Ý<0¥kfÑ¶o`ú¤F›JD{îþxb¶oÈà··t‡¼EÞ@#Ï#nÂÝO ºŠâq]îgL¸êuµÕf¤q»Þìß)fg9š}n4Q6‡éæ©èølŽ›ÊQ[*áð9Iñug#W=É›¨ñJW@ítVt%5P"ÎqùoKÉtº‡ôÿjuð?#ùe?<²_VŸ%Vÿ®óg5?“PÝÜ÷ÍÔ;)~~4º	…W³ÞZÓ½jVïq*Þ @q46T¼\Ð‹B½˜­@Dzû9‹²—V‰fÑóüþ¼™R"Öw¸^X(þß™±¦ÅQ ›ÅßzôrâR/9_ü­¾‹‰ÄÅ>rþîùT`!ž¯€”~P:M\„žd=!˜ÖmÀqÌÔÚ‘Ãýý	u‡ÅÕ[»eênU[šš—þ0V7hr7†­Óke9þº‰Ä’‘†:£j‡À%JoRf·ÔZÐâ)·tñÝ%»“_*ªÀ›<YPŸ=Óg²˜D»ÏùÕågÌVy«Åù/Õ‹bù Ý,þN[JUSmdùî¹»¤}¦øGdé3ÑËZñº~o’?ÆÏèïÂ„>#÷Ûx(2´KtŸ¾¿«Ë&- L0ÕñÆÎÉ;;ù¦§vÆÙIþøÓ'N|Ú°ßa€ü€¼jø“­¡ ³œË“s©0YêF‡hmØÝŸg¦f¢$ŠŽ€ó“sÅ»äâÔ50 Å¦íÜômú*±øQOFLò™é,áå+<==°’MVhDcÐÜN!É!Ÿ˜ë¶‹‡´]I„¾úÖ¨Úõ@¡ð•î··+û6‹ð^•}¥"ä½*{A¯ìŠS®ìv˜»¿dÚQÙ‡UYÝÉï;wvÄ?:„ú½Ÿ˜»iàHT¯kúvvÄ¶vÿ(}õ/r-‘¥c¼¦I–âàBm ,Ý¡úZy|jöVÛxUÏK/]Â9®…un£Ç^c1£•´ò:×ÔÚ.´äJiu¯•;p®¿{é©™£õÑð¡Á“iµmz°sªÕ\²¥oÌÏ½øøTo¤}|tå‰áá“}JcW[µ¥;äÿÑ—ÐÉéil¸¯îÎÝWw·xÝõf	¤óÁºûÂ[¯¼Ë¥÷Rk¡žÖÌàð¢š‰÷Îµv5NÅ‚}-ÝÁÙ®Þá³¶¡ÁH¤;•ÅÝÑ¦éÄžÃ=½ÑÖ_·7ÔåŽ6O%†Ž÷>Â»å-r-H${y=Ød£õÂ¶$õúuån;oáZHK™ò{‚¬H²,Èo/¬hsù>m¯3âèh¤û}Cƒ¾¡z¿wÞvöäøµ£]m‘zgx"Û“šl´kÁ]ñ¾
-ÉÐƒñÞDDñ¸X.x¤7œ¦é…rœþ¬úíº¹ï‡©â·@J_+u‘ê¹¬;µ[D½¤¡³<œ¼§šÓœA·Ëf•M<•qe]5z·+HHµ+6O­'˜j´Y™Ì¢èPŸ/¾©å¿!ËƒòPBÞ*¾íŸQüüÄ~÷#Ù2ä7è&Lð%ùW4Küzš»•L09Œ¨äŒ<sÍ?Fê«éæÝ-=_EJwè}]ød²Î¨áEÚFd¨Ä"‹åþ‰$	½ QTæª$ÊKv„¶9+±XüsesfsÈ<ïMÆ RŠÂÍÊ®÷ßMÖüÛ–X4t8ô¢ß&ûÞ«èOìl³t£0òUÂùžÝÀ¬4_^­×j·w{“¼+ûƒc»[Þ‰ý˜wb±Ï\»7ZÛTMêô¶¡éKhÃprÀf¥zqe‚(˜Äs÷E‡r#ðµ¶4óQ%£´ÉF„xÐ®3Põîžh=Ý}üÃÃÇÜ±ú±ÈH~< Îî:ƒÏW}0pÊö©ó/>>Ù×¡ùC£+7F†Nõ7Ø¿,þ°•›9š r“~VÌÎ0ïb†7X”à&(]šãõ«˜+[;Ïú{òÜ®#ðªÇYv…DÜ©&úq!.7U,÷AËÑÄðú3¶$ù^­íî×’» ×Tád€¿ˆxž—³Ks’i»äÙ]KÅ¿žþýüýë i˜{v~oñÛct³øqÝ]#ÅWyO<RºCOÑ—`‡²ó-en÷[Ê:ASƒC©SªdØ‰]Ú%óÝéB—=ñ]¾;v}òÀjoìØzºï‘±¶óüwÚöïŸšÙ¼>1þäá™O]ŸHœ¹>˜¿>|æúPî1Îë!€î£›÷×K¿ºxaxÁk2bc_ÓŽ?O7‹/ö]êï»ÒK.ò—Ï ˜¢3Ø¢[\Žie<Ùl¥; 8¸³9(Hwî(×n8[UO}‹Jg<îFƒ»Q)×x¼±ýüäCÞ‚ûòsgÈzAÂo…P½ðÝ?ò¥Óµ#?‡,¼É§¿?3ø{úxpzãîG‹ß1·_á´üïäß,~0'ï~ôîOÍ-Â›øZé;¾´ë¢ëbé5¼•D ROéJ¦‰	ò}É1ø¨apå;AñøÈo”Šd#´aÒ„ùøh5|ä3¥w|øGh¸„J-è%ï@¥wÇíÒèW¡â6n’W0L­ðÑøhƒä¨%·$ßJ^)}|*ÝƒÅ ù>šèe¨ô	Œ·¹Æ1Åé °Ïà%¼LêÈ1ò‡T¤#ôOéŸ
-MBPxBø®]ük“lÚczÁôÓÏ¥iéé+r•¼G~Zþ¼ü-s‡ùÓæTW=WõgU?·¸,Ÿµ¼kMXW­ÿÉú]›ÉÆß×ò8øqØðQTb?>Š¸þjl!è¦õ €ˆUüûG]ƒæÞÿñ2LaÃ•acØ*Ã"Úñv6!CÊ°„f²V†eü&©œc†…¶•á*4P­[ÑCÇËpµ ÐÇÊpzM¿‰ÏCAºÑƒ8ìÃ
-®àV¡ ç±Žu¬ß1âqý_ùmœ–q—Ð…hPð8.`ç¡àVq«¸ŠÇ°Š(˜Ä\Æ:Ì#Kü¥‡q×qËXUw>AÁaäq×  Ži¬#‹¸€eÄC7úÐƒaìÃ8RXÀð®½•qDõÞR˜xŸ;”]·Ó©¿†:ÝÊ®[Ïã
-ÖuÞ/ã1(Øƒ˜þ_7†q	y| «:ÆY¬â†~Obè×1ÞÎÝ´]ÐéÊCÁ:®êR_ÕO¿Š@Áœ½O_t:¹üùÓQ\ÖµaHÿ°Î2Î¼Œtá
-®ê'{8Ìyº®ëé*.èØ±w,"ë¸ãˆAÁþ2î?ÝNÖñÖ°Š#8_æïž]pîÏbë<Þ“€¡U]R7üÖ•2Å~c³P° Ÿy×É³»Nà–z¿v+TvP¶ûÞ{úxy\ÀEäqõ•{vÏµ5‰}8¨Ãë‚rŸt®aY—íÖuér."¦ëâº°€IÌÞGÉ¯–ÑŠ>Z;ƒëÛz7¸ãúæÞ¶‡u+?¬4BAJžÆa]"`G°8Š#úó>Â!ìÃ<Ž`Z÷.ÝCPÆæ1®ï˜ÖacmR·Èyd¡`Ó:?{µ,CcÜ'Ötê¯é´Vx—°¦ËœSÎù?ŒUÃ¾†œ-ŸZÙ{Mß³Œ8«crír©œÃuäq®lç*.é²¬ØÆ=1,‚¯¾toý®èqîªîsüTO”}™[«A“á±ëÿ­ÆþE6CÒÏÒ×ÑóžßÌwñ/ú¡ÁŽÃ8„%ìÇQLAÀÌâÑõ9ƒ8‰E,À 2hÇjÑ²˜ÁBèÇ$:p]„¢õˆ ƒDÀ·„³§×åë—/tÇ»˜y¯ÊùD–ã3°µäT²êI,N'Â2:õgûšù¼˜1ï7Hš¹U–-åéÒEš“¥”Ø+MútMj_Us²)éNÖ%k“Ö¤ü
-dX;p¥öU!¹ë_øÏ¿ã… yþ`†%ŸÏðç•ñB;~ÙcãYo!Ì§¾l¾	"&Ÿ_>RYàIûUéQº$ÆÄ˜¤˜äšÎ—Ié9&¾P ¿eZ‘0>Žÿ¡b
+xœY	#gu~ÿß­î–Ôj©Õ§ZWël#itÏ}îjFsì9{{mwgØÝvgmÖÆk‡ 6¶ãB‡Ãæ4à E
+†Øæp*Ø88•@8Ü„)R«IuKsy·(
+MÕÌë_Ýÿ{ÿ÷¾wõ  îàä™K'^þ&  Ho9µ0<ðöÿîE ¨:µ0Ï<…e y â§Î.¿þµ·} @^€OœY<6Ûž7Ü  ààÙù×/AnP–@?7váö—Þ÷€ò ^Z¼°lÛo‹Þ ¯% ô$^h !ÂG>Â—ÐÛZKHÅ+W·á»¯®àm€ @øð
+ÄÊÕz­Vå+IÃ¨FP½#H4EI|Ñ¼(+ŠTÌzYVL#ŒìSˆÊì§ZßÁ.!Ýd1€>¯	Ýl	$:í¦Ù¤	1põiôK²õ·~É40$V¯àQÌA	† ”h²Z©ÕêÕJ2‹RtK"k/–K²,I¢\.Õê
+e®®—jµj5JQ’(ir÷àÝž¸®tqvÖfÄ£±¾cS7ç½¢Ct¸ÄÑX±—veúe%"äúƒAnz¨›NŽ&
+
+ëä-õ@j$™Þ7úY&‰>>O(	å SÆùh @ žÅÌ®¡T5Á©×¥<„Ë%YÙ°TQ¤ÈÚ-æq¨?´˜My¬œbVÜÁ—GCSnå`om"Ê
+‰ÖÏe¯ƒ*¾¬ñø[¿—y‡+¨hój‚!¼þ_ë
+IÍ¸ìG"­Ö]¨ggË¿”x‚šhØ¯üt¢Ë«v'Ÿ$‚j´WŒ,¿¾bz!¾z«˜ ¶hrq‘¢#!Ü(×jÕŠe6Êî»8Ø¸s×Ø-UŠj=£ýFn2R4nÿäcÅá¬Â.Ï¾<–;0¨–ÕÌ@8èë)£IVaÓ¹È€‰¥€W×«ÖÛš7y¾¾†SDá·â‹µâYÁ9»côŽý½û{‚©„n8YOIÖt´ßíôæZß‹{nÿÃn96iR%š®àÄ¹a!š÷ÇÒ~Ÿ+(ÐNµ–›aZ÷øÂ>1I“‚ÿW!­õ¼ê±1“€ @|¯@®ci]¨Y!!Ô…²Š ¯[f#h‚2W2Ñ‰üØ%f‘û!òC­‚›Caä”²­¯ÔÝ,öãœø0–¥›4)Hè)™7cæŒýe“Æ\ 5¢
+$Ól2/£ûÉÖIôn²uIT:Ñcúmsà6±|•ß(ÃŽJ[è‰²ŒJû.L¾qÿÎ[ÇÇ/ÏÄ³’;˜Ò"yŸ¯Ì\œ;ú†¡ž_;”œí­Læ%}{ß¶Ãùç±„9È^ËyK›©¬¥õ$‡×öØJšyÂã |{ÊõaÑ$âCIÙ¸äð6M_h?‹újÖe?Rì(FrJHfÜ¢›qÅ«‘OªvL¬é/æÌu]ýòX¾#C}Sq§hý(Ä;¸ˆÊivwlk{7Â‡"xù«Éœ¨VÓŸ–‚n îUÇ'¡sp“‰z[9Ë¿óÇ²j-XD6Š¢Û~1¯Ú)[àqDÛSÉXÌZövbLeÄŒÜ8
+”C‰h@O¤FÏmóŠ’ÖŸ"RÌïVìN»‡Q£½¯™Ör¼ÓÁ‡¤>äMOžÈô…#Ñ¿ró=G´‘Žg^âõî‘lÐI8>-ë'¤íÝ#sÊé¬qAÅŸá]^6È«¹òÞnÚæän56¨—RÊ^1®*ªK"!to©P)÷äºê¦_œ ø?ñ
+ë~!’ë•BQÊõÚúM´½ñÌ€×õ.Ùg Ù’@s—lç9Ú—GR‰WøÇYq É`1øf”—4’žž¢±OyêËªf³7§ì„lýÛý>3M@ ­^Á÷aRíª±ÆÞDÕ*
+Š"ÑFŒÃ«»ö:Ôý/nN÷éY…•£ì3nÎk<ë"…Üwh÷·Ã~‹­§“9Á_K¾#.“¶Y—½uoP&é&sÀŸQÍ¨SWSxs‡2€²Q+7ªÀºŸÛ§&ÚþMZ¬”å ávqb’þ¢‡&¤âHfäHwõìžøˆâ‡q<¯È™±¼â®½0IaQC_K(5ËÚ÷…»|}‹{¾qÂÍV%lo lr÷`}2®%W\^Ó²( ÚG @èÕ±Ò‚°ÂÔ
+ÙhÞë`ƒþ®›sÉWÊ7–ª“!øbÆä'Óú3I&íøH.•ÌçŒTÎôyzõ
+úæ  u«2˜'3òD‡öJ½¬VšWBÄt{¯;]	†TÌÄFËÁâÁ>cTdÆ»<cF<)S™mÝZéð`n›êä>c‹æåHÀ«F×Ó•©¤ÀE³å~?¯zN_¼jÔww‰î˜i—€¿‹W ¸QK¢¦zD¡óÄZ¥øbCbc¡THqÝÅ·GnfÕ`*p*Û›¬)è‡¬Þ—ž{Þ›ëÓÙVPV	‡É53Ë:0ÉksìÖµÞ øîóƒcwì¾¡è£)'ç‰ª‘¢¿±->-$_Ç^Ü1w¹‘N(	9èw|Æ˜ªî;¢ø»úÍóðCxu#ç­1Œÿ#:Œ¤áf9_œþ®«s½}Ó1§oý(äaÝº?”×í”çC?*¤mÖálý3™îÎÎ–%zH+ëyÔ'9I­¦?%‹fÖCP\ýaÇ+Ð×Îx†AoÖ¿¹C”ê53îë‰æ0M+ëÝ~“^ÉD<wÔ8oWë+9¯Ë¬ŠÃyÞõ¼“tººœ¬ º~Œ(ÑÅ‰ÛÝœfø¾]_ÔD³d!ˆ>ï÷t[~ö9‡àÂÔÔƒí¼ç¿Åy’ôj&~! ´¯‚p~–Ùáœ×Éi1ê9·SÌN2„7€~•IjÖÁ^}@Ifh«WÐgð§Áßñ;«áz]‘ÊRl“¯Qe">ÙUÑl¼>è‹J1ªäbÛ+È7C¥¦{YûGµâÇ…Ó@€¸ú\Áß òfç³Æ¨zo&–Õûr8Ù.áE‰²,´³Èz=—f–Gƒã½]5_åÜÁ'Ë¡J¼oTËí<å,ø½‰žd6®Oûƒ¾¬ß—ñI½îôîÁäö~I-¦ºæzR\b  ø‡¶%k»êþ£j!¢&Ã~W`¼Ñ­¢yu0Jxù˜ON&;ÓŠWÌŒW¾Öå‘êæa31#mš³¦»Ó¨/ëeeŽ½¯‹R­§3^Wë•öÐ`º×š!ùùðÆØÐšÐøv$?õÙÎô`Y…—ñÊFgÒ±ªó’Y	êu‰Îcëb×Ët1+°œÆžè‡Èèó½ª£·7HWÀ×s!’	ö|m[žÐLª=á‰å4ç‹Î°NýÌ‰8è
+”Ï›Ú3«Wð{ð77òB{¨—S£å%‹üµºÂèÎ“ïšë>tçliG˜3æ„Êx¦‡¡÷6ÓÙ‰±×[›<Äíäüž{æ+­þ[Oÿ„Þ¿´³±0RÓ¾q_1eÕ3ÝŽW!«ò­e#å:¯=mæ•í7^·#Þ/sþó}Ž•’Ï²¤;7è
+w©RÞ/(JŽ<¿ëÀÝërH&©iÚsõ~ÅC2“ô._R9êI~‰ó;û{¦€ »zào´³BÒ cF=DXõw­&[ Y¯	FÚ¼Î5<;Ùx¾WåÕÐH97Só±ž]ÕâTØ5"ïôV‡ôt-<œ+íî§·ä¢Ú‹l¤–Å„/˜{¸Xq²è¯çüšRüž»: e“dˆs'JRm®7ØéSÈ™Îd»¹CÊÖÏZ—Âašˆ1â§÷R%¦
+¢Ýv˜¼÷ƒï$Ú¡ˆìEÖËÚÞôÄ[‰»pŸO ™©)š”}­c8rõEôˆ&ŽÉ)1‚tõiô»–0„V_ÆÀ«4™jrÄ0ªVWT·ÆšVäµ4’¸N–Â©@¡K¹÷>»³®V‚z—.‹ºJó.N½ú\ïtùâÔsn»b¹¸þÏeVÆôD“&<žãï×ü$Ñ'hì$Mxýè¿:¹þê}ŠHÒ“&.æìýk¼bN7fNßÒëT{Ñ2WâEŠBìZ²Rõg½lp¸Ò3dåÔÿeväN.Õ<Þz5±ÃZëõf"5]Aµõµ@ë…›î6õ3 ø$˜~1kJ}KçØÁˆøå_ÓŽK°(”rSÌQÛA;#']ÿãyömèV^röÙ)Š|­ÿU}$35Í|¨õSƒcUÃó {íÝ‚IF™¢e3/XT¸¾JŽ¸¿w2…¢)-æù¿wp‚î@Á¤è`o°t0r’ý~Œç¹É™ÒÐK•\¤ 	ö°DÈå”Þl–Ù)¡~ø¢°1SÓ4)é­¥ÊLÉ×ž|Ñïn}žìL¾ë½ã«&ß²´eÒUË{zv¤“	=îpÙ5—tÝ¿[Þ¶>ÝÆKFâáZ<’ÖTVSm´Ò8r¨õ¼*`ÆòüØêDÁß™ÕQ1†p=ÖN$Yn)åOH˜ãJ9S®èãWDÃÝ¿Qè/$öÎ®eÞy¼Úõê¿5×¢fMäö‡Ò!•»Që¤VŸˆ-:x}­ È]l¾¡Â¿À+à‡ðúœ]Þ<Y1Úšª‰2£Ó‚àøÖ£ßtzÄXëóCû¡ÑD°ËýùƒÄ4CÊ\¾úõ€HÒSÓ¡ª;¦¤n¢$Ì<jÚÿ¼ŠùÆcË	Jíô«—†°Unc¼,¯dtàìãÉêé‡O…úv–•Âá‘m®ÐÚ‘ÌÊ%uÏž:|ßMÝG#ã'¶ï9Sm˜èè»¯@d“Ï7ë#¶L[ôº¤Ê—ö5Šš^ŸÔµ‚Ã¥5†‡õ®,£v”«fx¹‚…F¡²£uøM~™`šè¦F#[÷·^AØ<5»zÇ« ™1¯=åÖ©Å*ë-¥,h'ë7{%Bèˆ.öžÝ]˜Ýi*z$§ðÝ4‰OGÔv3ùu2úÎí>üçMÉ»†z›Ñ@-ñN0qX½‚_Ä+ÐµŒh†èõÚIë-GÐ’Iõ6­“d*¥¹ãõ«O³j¡õÅbÅÁÓ™`®Vz†=+j¢ÙRÊ£­gRµ`¸Ï°"îKßªDEüiEµuzÊ’Bz[w¢žðÉdó£áŒHƒ‚=ìI¦
+òK‚ñÕß 
+Þ+»¬…Ï»ª•\¡\uwïè.¤Œn 3^ íÆw~<¸ï&÷Ào ~b.¿ðäE›ù÷x[ëžÖË¶GIó½/Ø\m?G>Ôú€íÑÖ=Wï°=jí´ù“E/C‰˜€"ƒñcˆáÄñ¿‚N¼¼q‚þÄðQpãŸ$üPÑYˆ¢ÿ4<€
+Ö!Ž?AÂEô¡Ï†gA$šPÄA?üvˆã%€¿B„x|è £Œá·B¿4á€"~Šø^`ñO¡ˆš0 ì‚"í@¢_ã(¾ŒÈgˆÇˆß‘)r™\&!ÿÝ·½Áö^Û×©8µH=Ný„.Ðo¤ÿ‰á˜Ì]Ì7íN{—}¿ýû×´cÒñ¸ã«*Y¸Ù|çÞA{óÇ¼æàq  ‘v xÌô†%#ðÀc_èÈ”à™ŽL‚¯tdô!­#S £¹ŽLÃZîÈ¨èËÙO¢:²2øÝ™…üµŽìBQüûŽÌAÁ8,Â\‚ópNÂ)XJÐE¨ƒsp
+@‡8Ë° ça–atØça^pÌzf.Â2œ‚E8@‡”µ×2,Áèƒà¤µÇ)¸·@ŽÁ"œµVaNÂX€°ç`.@Î¼JcúöÀœ„‹pæá<”!Eè†2ôÃÌAÿ5÷ç^õÄµgÚúý~ë»pÚ²Jß¢á$œ€eËò3pŽ@7ä¡òP‚^8ú'h>mafJËÖêqX€³Ö½¯áè0±	)špŽAæà,ÁÌYß-X›;ÏX{Ÿ¶,¿.Þ9y–ÓðZK×\´ü>oÝeþ>:LÁ"\°tì…c0oilc° yËŽó° –eí›ÖŠù½©Å<ã1‹	­ûÇ;ì:císìUö˜vl‡[á‚…Ä	8p+ÌC~?möÜfýä·ðeE×¿s¹ƒLÎòÔflÖž3ÙÝF¾Ñažyfíe¸ÍBß<QûŽ¶íæ)MlLœ.Zx™û™^kÇÉ^hÂè°ÓÒ|nËÎ3[vèZG`ƒaE‹a&f–mÕ»Á#Óy¸¥ÃˆÛ:ñÕæQFa·%/Cè×Dã8fyeÉŠ·¼eÅÈ[ñ{
+°0ó'>eVë³ú°ù?Áë|² P„m°&áËÐ{`ì†)€ƒ°f`?P‡LCvÂðCR„	¨Aì€87@ÜP€8P†íPþÿ\ôÞ
 endstream
 endobj
-289 0 obj
+340 0 obj
+<</Length 12/Filter/FlateDecode>>
+stream
+xœûÿ l{
+endstream
+endobj
+341 0 obj
+<</Length 548/Type/CMap/Filter/FlateDecode/WMode 0>>
+stream
+xœm”Ioâ@Fïþ5KäÀØÝxIB
+K²(D3gã.K¸my9ðïGî¯ Ñh€^WuW½^ð¼æÏ¦9ò|ñ3¤î›±+yž½­çûÛ¦k¶Ã+³as‹öKj»¦ìy l¿ÝÛjð|oËËhø–ó¿”Ÿ+û•0Õ lì‡¦ö|ÿ³.¼¤ÈõD{Ãv¨†+…žïÿâ®¯»$åùþÎš¬©§æz/¼wMyàN•5T¢ãT×SšLUBî»¬‹ÖM>\ûë½=5´@–[É$"
+>ø\õCw¥™kìŸyëw•=ÓìÖì·àalÛOMRèFÙ÷Lò¯EÍˆð}T,I}}^[–‚ß/¹B‹ec¸o‹’»ÂžÙ[…a®i•çy¾ž*þL;žÊ?EçÒÕšVa=­iÐ´ )PÚbGzJ%’™‚d•GG©=!ƒžAh’^2Ì“ØõBÐ™)(G&ê©iÂ0A=¿õü’¿F
+~)*(ø%9HüøÁ]‰zQâ÷‚Ÿ–
+ð‹¥‚øÁVÁ/•yâ·Á/†Ÿ†_Š^´œŒ´ø%÷}Ór†èNËbo4#É„c,ëÂ1Gœ¯†c,kŠ£t Ç…dÂ1‚•†c„=ÕpŒ¶î¢Êœ®ìô2ïo¤»Žíà¦{Óí¯,ß_xÛ´Ó,÷q·™‰Þò¿·uE™
+endstream
+endobj
+342 0 obj
+<</Length 7690/Filter/FlateDecode>>
+stream
+xœ­{p[×yæwÎ½¸@ @€ ø¸àÅC$.Àø&EA ¢ø”DÉ õDR/ëÁH”,×NâDvëeeZoÚ&é8m¶m²= š‰“ÝtÜ$3«Ù¬3Û­»I¶iÆ™¦¶'^O\UI“lìœ{Š”%§í”áþ÷œÿœóŸÿÿþÇ9„@ Xñt,]_SöU‡Í þ+€_ž^=sñT»ü!€¼TÙÎ\xòô½ë ú€÷+gWrËÁcõc õ ½gÏ®ä,sæ¿Z_8{qíÆâc¦»@ë÷ |ãÂå¥Ügÿäq í³ –/æn¬’·«ÿˆˆ ”K¹‹+w~×	D€taõòÕµ½M¦<Ð¹`cõÊÊê/Ïµ^º ?Æ¿ög3Øƒ=t ¯Å8ýLñ.¹S¼[l¿ßW¼K_%¯ïgx/}UïŸÁ ÑŽva‘þòB„Eú*¹‰_lµ‘lõ¥ÈÍ­þmkÒ¯Þ_•~UŸ7Œ!¡]øëâ~PLmÍ§m›O»?ƒ¦0Neeê%T˜bÒ¡Å4ëö±]™ìieýpšÑ`îËf˜±´¤žòùý†”:º	‚T6eDcJöt”QMõ«þ(4eù–àªE2Åœ)%›Mæ©+•Ì…£©…
+³©Œ¦R¹e&ÎßØ¤”¦²Iæ_iðóÖÍªZ’lPM©ÉM'q¦²I•a>½’ÙtÎe¢Æ„«M¥ùzÌJ•|Ê²Â^žgbhqs©L-1i,ígB0sðhÚ¯ú}ëi…ÍÏ§ý,‘ñ)¬ŸSý™Œ’7¸sËl×|Ú_zSXïïàœ/Ï§•ÓÊúzNa–ùtÖ§0…÷Y8ÕË©Þ¬/›Éd|Œ™-µÄp0Í0Å™ýÌ–òM±&N5Må^²c‰s¼dÂ©Lf9—a$’É”vQ–™;¥&3QfÒ”1…‰ÁÜ²ÂäÔ|šÉj’™Õ¤ÏïÏ0’2IW7"Êr^>•Tx'ß®ÏŸ29;¶ÄLm~…™SÊº²ÎH$ßa
+21t ÷åfÒjÆŸQXâPš‘ˆë¥$J”É«HE6A3›5V¡&U…AMæ=uš‘%F²Ln‹²
+MáÒV¥–^qJá3°D6ÃY²£º´m³¢
+©±d›8Vm'lÆ,$¢2¤˜Ì*cëjŽUW6|Ü Lñ±Ä–Â˜Ts£Æ•Îói>8ñ°AUÿjòV¥ÂØ|ÚïSý™6”UkyJÇØrn4Êì#YEaÕ©ý|…U«É³ó·ƒi…Ùu{94…Ùu¥(/‰XZWsÌ‘Ê*ëY…9Ô¤e5ÚÔB:/.f¬rE½eNmê@zêÑèógÌ©·»´<jR‡Óùšš#¹$sD¸Ë1Læ«ù‡“Œ¸U…	Áùtž«‰ÁäúºÂ—µ·ùUFreÚgôó!4¨·dXuj‚ÙSYFwë&ÌNu”‘ÃÈ&!D·V­†<èØBšÕ¨IeŒU©IV©29›T²_ª«#pÀ‰d2É5àR“Œäò.s„}$âkÉD™[Ë£6e-Oø³NËSþôjy?ëµ¼ÈŸ>-oâÏ-/ñg£–—ù³IË›ù³YËWðgDSËúgRvj!­*1FŽso‰2m[§{«ó}Fgt[gh«óŠÑ©h`Õ‘Gî“‘Ü­ò}nßŸ_ËC‰DY‹–'ü©jyÊŸ-/ðgPË‹üÒò&þky‰?wiy™?[µ¼™?Û´|Æ4eXl»¦dY]VI©Œd9&rÜ	c³k°ö¶(ëÔeBy„5Õ\¿Êû{røøî»Ê&ÎWIcq¬³-o"µcéŽŒ¾Ëø6õ<Š§[SztÉ{4”xÆÞ½&#‘‡ÊÂÛáþ3=ßŽŽ¨ýùnRË÷Ú«)ÃÊÄ#ägHåú£¬O‹y†£¬ÿW±2’Zê²-Oá*1e‚‡Fƒ“ëëê„šSÒ§|<êªÉÍ~Bj]mQ6¨1¸™GM21ÈÄ Î–·!É¬©ÈÊzLU”áõþ(ÚÉ¦ÄŒù˜¤&ËÜ
+Ëò˜’8¾%*&ÅwK™ê3Ii-)e]ÕG¨ãY&¥t×,vFVSÙe•™R¹åù4S93¥²<Ò=8&§*
+Cêx®ß§2Kjœg,KJ_%«<lÕˆ©R*Ëa
+æ˜é]³21Ä…r!„`v¹Iï¯•‰²á².Ea¦PIêp”íÞêb½\à‹r+Žl©oÆÐ4ÃB:¦«~=ß–.WÉL
+2Spr{íbñah/YKåß³M’TÙ\Y^à<¸å²‰šªÄ¸Ç™'•ž÷Ì¤•áL,ßA\‘(Û»£÷ o~Goò¡cßkDJcƒ‘÷ZpTcC‘uEæ[ï4+“R1Ö‰²1}ËŸ!Có9fS“ÆÖ9@UeX‰©ý¥ùÇµ¼E&ËCþ…žø·B1ßcÃj¿Ï¿/þLIÎ	-ÁHY+û´<†"~n3.hi7[*˜Ôj·ß÷pgŒõ¶EÙþG´Oiy—“õµEÙ´ÆÚ¢l†kqLUbÊøºš+kkVã€f3‘(›Ó6ñH”Ík› œ8 m½å ¶Iô–Cœg"eœ‡‡9'ŽpN<¦ÝŠDYZ»ÅK§H”e´[Äh[Ôn£í(ç#œ:Æùtê8çÓ©œO§Nò5Ç"Q–åkr"Ç×äÄ)¾&'–8Ï¾H”-sN¬pNœæ<œ8£Ë5‰²³º\œ:§ËÅ©óº\œz\—‹St¹8uQ—‹S—t¹8uYËcxË€«úKD¢ì}¹7eW¸Òõ·d$Ê®jyRâY3HÎsMç!%žëZ»·f}BÓGÜ0H>âIƒäì¿¦åI‰á)ƒäO$gx¿–ÇÈÖ|Ðßtö$gÆ 9û‡´<)1|Ø 9ÃMƒäÏjyìÙšï9ýMgÿuƒäì¿aœýy-OJÿÎ 9ÃºAr†h›V½²e’oS¤ÂXZõûü™L2ÂÌ+LÌß('ë(L ô}*PÔ¢;ÑYëªqTšJ¦PôB„Ç ä¤Hˆ@æ «Å,C€à0IžHÜé„x_Ÿêâá°*Ë}a§S|˜Üþð§ÄÔâßïúìÏµfqâC_˜ú¿Ù?¥/Ü»@ž9þÁŽ>¿²òØ[oÚÈÿ~‹ç{À]ºÞ„Àâ%„%³€¾˜`å‹ÅõæìMºqo•(Þ¥ú4¡3kðUÚD]tJI„dg È‰Èa–Àë±WYÌh"M&«;bj	…zºGh¼Ëí‘CjK­u¹Ýñ®Þ>$eÿ™ÞŽÅ§§ú»¢áƒÇSjËä@ÛD“?¸hKÝ˜yá‰‰îÈ®ÑÝËOïQ¼í-Ðâ+ ùkº
+8Iì’ˆ®IB8BgL"¥ô(µX,‹Ãáð:$k}Ä)ÇÃ¡PX•$BâN5¬Ê7øu‹hÅúxá[äÔâôš7Ï‘'WW»Ï÷œ)à
+xå•²Þèº	D)È4!\¢`¬ÀÃë0Y½\…N·ÛïííãÊŒeeA½yð·ÍufQª¶ŒM?;ÿÛæº
+Qª¶ŽÑÂ	Ï¼?ßEŽß[%ŸóÌ…ãç»
+/–Öþ>±/4%| !xŒ·Ÿ¤„€#eËp}}qYµýMå÷‡† Špñ.ù¹T¤	¯Ã*ˆ&ÝpÇg`2éÖ[âÖ;:#QDN2lè®%hôÕªnÕ^]UY!ÃE\f«;âiÙ2e¼/.¨}ª$…»zûúBeÃÞJLkûOÄÃ»¢s$·Ç,ªéšÐ\@«íj¤zš;mG?y,¾Ë¿»P¿/Øžˆµ7ÔÒ6y¼kÏn‹wÉ&¹ƒFô%º­„’z¨@¶Ð¶ô ÚêÜöª
+¤Ñ´SByK¨Ø¾3·¬Íäz´=Îˆ£µ)êmhtù}³¶ÓÇG¯noñF\ÎðX¦+9îµkuA]÷Í yšÜ‰h±T ”ÃíøÌ}¡D"GŽ@r¼·7ÞeÈ"ÉBsnUlœŽ6ÔøäÚªÀtónòúqmwEÊD÷^á6ã:x™Ü»¸Í‚Ä$†5Ñiˆ&"žá6r„%nCš“	¥9:k³¨~_½«ÆºË¶Ë$ÂB,Üf¤E’¸=Ý!aK9îZ—$û%×WlÞÛSõK¶^JŸNkïO6Y¥Â7HËpHéó46Î’?ŒvØœ•mÉBâ|nô}µØ|WcWÉ*¦|µŽw³9¦·Q‹ V¿T_c@nŠEçÓ	?(=öžÈóqBŸ{/žLÂãq45¸ž€Ã^ÍÍ_KjßÐ÷Fè``Íl” :|¢aåäŸßë £Å"Ç~N7i $´Op”ÿ‰¤é‡àÃ¹„¥ŽHÄK Ñé)æŸO'!‹3&B=)Ýù$	9¹¼åFTxîQý™D-§–{¢Íj©0ËðßÖf{ûœê—ã²*H:Ö¹1¿4Ò-Ð	ÛÔ®½ÍOÙÞ? 447ÖÕØ;*öÄª¼•Ä>`úô§G
+o×Ô45UÆ+ªyf  Å ¹Cî 1Ì%¦^«`’x¤çhE]ªðÌ„#”áÑHu³~…`WH‰ùc>Omu¥YB3i®0d÷Xë“$ug‘$a‡‰þ4–VUßDxd•7´Ð¾{>2y¬34âœ{N;¯¨Z"îÎuo¼©ý{þ–NOÓtâlH;r8µ–éâ‘E8yšø#mÿ3ÔÒ:žî)Šwu/óVç‘d‚ ïbÉØÅVLi¨¯uš%„IØ´CöžîP˜g3îÓ¥ ÃuîÑýIú\ç±º6O*Ü¶»µ?6 MjÑý­®>%ÔÙéî8hëlS›1Õj®‰´%‚ªÒêñFv¹ü»µèhÍÅ»ä-ïi±óž²÷ò0ïtïy$OÉ{š¹÷TWšeÉ´Í{Âª¬:ã²¶Üµ®*î¡=Ýzø’Ýî…w;×žÏ„Ý4°Õ}©'êiêhm9 Æ\qÛ.ÿnzûÏ³‘Å#Üm“Çã#»Û‚o„Z@Ð]¼KÞ"¯ÃËíà&”ir|¢x”‡Sœ2•­PërÖpá%^iÞ9`j]JÎ’‡~wŸ(ŽÌìÅÉ†‰èètv,†Û’}Žf'é-¼êôVNµÅHºP¿_ëQ]+þ~Ao££_´Ð²Ž ä˜.GN(ëÔBÉsÛÛ2‰J›U2¡†Ôˆºh=ÝÛóHÒê¨ôÔÌû	±’$Y={uôÜ½Ì&;!ý¢	[Ùå;äêM´	„rPê‰EJñ¯\É ¨C]°6 W2[©Å]ë’ÕÉã{9ÃÈbx!6Òc™Å}ûbcäõÉ@çÞþæ@á¿ÍUÇ•Qø<÷ùâO‹qò¹£ã-‘ØÝRc Îa+s éŽ’›‘ˆ œf=n” „ZÔ†³Õ‘·	UEUM²s~,ë{$1¸ÓÓvÒšæ?ÚŽŸWè­Ds´‚›Ï¾HH	@¡7ƒ~#NñªæoÈT£‘km›ª·QÉ‹v½6ht4VÈ¨&Õ[ÒãŽl=+ª-ÜjîWçND§ŽwÎŸˆNhˆ÷vñÛÙ£cWÇŒÏDru49‘ZMŽsÛE ò1ú*Ü8‘°ðjÅFxa0ÅjçÓ‰†ripl†$œ„ Ÿ‘ˆÉtÔ4ëKÔƒ€
+„ž{wg&QÀ·Ã:d«/ç!¾stEòh9<j³WÏî®×ìõn¿¿Õì8e[:L>?`:°ÿP¥µ§º+rh¤.ãŒþˆÜA?}ð
+F,Y"¢Hrü°4c–MB¹ŠiC[ÐtŽ
+kã6¸yJö•v îA †…;MíéàîÞ’cNÔîÓÆ8 ÇÝû" ûviñ½ýŽ&×vTîÀ'Á@ÿy~„»$ Ó”P.ºI¤eiýð;¼F¶Þ;KðÞ½?˜©¦„ˆU•ï_°NÕW}`êo—¬œôÙ¯’7
+¯5O´´L4eå%r`ª­m*Pøù}ß¥·áÅüEÝuâpì!ìã=Ï½»'“¨à…7XÜrïGø÷Çg:ìbëAm‡ƒÓÛoíVÛßåážâ]<°¢>áÑ“-‡WÙ+±
+[Õ0ë¸Ûnp×mîz­ÑíÕŸã§Ÿ(Ý€.~â‚ ¾á3EœÔ‘Ü÷ô(åª©²Á
+kÐ/YëøFôi%UœFUUõæ—]Ùÿ¡…sÝ{O®œŸÞ·B7ö™?ÓYø™˜Ÿˆƒ¿Vl'?ÔóDG"j·ˆzh¡Ó‚Q•ÓõI¾w­Í*›xšàéZÖÓµ^il‡‘$jWlžjO0éµ/Ì…LfQt¨ŽÎÞÔr)Ëò`—BÞ*¼ãŸRüûýÄ~ï§€_ÈÿÒe	%TW•LÄòÙïøö³ŸÞo¯ûUg8î)-Ü—=jéÐ)ËÚÿ9:Ûf®’Åj¥úð¡ÛKsšÙaí-Î„þð‚;\ëj­½ð“¸âŽ¹Ýšçêýñ6½&¾d‘'Mi5Òxþ,âãdÛ3	 l5ÎòÁDàsªaYnþøL–þ<ýµk³ÇWëéíB#!ß,üýÛWžâóTï’ÿG?ƒ6ž¯½uÔMÙê¦FŸÛe–ÐFÚÞ]7½«pÒ+§RéôFr5ÔÕ”š×BS‘¡ž£ƒCÙ¦vïD,ØÓØœnï:mˆD:’}¡¸;Z?Ù×y¨«»5ÚÔÚÜáµ»£}ƒG»}ääuTÂŸh’È}cqì¶ªD¥×!r|î€È‡'¦¢$ŠŽ€ó7g
+÷Èë…7Ô)50 ÞB}ù€üÝ€	Í‰ø „fïÏl‚ÉaÌìŒ~Y½9{¸*éÆ½Í¤ž3Šwé}íøÍD‘3DÚBd¨Ä"‹¥óB„'‘ÐsEe¦B¢<E˜ˆ ´ÌX‰ÅâŸ,›s0›CæY_"‘
+Tž)zï™„àß_ˆEƒA‡CO26¹ùaI¦oû±B/jÔò‘ãaÙçOÊ‡Ÿ¿ÚgµÛ;|	~
+ùÜ‘)‰Ÿ<~ÄO±Ç\½'Z]_Ijô4Uºi ŸA†ý6+5ñ{&DÁ$žyà¾©TÏ4756ð;§
+-¤E6îœÞ}`„U?oíúû;Ž~pnèˆ;æ‰çFêôžÀ€3ø|å·'lŸ¸1ûÂã=­š?´{ùÆðà‰Þ:û…6ñKz<l¦p *½D•Â$RÓ. !Šä¤T¾aSý¾ú:W°ûeã¦Íˆr­á	ªPŽ’[„zó?Ÿ|<’
+ÆÇ&~mvðÄ‰Å±ýG¿râÒÌäÝØ?¡jfÑ¶·ò¸F®OôE»îýhlºgð~Üî×oÊœ<ƒn“‹Rý¦ÑËé°YP³ß´]&5/•Hªzóé_ßxìÅ‹éô¡§ÇÎgûéÆóO]»µ’Xø÷'OžÁA€î¥úÜâ¯ö¹ÍùLfAôöÔq¡ðºQx¡çboÏånr_>–nÞìúZ!P"ÎðÀSÎ<¢xTä+T Âáp”¨_öëèUo’ó•…¿‹þCå;Ãtcï“…oë5d\¿+Õ½õú°›1ãà`GÝk\<ðº×
+òº×ÔÇ!jwi‰ßßDƒéØöë±õ·_;¼òâ¡ö­Û±{3„l¿ãzÈ‚F7 pKúªM÷k¡ÅíµÅá­+—‚~ù£—BeŠ¨Bw/—Xrò
+Ñ,zbž?˜5SJDWkíÇæ
+ÿ¸,S"V5:òt£ð»ç/õ]ì&g¿Ûs¡¯ïB9{o•|"0Ï„
+—AŠ?(Ã.ÀOÂE&õ¤ à(fj­‹ÈáÞÞ>#vÐrYÛdênRëÿC¬f8Pïö†M“« ¨È3ô°bzŠùæÓ¼X¦ Ï€RŽ(@Ì–¬Îk*ý¾ˆ€<·£Ç¨©¬°:œ%HôÅj_o_\ˆËõ•É¾Ïr¸ohíÃ¶ù~—­åÞ×e¬Óëî-¢@Ä³¼dZœ‘L[*æ³ò£8~^_:ýüÎ¼ŸìêŸ¹9»§ðºQx‹ÔÞ[%ý…ÛÜ‡‹wé	úØ¡l?·dwž[jõu¥F©a'viG<Ûy$7 Õ|éZìÈµñý+Ý±#k©žÇFZöÏòÏIÛï<=µqmlô©CSŸ¸6–>um wmèÔµÁìõò^ÿÝ@#b‰H]Q[CàFŸ1¼wÛá³ün»«í…µ“WT¡|Ã}ªÇd1‰öfç_,ÝÜ?]á«g¿2<èÅ*ó~ºQøý–¤ª&[ÈÒ½Ur%vQûTáÉâ§¢—´ÂÇuœOÐ)lÒMnƒ¼´<šh H¦\½Ø^¼æ%Œ:·Aë†³Iõ¸U:åq{ýun¯Rª¡ð
+y}ë¯ÇñWæÜÌ)òºžìùª*çjn…/Ÿ¬þ	dáMÞüÚÔ ÿŽ$^;0¹~ïÙÂwÍÂW¹Î@Kßaä'º7_Ì‰{ÏÞû±¹Qx_+þå¶o9vÒ5ðs¨4„R(¾B‡J"P©arArÍä5©a¼f2†ap9AÉo´ÍÔ‚nü­D3õJ)Â¤¡Íôë£V4ã<4•¼\üùOÅWÉ÷ÐL~jò2†È· ÒNDè4è Tz*yÉw¡R7Âô.r¸SüyõôTú$†é_è?šà2Ø‡Søø!i!#ä“ä5ZGoÐ7é?
+‡…ÃÂ×Eøâ7MÕ¦9ÓLoK)éEémy¼$ZþÙo>iþ²ù
+¹âw*Þ²ì±\µüå›Ö õ}Öß³~Ûf²ÍØ~ÏöuÛßê6èÄGaÃ³¨ Å><‹q[VÙ BÐÓÊòÓˆXà£º59Í£ÈGK4…\¢Œ`³D‹Ø…wJ´	iRW¢%4Õ-ã“¤<ÚR¢+PGµmE-Ñ•‚B¯—è*t›>‰/@A:Ð…8ìÅ2.ãV `ÎbkX5¾OŠ'ôßr[<1,á2.¢­Ð à	œÃÎBÁA¬à*Vp×±‚e(Çe\ÂÌ"‡‹|¥‡p×pKXQ¼Ûß àr¸„«PÇ$ÖÃœÃâˆ¡=èÂöbIÌahÇØòÈ8¢úHƒoIŒ½ÇÊŽUŽèÒ_Å9]neÇªgqkúÞ/á:t"¦ÿëÀ."‡Ç±¢sœÆ
+nèët!†^ã½äÜ)Û9]®¬áŠ®õ}ö+x
+.ãôö:§ËÉõÏßã’nCû‡ôñ7cÎKXF;.ãŠ>“1†Ó|O×t;]Á9;¶myäp `1(ØWâýçãdOb+XÀÙÒþîã‚ïþ4Öð„¾Çû0ì±¢kÊØ_u¹$qy¿‡0‰i(˜Óç¿´cæé3p¤>hÝ²•m’í\÷¾=®#‡s¸€Ná‚Þs÷ÜZãØ‹:½†A(hç*–tÝ®bM×.—ábº-Î sÇô’üj-ëOÃj§pmËîÆî¸½¹·íÅ!å‡/$õ÷IÒ5ò&±€}˜Ãa,èï{q±³XÀ¤î9\»¡ …9ÌbT1©ÓFß¸ŽÈYd `
+“:Ÿ{¥¤ÃbÜ'Vué¯ê²(<‡‹XÕuÎ%çû?„}‡ÿr+8]šµ<öª>f	çpZçäÖåZ9ƒkÈáL	œç
+.êº,cã¾¿ˆà½†/Ýï?ƒËzœ»¢ûŸUÁ“%_æh5d2<víŸaÕØ¿
+3(þ(~]ý¿ 4„@'ìÅ8c&0Ç `?Ž`iÌá á &1ELÁ8ŽñR½È P´!ˆ0ÐŠ¢šß¸¡DÀ·…Ó'×äk—ÎuÄ;ú0õnLç	ùx†ã+y«yÈÉDÅSX:”êËhÓßí«æ³bÚ¼Ï<,iæ&Y¶”šoHhVš—’b·4éÍUÉ½‰ú„;Q“¨NXòËamË£6¹·‰¿¼ãË<æäùi–x>Íß—Gó»øûKfÍøòaÞôó3 bâù¥…rÿIØ¯Hçé¢´_c’b’«Ú^"Åç˜ø±<Åè-Ó²„ÑQü¶‰V1
+endstream
+endobj
+343 0 obj
 <</Length 9/Filter/FlateDecode>>
 stream
 xœ{   á á
 endstream
 endobj
-290 0 obj
+344 0 obj
 <</Length 343/Type/CMap/Filter/FlateDecode/WMode 0>>
 stream
 xœmQ=kÃ0Ýõ+®ƒ RËÍP!Ð85xÈqigG:»‚X’<øß)rRJIÜ»wzïîèÓ©^¼	}ÁÅò™Á,ÇE±o¡t§ùÐ£òDbÊº«¹CEµ«”ô„ÒJñë pâüGÙb'Õƒ4 œ×=¡ôCú+®`v z‚J òÒÀæ„ÒO´Njµ‚œPú®D¡û`Î‘,i@v²š×è¡•JØ¤— Kò’ûÅ›÷‰Åõè<ö•j5,o,1˜Ä ÈÎØIçí³hlÛ[æhZ©:˜Mf%ëÁ˜+“À"ŠJÄ7Íš!KßÑÔ%äèc4˜>È¾öZLA~³Èµ@gŽ¶Q’5cŒm`]–e¹	Šò©êÒòïÆFv¾5cÛ×ÈNx¨ã¹åƒµ¨|œNt,H…÷1mBU<q?ÓªCt, ˜®Êb
 endstream
 endobj
-291 0 obj
+345 0 obj
 <</Length 3370/Filter/FlateDecode>>
 stream
 xœ­X[l×yþÎì…Ë‹x/’½ªsVÃ¥(î™%-Š-Q9Ã%ESW$%Ïøí»”“"CQ7ÇnœÄIíµ]EªE[ W )þ¡ZT6ZT½<4@[H6èKŠÂ"jÓ‡Z,þ3Ë)KvRd	ò|çüßþë9³ õxôÍ_]—³½ï ø3@ô-¬^Xžë­ÿ& ~46\Xº±0÷î÷~hú ÷.–übúwð@ó ¹x±ä×þSìë@K'€Î‹Ëë×£I¼´œP·´2ïãþ
@@ -1084,64 +1271,67 @@ g=„Ì¹¢9¢Â¹ªœ¨îzMÏ´Æõ²Æ2ý5ˆ
 £a«ÅŠÇ[ñÎ`§ 1¥÷¿´cçS;vàN}¸Â[U”Û<Ûi÷A=®ÂÇ"–àcKZò ï¹ZcÁ×qò¡ì\Æ¼Îí*ÖuvÙ‡%du-. SÃ©‡<ùüõVmWªu£ãzóiÁ$&0#ŸÐÝÎó	ÌèŒ¼€	Ìâ$¦p³z>¢ß<Žà4f1¡Ogw¦p£ZcBãP6¦;ò4<HLbBsxïR%?aÅø\¬jï/kßÃ.\Ä2VuÎÙsŽ%áÏ^a‰…Ê®[º—µÎ<± ™\]ÎÊ\•®`Î–u.·zãÁy	;‚¥áYz ¿€}Ï­é3Ç»JÜ¨œeîÖÐ§ðÄ®ÿUÍþ¿z¦ò,Ûüzä{p~ý5Z0y;íBü²G"üwj5@=\ÿkxcù•3¹Ô¢G¯´•ßˆ®%æçâÏÅ%TMg´¶®"úÕø·×â_Ž¿ÍGíx¬ÛÐ¢f{¤~ÿygß½wÚïì¾Óx§~¸vµ¨ï	ð„=RáOý°ðCöo4èoŸqiøm—çÅÑ ›ç·0ê%ƒ¼ôQâMˆèðÛó³[þ·½ËXãnôTt(žuµ=·Åæ·(ú~``ôV¬Çè(€ÿC¯K
 endstream
 endobj
-292 0 obj
-<</Length 5397/Filter/FlateDecode>>
+346 0 obj
+<</Length 6155/Filter/FlateDecode>>
 stream
-xœí][7r~×¯è±ìXÕpxg÷FqËû XoÙ<Xƒ$4»;;A´ÿ>è>M²«XÅ¾œÓ’É4gæô…·*V}õUñîŸþëôëýSóãÏ¯Ÿý©Qlds;üPRvÍýû»{ÙÜÿ¹‘BIÕ{:ßH!ûNš^ëñ£U*x×üùþa¼ù}ã•ndónü9>å]|Ü»gÿùìôì_Ÿýîç×w¿üñ×‡W¯î~~ý?5ò‡~üix¿ñã3Œo¬Á7½‘BÛ¡dóÓˆ[U¼55½ëÏw:aý¼½t]§‡7ˆîÜþñSnþ³ß4²yóxw[ðæ4Ù¼yÿo/~/¥ü½”jú©[ÿd¦ŸvúéZ£ãw>^>ýí¿¿ù§g¿{CtGÝqR‰Îk×ôÎ	»Ô¹a&l#…õãa˜mœî­Ò°Oª	Â­ê×#Ô›0þ|;þû4þûpþF™Ù7çOímw~Ïc«ÔôFå[m_Ì®’ª22†Ý¹¦·NSxÐÀLÝI£åÔ%m¦+t:úÊ….O×êöVùä¤Ž¿O/ÐÓœh‡~Z~ül9~Ê	­†•e¼0•æ¨!ÔP¦u¢ÃlíH#[%W­‘ë‰+ÆdR;2ˆ æ£áGÝáÜðñ<ÃÈø³Jp4­·MÔ¶‰\¼ÿ-øëS«’Âq­ší|Tüí	¾]ÁV=Æ‰mJÓ"Q_âôœÛ|jõ4ÉÃŠ×Ó4?ÐS™ú‹Z§6ŽSj¡C×£6Æe8-¼Gô-ºx÷ôô5‚fºÖÄÅ‹pÒ Ps ÷¬Wf#çñ¾ëa\IÊgaB-DceÈ6á‘-[²üÆ¸ª’3éŠ4ÖhM™ë|j©Ñ•ÑbzgÒóy•à•ÐõVhÜaJÁXz‚¹xâïvþ&m’˜>¶q|KóÓÚ[Í!£[“>c)$æ)u#j¤	gk'j4¸Vž3ŽèÊãÆ†J×Þ¦ï\YÔ€iär§V-îº
-–ÚÇFú6êÆ¨o§fä©ÑÜ¬:°~¢Ší(&«ÖÚS{›%ZU%™Ð­
-ÄRÿHzÞ%±nŠ²¾e;Hoñz%pz¥“"èÃÔÊCÑËBÖÒR å²ì{ÞówiçcßTŒñ‰Üs€¶ÇqR^XZÕÍ¬žbž eõP¨´¼Sà÷)bÅ"Ã†’o]\¼LóñfÌèüK	DT3Ûù¡ÜÐ@Ê­ÞÞö¢ïûÞ÷¹AiafhTËI¤/Æô9mð¼ vœ Z'¼Ú	˜Fíó©	ÑñL˜ÚÉ+|ÛFS"—&‚8¯^Ý½ùËÿãîŸýËþç‰ë¯ê…(Â¹»ÎŒhÎˆòtÃÇÐY£LˆÈŽ²b@!Þ7²ñÂÙÐggŸÒ²¹o”Ã¤°N+?\aæ·štÇýøù|Ë»ás¾'Ê—˜ñç[Íˆ3ÍŸ9¿;Ýr?ÃöÖë_)´vðŒ‡g<(g=¬TóËëi¤®ùßÆ6?ç1yÿùIž²w+æôÙ/„LõqØôyÜ”ôÞªÆz¡}z/z7@‚§O–ž9þ0°;%Ó6J_„vñšD)¦Á¡w¢{·r×ô—5Ø#},“™Àº¹^)€»ò[èûBKtvõ´á¼{¬,Tø~PõxÖ*[È+ÏÎH­OèyÐV>'>‚ÖÀ·í}&E“O‚}¥·h¿Œ{›«Lå|´¯,NÍ-Î`„1}v
-”Zt`U«ta“RJ#³ËWpôÊ£œŒì GsD-ÜïÑß2…ÀÈüw…~ÖT@‰F›`D¯l‚Æì·çkJÀÐöàø×&w…á—}%³äâCé›Æô1ÛJ™ÂÇ«oæ¿|Sš?Ñ@&½Bä_<Ÿÿò-?$ßÿüUúô=Ò,
-üžÇ·ÁCµ®¬ËI¡SÂíŽáxNÓ&Ñ¾ùo¦E%ÖÝ;ºE×ô?*tÙça¡fÂGgï(¾2”ãE;ÌHÁCg·€¹ù`\¥ç´	{ªáìD"ác`t ˜‹¿ƒbw-Dl/ÄÝˆ zZRžAÓ	éÃ–ÿNgÂÕ b—&,ŠßÔ šINØc»œ/Ö²‡Œ&$-Šx+Ä{1ƒ ¡à·ü,,·ŒÜ„åío„5®ÀžÍÊP»…§¡Z—RO0| Ž€Ú>ja	ÃKÌr]áâbUAœ k+Üq1"$ªÃ«™_K+„qÔ­¾–*8^~&Z'3”‡*%¹¢ Šw6@™ž†Û.YÍ´MTgàI#œuÒ~
-¯çÖ%Õ¨+®Ì—[BL¬ú·KÞKqGHWF’|¸(æ[Ž ¢eƒù(´Ž×P3ü¨÷Ãhÿ£Â”{ø[ÖÝÜ‚UÁl	¬sG#<€÷­i$‹)›‡¬Ê}z&-Ø;…9¾vO«Ð%#ñ¾pýãâŠ¤¿NIŽWÌ"*'5Ä`¸g£kF†¿²®™KÆ|òæxœî
-¿iMìÅ%}ÅË-ãÓz+VºöüØ[Ì¡XaÆ­ïÙ+}¹rÂ¦ƒW(æ·Å0ÄßZØ½Ž«ù¤5KCsÑï{!µÞÏ¾ÀÒÐšÓ;T£áI¥ÅÐÑBÞè½?b·F6ËÂ¢«¹ËŽˆµ‚ŸÁ±@–[ŠÓ¢¹ÎïÄù­ˆÇ™­:bƒ«i7[ãâ¯6`¦×#QDªtãŽuÞYçkÒ,ÅhhT4\|B¢ó?qE|_½»VÉÂ~+Z=U«ÁpÒëœpæ8Þóvsÿ*?ís7)à5-R*ãËü¸¬fðæ§Xî>&Jí5æ÷ bUˆf4;¾ÉÚÀ„ùgêÝ…c0§“ïou‡æ‚=ÞXá>ÅîÌÅzŠ}ÊùPê8ö×˜ð,ü°zÜ®ä. ´_B¸<pŒL‹ò]œ#V™ë%ýÕÀñw¬*Æ÷0èéu´ò?ÕàkÞæ €Š~áâF^+!åax³fÆrÔ†3òÁÝ€5gX0³íu¾Úm,
-S0M5cñ¯õ#Y3<')¥µÀåÛ[†u²Ic›ˆ±Ö÷ª6­÷´ú€ÀåxÇnFƒH±`ZPÍÀàöG2p2yH+ÃG¹ã›(£®WB ÿÿ‚Y´hH¾òhŸŠÃEÃ³ÛZç;á§¡û i­æbQ®ÓÅþpE
--Â-µ#F4 £²²Éõ\'|þrDV›v*`Ue«ì)
-ä+ëy~{ÞßÒ¾ŸÍ”ÚšR]CªÍ6—)2Ñ …•#§ûÓwÌFŽÉüeÃx
-”j.‚> ¨€|´xÇ©Úq£!2¶á›-ÄcÐ–iÞŸg–=Lió×Ë\ÃñÙubL¨ø,	¸MÆõ¦á{.{*L¸‡«ñlÃ9³%Y—5Bï7 SÜ«6•N@¤jÐÆ¸6“½•n{È`ækÆ—$´¸2é%Joü˜ Õ8ë…Ò—Xé_)ÁÛ(Á¥2„î)âG‹8®_µ“^\Y)ßi#ŒîS°E‡“ú„HQvÕ&›#EàÝ$Z&Es`RfEDÆë}’&~&0¤úÂ‚3…¶™‚‘Ù€w´s¼ vœñÏ™¿UŒÄIr-šjÏÅ‘Îñä8”#yUgíý´‹C¸ï¹)…;J5ÞG¨ÐðÍƒ‹¿ÃE¯Ï‹¾¢H,'³²¬tU‰-‘›Ža
-âYÂl+\3¥.¢"…{œÇ€Òë2²¸qá8ŽPÒ(@ˆç‡œ¶ÎÉ¶ðS•FÌGŒi3bn†­ÄÇl³¶ëDgœÔŸb›åÐ[²QŸ)3í\Q‡³:Mªgÿ>S¨Ÿ¯  àÂ(ðp‰T¨•Ü¢ºv‰
-8nµ_õ³Ô6–Yë9ÁŽdém´²ÃµrLÎ4BímD?.ŠY›µäÙRÙ xäQTsQj›.G÷·Á	cõaŒ	¼Åº
-EÞùÊ{•{ï"®oÖWAª‘¶of5Ì×[^!x›Co€˜Ï-*ÓÏÉœµ¾Î_^ˆC“>¹,Ã–²HˆØ:òI*±ô5…q®•o´2§(°‡çqá­ZUäºãäÚ+ÑÙ¾ïŽs€7:€›–1iÕò¢ËY‚qnÇ×ì3ã·VŠîSg–ãÏ—-úØYÑtÞbÅ™'Lª“Ü"†°^“H”1c¦m"¦l‹5ã¶¦Ëü[ã™Ô¿¹‚k–8x¥‰†ˆÆ6}8þQÏnÆ™¸–[™Íæ
-Ñ¬°9
-·î»º†ErAü·€iR©d¬8¡ÕA˜‹öªØ6+S®¬ˆXÉlfdQŽvV1¿
- àˆüaÎÑ ÄEÁ\ÏIÌÁ†”Žq8~Kì2u%—üKm4Å&¸-ýg‹ÇX©ùÙ#Y¤”¯ñxYQ†2 ƒ¤—”ík0ZL„ÁsTŠƒ˜ƒ\)íl/õ—LvÁ£õ•íRèï¢“ï'Ò‹nlsÞ5&8ô4ŠM|±†±'M×Áõˆ/DQ4ÎÂ!q\&<Õ°¯ìv»|,8ÕCŒù–ñA‰´DöÉ;IrnÏý˜ú?/8çVTd` Z]‡r‘Ð5s˜iF AT´÷Ìb}ùŒÐ¤çííòün+eÚ#Q*â˜¦7Ùlà[$$$¡–<¯åÈ ÊrýºöV¥30*ŒËáòÆ)a]púJÌóÄï˜ŸRR¦ô'"JÜ,G˜ÿò]RR/&«"§j`DË+M’™gxE%0èJEæ¸$ZJeÄ‰2öÚ	§TcœÖCG‰¢ƒ…ÒŸƒ	—ŸAm¸ß"IP—ðI*ó8IÐ½ðá8×[¡t¹'ŽXBëêQ¤‡«æý\ëP%29›·Îh‘¢ìÇ,vÚ
-¾Uˆ${ˆuA„jºå¬ìïÇ2PqDw bVlõJþ˜›ˆ>°ÐåŠqÙ±.ñç˜ÚFy¡º/¾ñ‘'(ò†°ÖCë{kH:‹¶–¯¶’Á„á½É©Ý½ï¨œ]€Á´š‡#ë0³AÎp|âã„ŒÂˆXáŒQ*äéëÑm•bð}¯Uù!HÐufpYU¾^«xÃýôy¸ãÝø9Ý’?åK†¢ãñV­šwà‘¼oºcZ@Õ´ ÊûÏmPòŒ½[œP)È#!‚®òbtg…ë¦qû`i|À•Ñ¥ôx{o…•žxw=Çãû™¥Z²ÝÓ¦’ÏÂ?È#=žýÐB3tö°xh`Œ*TWâæjÈ
-ÖÑrÝâL£ÄGš°…tÎ>Í¦
-_çAÔ¸Üà®“_ŽÝWÖ¯(ë™PÃ·D-‚Æýaí=ä^Ú|+å‹W°ŒwÏs%®ä4«.:)z¥!~#¾´l«$l\Óô®Â˜ÚI¸ª˜€|(hýr’›J\lÆÝª’%¸—õÂºZË}[|;Í;•	‚L%©\,…¤cqæZµžûÒÞÚsÐùfoí•›ö¶±P3·^±p´Ë#ô c‡ÚŒZ—¬{$äq+]A¢w†•s„UG0JH‘lØz´{0™Þ']·#¡îÞ€GG5À³bÑFKòñ(Í0ÔK<í¢óô“HŠÞÛ ]ŸSô¿4ÎW¨Š|›b”Vt¡³Ö6ÇÎ8Ñuò¦tŒâX}c½0½”ê7D-pðo’ò0ÛRÔZ_¢0(+…ÕŠîÔ•Ù“ŸK¡)¸©SI7ó]yQûÒõÏŠ2(Ø>Ê´9Ë9,ENS-Qãh^’›Ü#mÔ€ÊÂ†&7¾Ù`”C4×mè1¬j1Zt=
-­^×¡·K)K³²fŒ¿üMœƒ±Ì°h»>[ŠMk
-‚{IbŸŸuWˆA
-ìVÎ÷Š÷rŠ^™š?ÊY/.J¶®U"!Ò¤\Úb„xpÑä"ÚÂBÈŠeìS6e¶8MŽýþš]K'a¬Tîj³¹Ž@ÕŒ¨-Ðüóª¢9œKõÏ°GuôñÛ\I=Së‹|éD'AÌ`2J¡Fÿ ë¿X÷ ŒÓWÿ ˆ_î:;ª¸çº]žö<žP}wf[á¼,ƒgÛ´&æVœ…þv¥3à‰À‚“ÂHå¨®\PùÿD–à Ï2/g)õPn~[Ô§R‘¡ÙÏx°%¹èÀt
-¨ºi-ôc÷“ÊüžÚVyx]‘+6 ¡:+ºîÀã]>¥;T;À$i®ª§\Ë† <@YlãëÐâÖ­«PºÍØZqÎÆµYŸ¤&ûÛHUý!>ÅPÙÑrù8@Lh©¹˜¬…zÐUyó)/ˆ÷
-N˜g£*¨ƒ´õgð‘9me¦•¡ƒ9%‘Ní{ìêâåÉi›FË2y‰?¡\¡CÁ#5Ì
-#Õ)kRÈÎôqÀCõÕ© !ÌpÓ?qŸ‚°½±]£¬Îø!0þw­s7§<ÄÃÀh*Â0ËgfdEXagzÔù¡o[­ù|¿5Œá‰0FïE×ÓCôÕs9ÜsÁ˜•Ê5_¯\®°Jv^•k2wiŠ~›…°
-ËéMèë,ÿ›~øîƒ5¼*ëˆò¼x	c#ÊxÑwêyêË‹ÖFËo>i4Ç¡jI#MFÍ|nLJ\QåGB;–-Xx~äßg0³YÐë±6ª;:Œ{Â¯Íö,²p £Ž¼­ ©ÑnQQHÖáÞò‡+O¹¬Ü"w`)/¼ltC5‚“]ºÄ{HÜ'>øc2je/BpR[¦NÂÌH¶î—ê à±úê ¹Ãa…ÁÚ7Z5Eú ºÎØsöCG›ÿ/H-Œµ}8ì$dÓ¤¡µ"0
-åw­µg‚RMXlb)¢Užnð‰«+¬ÿ@Ä-B/\ï=F×Tq f‡ç#}~)™l»k¶{l*¬æƒs5ñþî6WYÅÕg=I;U‹¸o?_õcÄ!L«§Õ¯ÿûìò¾\›Kó©ñ`ÃCåbwd:Äõ
-~ôb2l°©Lñ®yäD•d@ËìaýÁÍ•2Žöf Cûýæu 1¾râ4]‘«™¸D	
-QDºp}†y`£	C­b×÷&™WŠ¶—™zŽN1À±ÃUîèÃÂ@.8GN¥N5­%å%
-ç¹ã“²æ{óEUUÿ%æÍ
+xœí=ÛŽ7vïúŠŠv×V9Šw²Ç@,ïC‚8@`½eó`2H‚ÑìfVA´°ºx;<‡uéî‘¨«§«Xäá¹ßøúï?üçÝ/·†~zóâ¿1ð7áCpî‡Û÷¯oùpûç3ÁÅd¹óvàŒOž«IÊùRá¬þ|û0?ü~°B|¸Ÿ?çQîãp÷/þãÅÝ‹yñûŸÞ¼þùO¿<|÷ÝëŸÞüÃÿþû~ïWvCÙAæì0)Î¤ÓøÈ‡ÿˆ<*â£iê~:=i˜¶å&n¼—áÌŸæ?_åé¿øáíÀ‡·¯ïæ¼½+ÁÁ‡·ïÿõÕ8çà\,Ÿr4ñOjùÔË§•Œ¿ÙxûòéÆ{û/~ÿYŽl–c¸`ÞJ3LF³I™rIÞ„ÐgÚÎÿ¹°#R9i!ë5‰Á1³iQÔŠÀjÜüùnþ÷ÃüïÃé¡Š_NÿÞ7þôžÇQˆåÂŽR¿*îâ¢…BFz3LÚ°°…WÌ²œÉ—%IµÜ!#èð;W–¼Ü+Ça_¡p¿//ËžH>5?ÝÂO&EÀ,e™™®@Yãÿ‚%Ò˜Ãß„!—ƒˆi ²0î™Õ%4ìÌ9Œ	—'ÈØCt54ÏÛCfûÈ->ÿ®úë‡Q$fcF±€ì¡&Røë]çžÇñ&î¶Þt««§ÿ19./Ý—÷Kà÷¥çãøju¹pÄsîêù§_!>‰jø,\uW\[Ó€§áLí
+Œ *,çú8Ê¸;R%¨¤¹)Þ‡µ#qóÁÜáþ oL÷FZ‰Æó=ÀÛå{â^¤wá¸öXA—€B\Í…å%v“Q‚ÍW,ÁWüd˜›®ÄW.‹	Õ–ÑÒæÈÄšÝU2]æñÆu#iF¯àØ-K‰
+° À¸3 Ê¥§éD9òßW¿»À;>Þˆý“‡P­~ö¡%‰zÙi¹(€Z"É+ÿ–^í [‚’i}»{7É7Èn\gþ¼ÚnÈ×D`«ØP¶C±mð¾‰«µ?‘ò®¦'çƒ–ßIWÅåY(›Ò#Qiê1/G1//Ùt5¥¨F¹Ècu½¡	à®1Þ$•‰úwX¤¢ÿ¾|iÞƒÊ±Q8”Ñ–ˆ$ûˆ»\ã~KHXqÿ-""¯uñ„C9“¸€ÊjM ­ÖW¼i;Ü‹DC¥gÍ¤f™:Fá1^¯Ð•=´¯ÆMˆÊ ¸((†RÄ¨Q#æƒ·¬0ÑÔÄxÜ‡]4‹ð‹pœq?MîZ\Ò‹m¥{‹ë5ôôL\„Ž7›¦i²Sä1EÝ‘‚_‚ã°œmãå‚Þ‰Úe˜qæ GLâ˜ó¨•µÜf¯Yù³÷Ç»1:V8°Þ£·ò»ï^¿ýËŸþýõ?ýò—?þÏjÁ|bJV>­×¨Ùo9û3}¸t^+¡\ôa
+Í‚¿íýÀËŒv^]\¥øp;ÃÂƒÁÝ)ÓF
+îPå£*=q;_Ÿ¹×ù™|•oQóNªÙ£ZŽY>¹-<¬g@ëÍÏgR:Ü@áòD¯teÀíÄðó›8sføßA?e ¼ÿü€’÷ì~Ã¦¾øó3'µ<ANhæ¹µZÚ2iç-›¤˜™ßGA8«oµ:AŸ3q˜8õ äYž]š›IÌØyÃ|íÞÃêÍ03cÒIVXð‹:qÌG}—|å¯è“ÙçU{}îÀÝq6ï*Ó™£þ¤¨ ),î  ª‘5|ÿ"w€T9ø€§JÚæéröq¤Ú>OP³Nþ˜ÑÁÕ™åÆXßE¶Ÿµ£Ê	‘$e©©=ÒTVûÇ—|W¾[ÅÌÑx’è+6JŒBX%A2Î9W<75"DU.ªíQ=ŒŸMäB¬<oÁß£ê÷² R§OÀP6
+"1)6¹Á99Ë,qx€´˜Á«}yÏž„¶`ÎMÖzQ\ÅßƒðP†©(Ÿ”cFI¯T¸cb*„CòSñ/§goÁ÷ûôÝ2á¸R²Î±É¤7Í_n—Çæ/÷Å[æ?ð<HœëYŽ‚pæ6 ¨ ÔÂXoe ¡N[(Ë#¬Þÿz`•®î×1 ðm€LLn†¦ÕLùZ8/¨Ç™“38ƒ¤SN=qµ':6Ô”|W‰Õ§˜Ë_l9¸(iÖÆµÔÄYPægSg¸ =“=3`a Ð¦Œ|×v´Ù2·wë®çrÜQÀ‹M:èÚwÀË——¤’tùÔFøoÊ/¿¥Áò»ðÏWéêëzþQåX¾²Ìî‘tÀÐxb)Q§%ãÊpu4 lqq—”»ñíSj½!fBLér®…wt0uq'A¬[¤\÷ù".Y}k\CùY ‹k—3WàŽ*ê<#}ÓwAK5&Â(4Jè~¿Ç=ÞÎägƒ– Ðœ—ûÇrÌ&è§g¾©_L:Ug£Ý²t@PuøSš8ñ€»
+$±Óí°8:hÕxÌ×£ô?£ð7µ@¾/èœµä„&>ˆŒ¹ÆÓÝ­[ú‰ã±+Ô‘ú‚À&´Ñ€&ð×;aŒDóZgjÌ*‘ •kbè¸rÓÛ%B0høÌŠH¥)ÜÜKMœ¡j­¹÷R5ÒxRt4zƒKZL”¦Á'Æ½žì“k’S¼›ÒÅ¸Ë·{âœ¸ú0¬)ÐÈÌItM¨ÆÆƒnË»¬b
+;6X½%üØÓP°8ø‘”˜âuGÒ#L¯"˜•H²%Q¬\q­QAçxW­kÅ5TAMœlª'ìÚ8êÌ&áÊÌ¯ezT²Ò&%ÏüŠfµÚ¡-Îa'Ë¤º®V²_Æ¬`æ&K…`,„a Ô¡»‹^à¯u¶ÄQ¿+Uª£„<î0^©¼©ŠO¶/7‹­wÓñ¶è±ûìÍå;aÆ5®ð`RöQùcz•Ia•oR`ÃvØ‰¤Ø‰WÐëxÉ\
+…æN5Rø¬ýëé„’
+´X«BUÇ'ð>IMm6¥‹mÆpmÆìym, ]ªM¼µå’>âT:¤ì~QÕçÅÍùA‰1¿ÒÓ¼‚
+Ì÷›ïf%˜¿ªÿÙbœ}½éù$@HºŽS<ÏXŠìÁ\-†q­¾¿&µ£&&PT¯Î#tx”¡‚áL_KÕÛ¦£?u~cõÖ”'zH… Ù~?ãÛ@E!µ¬®bƒøïÓ‹6Qõð;ØÆüëËLÿÊ–×4Â÷+vºB˜
+YÅ™RŸÄ1C…€Ð)}"!|í’¦Žè\c¸­_˜Ëg”Kí1Ê‘ab6Šœ”UÒ2 °¶•JÚFma³Ù8#âevèx1æyÎ&pŽÄË¥HS³ëIþ0=÷¤†›‹²èjãMtœŸ¸.©€’ŽékÙZõDaUJ®ŸáÞªœi‰’­JZ|[­ Á«¡ØWK¹[ä!x9”h3N‰ž®QÃóüt“Bž¾K¡ï=Y¥vÃ~-8A|%"ÞÙÃ5…Qä‚zD5¬M¹:©´©RG"þ»é³&€@|ƒÏd¢è˜ë@­×*±EÊîÛ:Ë’åh-…¸t¡‡~˜‹Ô
+â®²ãEí¥óÿ_p!E‘çBŠ¦KŽ¼†›ÂØƒžB…1žùä>J¼€BQÆI|¹`t«ÕÔc“e²ùC§‘URaŒc~ºVIEœ³ÀUÐÂ¢)rèJT…Y¥UÁœ TŸ:iÿ±<çTK4 ÉRís5²ð(`+ UîŠD§4¥q;c‚<Ep\ã†‚	b÷AÁD1Õ¯µþ°¥¸BQ>£³òs,®x÷<íÕ»ê¶T­¬ÔP¸Säo¶kü¶Î_xPj(•F­Tëj‰E;ƒÂ;ŸH/yñ%)!òú bÖFKÈóž‹=Îás±Ç–bÕ†ú¤s34•eZÖÅÑC‰P'JcÄŒŸj"³jªä~"›˜u³Îw´`oŸ·K+fµ+'þ%ndýý>}O{ž‡;!Îò¦'#2Š3™é¥p< ƒÏ$7ÿMöèì×®óé©E’|hKi~.Êjz¾‹àÜÕsð¨Ô/Äo²ÖãŸ€ï_uÊ¦UXQÞ2ëÍ¬í8V¯û¹ë	Š°Ú²òZC•X¬W‰µ£ «ƒ$ŽR‡…füx?ÎÃ±7EùÇ‘	}šÈ[îº˜.€l{]ÓúùÌXŒ¨Â–hçDµ"0ÌÐÄújö
+aê 6ÒÚh^"Pþwç4£õ
+ª
+ÑL8ùÔsg$°Áv5ù»ëB–qŸæ‚­ø²ÊBm2¹ASÏkÀ}u²ÄŽ”Ðz÷¥Cq´Û ¼ßs?d}=ï7D¢¯ÓÁo3&Ñ)Gxq¨•¤¢ë8m&éVSj5sÔ7“s`kJ"ÚÀ^4OdµºŒLnrNTP÷RG4'„—ö‚	m¸|rñ¥©Ì|tJŸSMOBA^?›T²£LŽÛDv/£z]ê/jÚ+®ÊúQ"¥¸yOÒ6V®›©%`%YÎ‘dÔ•:›mœ ÞßÉ!?£¤aU×iZÚm-düåPÑæ ~£Ñ­'ëyí˜ÞEåÜkë™œôä¯Â( ¼D2°6e‡	“t‹@Æ]hÆ—ˆúoJÿ|X«5ÜƒS°¸†Ä¦µ”™*É¢©Ý×^ Öá“½@Ïa%€ï"	|B´rj@/XæIôëB•!\ÂYP}bV1ýKWU‡ûü‹Ò€#îìÍGÜ•‹‰Y}j‹¡
+D›ß—æÊ‘ö:Û¥)½1Ä´®»Ç>ÞH¥ù£SºéBMúZ7&rvxG´»ªÁUÕŠúþŠó7J†Ýt(aÒ› Ç7î´U29Õv[õ+Fž¸Žßc¸ðÝ&ø[7š–K0-¤ƒäñE×žWµ×T¯¼­é°'Kñ)™¾’tßIÏUX7ãžú …mÚ«ÖEkgà6Ä™WÏ‹‡ºb‹òÕk.™š>‰»ƒòÖ£Sº²V§äà¹RaE»ÚëÒ"ù6©9«¼c­±ÚÃ%Ú¬Å$ Î™ˆ§=0w‹jÏ¿ˆ¢7·3£ÓgrVØ'´'kQ•­rT§PmšF³îl#ï[] ÐÖí©èÚÂ0A`/äpä¤{tXP~bF_Ë«A„…b¨QÜ%ïë–@‹‹^¬u•jR<ŸAïµ¡ÏIºWÖ¶nªê@ƒ9{2l¨˜³”ä—œ¡õœ’ß„™c9ŽyîíœÄCR¼vÌcÍ ´ÎLä£ÂÓó•ž¯Œk#0—KÐÝü[ÐÄL¤þ=Ÿ+Ú97”JàW!EŒ_)á‘ûúü—	úðT(ú>”Mù7G@§æ·.ãÅX)JÑê´ô0Zj˜³X$“ïÑyÀjuÀb!®òeÕëEÇÎ\è¦È*E>¤ÍÅë4—Ê’ÿ]Jù.snTsr\‰’_•_¾]ÜàtÔÔØâ¨YóÍnàÀY>¢L:X©©¥¨2ðÁjŽžG …`ÆJ¦øœ¢~(EásŠú–ÔYƒ¤¨‹p„× ¤`Ê õïWš¤.fÞ‡mA¨ì9Iý<(>'©o£´6þ#çRÔ ­ý¿IS7ÈQÕºp™’’){¥4õ¨–ÕQ}$Q·²û,ÎèpÝ3:vf™w6‡r9Ëibü¸™±âÍ){®vÐM’²x?))S>ý¨’¯”ÈOÇÁ=®´]ÀûÑÓþI‡ÌÒ$UŸt$sU?“S²W\öÀà+O5€Ùu˜ólëœ.~8ü†#)êÌ!9êä–éãkQfH5‘Žwq„[ð[ð–	sµ3r>uxçØ‚ÕsIze!;»‚¶È×S¾Ài`<´Sc·Ùš¿üI›Õ­à8VqÔ¾à½“Ls€÷¼ˆ»"—‹;|öÏÆƒfF)!\¾H?Ï>YÎübu
+‚ºÞ«SŠ|¿ñÛå:<q?_§GòU¾EŠÓÂ£R}¹’Wï[ž8`!à :â
+@yÿ¹%ïØýê†âv@ Éèÿö>t¦‘ÆdÖúQãÎoÛVD!çÇÃ©{µÂv±þc¡è¶-$’0ŽÄ‰s|ÓvµXìˆxúN;ÔÍâT[ÊTÇAnÛ0€p>à‰«45GaÊkÅ7M–0U&ÐBnrg˜:2œ@–QtAµ©Ûs®¡Më\O*ž/T]UcQØ\Ÿ¬ƒéù‘qU±9V­Cs’ä>F2m®–ÔÍ¿\SðkƒîøÁxIÓY;ž·ýž¢ãäZR×F%OWÜ˜µX+Lldýx¤U²=S¯­WÞæ@É"¶Ød!B§’¿±ÈäÃ–”ú-6žU$1g)¿^.V”ë"ÎxD»2O#ÅtLb»ÑÊ…Þ¹£)Ï•ïòRO¯h¡Äº"øy–$m‹Ó’pÊÙ4ÇR¦Üšó‹3} |žMŸŠáä`ã’ú£™w^k=x;ƒ{f­ñ'È!Ù–˜˜¹ŽTeÀÈÉM²€
+j[í˜6<"T8[Ï%]ðÇªŸÈÝ£\òÈÓÇˆ4ç%'Ë¢Šç`Ž{ªéßP†ý”µ3é‘®¾[TÕFz…Z‡Ãûr(AÐÆÆÜºk‰¶8žâq»ü~$Õ˜pvèÚ‘|Š[f¯éCGÕŸæX%½Vû~èÃg\Ï7ÎêÜY&ZÒ58+l£µRZB˜É½ª³Ó{¦QªóOÞàë>…hÐ¢#Ð}&šÁËåqþÆÊñÜ›eÀ¡ñ7%ØceìxE¹Ö½{ŠÞÅ¤ÎÉØÝFím=ËZ¡nG¢œ¸±Yx jár~äh¥5¦
+œc×Ïá!åE²ØjßÔpz¶n*úŸÚ#Nf°)cÿ£ÅG†u„SÌñãE]³†µq“ x9*_u^o´f•Ñžé	_ÈÓÅe¨â°F{½€0ïW{þiÇ¼u|YÉÓÿ6‰ïÇíž¬måmçˆêÎ•}mä"ŽéF¢Y¢Ä÷òÇ´¶ŽíâdêDB¥&›Îl@yì¬´8B‡NÉHŽ°¡´üŠ…œŸÎ•ß5ÜQ.°èÑ¨äw±HÄÇq"—­|
+ßâ©_+Ü6÷9Ìñ»œ‰BÞUÔwµ«Ü’¸;ºÕ&ïQnºëÕ¾°öªk†ÎÓJ¤Ð6ÖÈ9mÈ °YDŽ[‡Uq¢ Ù¯—#¼¾°¢éÇ¨ˆÏ2”+aÂÍ™]¹þ…Ï5Dæ‹tÔ€z¶*‚Éq
+=Z–D/Çô¤´„ä|?:Â* CBº`\§P“W
+]ÓHõ­õ}tmÈL¤§›ßRÒõ“u•Ék‰L’y@OfmÀŠ(Ž@Zé/Î­7©­A/˜5ôÜÀÂ y¬-™¸ß‘¨Ç2œ[uàÂý¯×õÀ^·Í3ì3[„§ûºCâYWÂ“¡
+!ãFOÓµÈhCWO0QÁÓ}mŸ»­ŽÊÖƒ&«¼V¨W0ñï
+Ž–&Ù`LU„YW0501†.áÆÒÑv¼;Z‚¢¨02N	ŽTòù­x?J¸Ç"}ƒ«5âúÝÇŽ·ÝÇr;”O-¸dòzîºµ¼¨}ë¦0(ÃûiRéÆx~èü³ò)Ï1füÔî`ÑÀ©0l’êþ…Z3 RÏæLÅ#``C²PVÏ•XâÎ1%”s÷GÛ2žŒpxÉD“Sx¹“Y|ÎÓxˆOôËÍô÷õ¨õ)Ã«IQˆÌ>K±òÜ±º þa¼™^m´d<VÍb™šPð<QbýÆ¬Ž”¿Su—,™^NŒÞ*à¯R•{á"J¢™g®Íþ\q÷HU 7Í&;2P• Tº^\*‚Üÿsˆ0¡˜Ü«¼Ý2#ÃvbÒD‡Ìõ¯Ìh¨‹ºÅž’œí‘ðƒå‰¹}·óûìÍ‰¯²vÁ×¼Üjtt<nÌãÆõFZ8¯:LôGXÓv»e÷a~½ã&€Í³*8v2Æ“1	cÛ:í'3[’Á{&ôè’Þ	iŠ>ñ`¼Éb=/`÷™G™nÍ$*¯L±n"f¤Ž$@Ü…4°
+,DÝ^Î}«i¯QRV’ìÀRñÉÚ6ü?ñ®¸Þ
 endstream
 endobj
-293 0 obj
-<</Length 4273/Filter/FlateDecode>>
+347 0 obj
+<</Length 4735/Filter/FlateDecode>>
 stream
-xœí][“Û¶~ß_Áµ“xéDXÜ	fÜ¤ñ¥iÒ¸3ï[Ý‡x§š¶coÒÍvêüû)Ä98”´’×í‡•d x€sûðáèü›ë›®¼¼i?ròïF5²‘ÍjxQR†æòÍù¥l.i¤PRõ^vÁ7RÈ>HÓk=¾µJuÞ5¿\^ß4^éF6¯Ç×±—×±»×'ÿ8YŸüåäÙó'çñÎ_üúóßÏøñ×ŸþsóÕWŸ‚X%:ßôÞ‹¾ÃÑã»qãÐÂð¿füg§Ñ(+¼vÍ›F6^8Ûãlö.] ›ËF9aºáíëFaV~¸ÂäMMjq9¾ß4y=¼ŸÛÌïæKÌx‡MS3Ê&ï3oš\DVO^4RhÝY'ûA@z3‰v|«:o;Õ¼xòçFŠÎ5ÿmló|–É›÷O&ó”½ÞbNO^Lò{ñóW?òÝÓFF±éÜ:Ñ+/•óõBû¦·AH£ù½•ÍÓŸˆ.T!ù`FÉ»N›¯Ò^º´t&ltf|7«ÌÉã‹F6×çkÙ(Ý\¬s”ÍÅ›¿ž½”R¾”ÚŽ¯ëé“›^}û·‹ïOž]£ÔÜ(­.¤ÇèÜðÖ¸A¯†åá7+¥ƒ£TMÏòt3&Ç¦Ç×ëÍ'#ÁsHÙ¯¯Æ¿WÃß|!U*?¼~:_?_2Ýé&ûnº«V@jãu÷[¥Ï@¯Z%ÏÀÝ¯Ð…é™,ý±ƒ¼I·<E†›"-Eßí¹£+;K¦ámd&•oµ=Ò’Ædó¡Ý,xT°ià÷ZæÓ´éîå«6ÝÇ€/¤‰¢ŠkÄÃîÓÿ+ôê˜ë*"·¥ÕôRhcš^+Ñû}ÃTÃÁáÅmT«&‘L’’`YÝÏ?|¾É¿uâ3ø.[*ÿüZÏµŽ¾ä¥è˜…ú^(à§Ãàxä 7ëÇ£ÇÖqj(CË­Ü¨Rª½ø= _¨wô€v›Ôª*½”&Ú‰&0*DTh©¤îà<`£ûQ>*ÍºÕIQ§™*GMÌŸôH1L¦Ë°¼²<xZ«Åâ‰“ÚÚânq}ü¸xÄq¤hWóÝÓ¸mÞN-ö¼ñøyÓó™V«3¢Ç5­»Q¨Wi¢¶9¬Ûi¦ñ›$ÑSp#‹V€á„™M7^G±¯,†(8ÍÜÁ‘Â­ÐJ-]ÑâšçíKÇ©spÂ÷C$x$…ŽB(‹Y™ócÆÇ&õ*êJÑï:Ÿ°¤Ñã*²­f&®.pOä|7ó¹*ˆëb/x­¦%oó¨]1ª&âwíÔêºUVUdbÆÀ°SšœÁvÎäkAú!ÕQy^*……
-rRˆ¥õ1/Ä&' ¼P)áegµžòÂ`œÖŒ˜È[E'†=Y_˜­Ã¥†Q¢/šltØƒ­¡¿J`žJÍá
-°Î’7ètµŒ!~ú<™ ã@Oó÷<KruÈRÅV8²†áÓhµcŽ¦¨â„”ä¦Óha\w”$úb†Z‘J–½¦œ9…³{rT¢‘Ü]òæQ Elñ
-ìjáºñûÏæ/7«îœ&”¿ÇÀ+÷6gE‚NŠ¸³¶’÷)´	²Aï­›ÙöýVMNüX’qôPíŠøörE"%@d}'ô4()‚ºM˜Å/ðÙ14&ÙðËvŠ5â2ö'²_¾9@F<vô¸"MËéBÒBY¾£¤XY&Œ¦Æt§yñ4Õ|š'›MJš'SÓEßµ"’(œÏ&#Iæ¾e&2"1ƒ¡ôˆOãµ&_Œ[åädh˜üs]“Âœ›¦V0™Û:ÿ†Ï)ZS¬ìîxµ”²'ìXqÀYš:Ûª€Eâ·K®2ÀÏvZSž‰‘WÇ<ÚÌ.ö¶+©bŒ§øÎMïìFls±Ÿ¶6= ¢[°–eb^A@ÊÅ[ðz7 ‰ïpvN0Á.—5ƒ	õœwqF8}'Î…Ãhˆ!p=aì®+=¶éð¬¾ˆ ÑÛ‚ÃE\”üøÌ`­É c¸÷ê˜è¬"/‰ô(Èãm)Çf ›…yŽC†‰0J““ÑbE9·¨§ï×:ÒÀÃ}`<–b’ˆ±)ß®´ÃqsŠÉÛUüäÍÛùÀÙ+‡Mõ»r<)}ÂH‰¤Vgž)u§d	oTñ'š_Q)ÆåBWZÑÑn…¦vJ
-àÍ`ªÒÎö’ û|X*’ÕG(µ03Ú‹6ôÞØN(ßøÐ	?	ï­¦aTÍoT…9Žé'‰Y“›ˆÓš“‘IdarJJkÔ<åÃ ë£`Ÿäæ#=	LÍ¯³¿Ë´›yw3Å;øï„2Ò©å¡ Ê¡qI×ì¸¾÷}tsq‹yÐ
-ðŠ1ÄÑ”8'×HÉþ_oÁââh\Þ[¡F›pÜòœ$ôD/ESÒñi>m»)`IÍÒl1{¤¹»Œ;óæàôšVB†s£~§þ®Øš`´*B.Á;ëƒ°Ò5Þ»aÑv¿,ôi}¸DÁÀjE¤–[·Vî$eÕ,Bé xhÂ67–ßË:¹%†ÁÑ8#õäð”‚æ‡÷óÁBÃŸß×ùLÈþÁv½ÿ%@IÆä,rˆ“n ‹giÉÇÿI8DÁáC7Ì[ÿhöc¾¥Iq‘Ý öuÒû?.ñ¦0O£$tò²4ˆŠ¡á¨^ŽEý{FØRzN–pï2Ø-#ºãìªìDðwaU¹¤¿ÑÝr/(Xíªä9CƒŒLä;m±oq«ªc Ú{Ò ÿØ¸‹\Õdc)f»rÒæ¢DêEF1Ônb»êQJ°™rKkIï3eÎuAH5+ä í„„[¨Q7Í‡Œì }Äu
-Kß#ŽœV9Î9-Ü(¸·†Æt‡é8—8¢ó	Å‰F@Â^TŽèpÀŒsV8}X&£õäz €—”'˜æë ñlœ†?æì9¡;þ°b×dÿóÑ'`À·€ŠxúÅ»ÿ.±£ê™-qF¡3ª‡ƒc ¶Ò*-äàŸdÚÅ‰1v
- £_®Å¾o/+§¡0-¤S3Zôá}=9µ+¨ñý!’§r‰Sƒ‡¹ƒHÞpøH9¢CFò7å9K(=!òËumWÚ§°Ä°÷ê@ {6ªý Èi)œÉ¬ä–” øì;PÈcŽ“fý	4†´ámÙðË4	ÚñÀ¤ó×Î€mš4±½Ý­˜¿KHè‘9`ˆûQ$R„ªBBFÐÒ°°,p %Zñ)omcãÙò(Âœ¬«b•*Êölv8§Œt•…ÏôÙ³L È7g\RH`anL3«æ¶ s)LÕ(—è™/Npó(_<s:X¢‚Ì5ãØ¹QîrŽmgƒZÛÛ„_KG"ˆ7áZ§¥ˆn5Þ–›õzY;þ.×k8©	Lt5­ª¿‹í'ÓssXé½>¥¾OLÀ0é×]¶&Âƒ?4Ò»×ŒkV}£ ß“ŽiwÎËhï+epRGà–	¶,ß§à<¹ã˜ ÊŠCK„úÂÕzÄMk–¸ôq¶hTÀ<(ú¼ýúP†ÛJNém<Úž3 ˜  (JQRçDéG¾Å	.=X3h6û%'AÖ—<WÌ¥<8·™œV$ìƒd‰ÏgCö;M«KP±ó¬•1Á'Ç²Ýitäù_˜Âæråv]ðvu±ñƒ´ÒD¨ºnç3*ê®8u7Nh%¥>š—œ2°Ñ†ÃTZLèÍŸ©B•E°=äØÑÄ‘©èxžü–JC>áÃ¨{¢Ì5‰%Ÿ²õ2SQ¦]6ÿ¾e¨Ý;®~nc&ãUV'‡][e…
-w[ÃéK1¢c9Ç%¢JiùW„›ÜÉç3íÇp©ƒwFGO®)ËÜÐt£%€Ñ‹“8ƒl[Ô‰ÍÑ!8ñÃËÛ*Í *2UKFíÐ'¢‘«ãŽ€„†ÊòC,¢¬
-Y‚6¯·á!˜`…1È‚‚®syÙ0Bù€Y	X\‰	…±ˆ˜Ð§ÜÐbCO0Þˆ õ¦¨«¥	
-–«ih:‡<Ñ¡
-ŸÖHõÈ½‚Nr¼Q½ž¢H,èž×€ÑôMV@Rç%[PÁ‘8š<Æ^2Ô7—ŸUî|³ñR+¥9ÑbŠcóã)7ä1„«l#p.ÎC\óäŒRû|ú °æ¬lúE«c\œÌr|UÅ1–™5
-@t  |²¸<n¨vËµt“SI›òYì€)¯UIAë0nö}Š+å)‹Z¯!Vë½r|Yc‚0ê˜§gbÁÛŠµåQª´î¡jâ¦Â[:ÿ|²%SþÕœ«£]²”-Awë´°½iŒé…9Êš™>“W‹tŽ«‰ðbÜO=œúTÆˆðè}IBA´5Ž	æ£TäÍœ3ÊgÙ|G)ãOrPw¹ÑQ…=ðyH¦¾'_.æô5<RXO!`E¿ý)ÞÉDVî‹7_HœªÞË¢•ði0¯«, Çƒ!.›®â€ìY•mabî’B_¯«¸¸¤wËjÄóº¦÷Ëw@o7†í:V‹ËP§ã N#¦³ÇÛ’N0!Ö"YF›–0ÉOØ«UÔvö^r|€"nÙµaó¦Ú}y|}äP¦£zD¹¯¦;ÝC”$?~É|ŒxÁ(—(Iã>ðV[_¦B¦¨ÂŒ³¨¨¥fÔR‡^8{L¦^Ã¬QdäÂ9Î‘ø±iÓ®bäƒ»èí¸ÊŒÚ‡&¸‹‰+ÌHé€3äX‹V*´Âì,l"}Õh·û|Û©¢ó; {}®³Cß1=w;xÊ˜ÛŠÃò¡÷ÃK°Ò	P‘%,{ï`­¦ÕŽAKµVÂ…ùöLíÝP«fñ$ÿM«&q]µÓ›”&'j—\çÇtn «~(JôXæ^
-;”kRýð¸~0º÷2€ŽÅõ@/´É# Ý‹ ƒëM˜tÕyÑY×¹û[GCèŽÃÚÔqø½lÛÕGDðÊç,@Î‹S`žŠ7ës);ºêü¦§Ï‰4
-Œ&kˆ0=ÌL¬œ‰xÅpêUìG„UÞõðwÆ	­G£¯Ä›ñOÅ!¸x®UœEÌÊËß›Q6ŒchúÇØ¶8•˜vûa1T¿)¹OeÇe<jè´ã <e{¡ÌqÐi §#ƒœ‡-
-)A\ùœYàˆ*Áÿ¸\ùËé¸ýü(œ/!Kë­ÐR7Ê[Óÿ_À5UlÑjàô×ûƒÓ»¹å¡:`@x°V¶r¾Â˜LÇßð	Ö(Ó}ÐÕ	°¼>†1…'HRKŒ”]ØÔ)è†0ÆXÛû¦—¢‹B|ëé@Æs<95”þ4C*}œŸòIš‹=]¸v5+ý)M€éåôŸ8Ä¼À‹¼,`´©¶øÏñ[;[œ.÷ìO¡:Ñ…~Ðª¤<›ãÐïà£8ÕPlÑ×üwÔ»3B{™×dù­8úSê§d»üê50Ý¢lƒtäð¯SI…AuíÚÕô€«ÖnHÌ g1ÿ£‡-+µ' ¯†ßo:+ns¢£¯¤:qÕõ¹'½E¿c“¶† EnûÜz?”Æ[¾’ýGÛ5
+xœí]Ys·~ç¯K²¥±E70Ù±uäª(U)ñ-ÊƒÅ
++IQ´³f*ö¿O3À ÇÌ^eQâìî@èn|_wÏÙw››]~qÓ=ýâä?ëhG»S÷‡Qj»‹÷g´»ø©£„Q6hj¬î(¡ƒ¥bàÜJÆŒVÝO×þâ÷f¼£Ý•ÿëïrnwuòÏ“Ë“¿ž¼zýâ,<ùÙ³³ó_~üÇÙŸ¿ÿå‡ÿÞ|óÍó— !’£»Ak2 9Ü?Øø&ø¦Y÷­ðÿäÔ&‰æª{ßÑN%J&GñÚ]tLaÜáUÇ‘Š3íÎé¥"^qáÇK®Üñ|Í|4Ÿ"üÆK…—MzÏôêxÉÅAdõâMG	çF*:8ñq¥?dFKÃº7/þÒQbT÷¿Nv¯g™¼¿{2™‡ìjÅ˜ž¼™ä÷æÇï¯Ÿ=;{ýâ/;ÄÆG¹20M™ÒÔ„ën–PÁü~¦ÝË
+·`™ä­ð’W†X™ÎÒ*k¹pkÆŽkÆÍKæäùyG»óÍÙ%íïÎ/Ó%H»ó÷{ò–Rú–réÿ^NŸÔôW÷?ÿÓÉ«óB+y­•R•6Rû6*å…rëÊM=Î[Éº¡ÑHÊQóÄø—™é3›þŽŸoüÿïüÿ›éšüB©×M2½"ž3>ë:ý-<WLç0ÛEMÏxhûxÎ»žÑ'I6ù™±w¦Ô›x}zÍÔÁëÃ%jÃÅánuí4«œ®X‡éžË'p¨„ÕƒÐó¹wáÊàM¨@cM“q™n÷ö]Ÿ#ÀTpåM-ŠnÏà dç¡²R•rÆ‰5ÝÀ-\+^eR'yæÅ-mnÌht1fÐÚ²ä(üî´ŸPD+Q‚[!ÜŒ«äªðÍxíú|?kÂ‚'·3dPñIþÃÅt™ÿp•<ÅAç›„¶î`‹
+ô¶H»éÊœ %SÚjîÍ¶;0RcS$õþã‘T<ºZÿ¢}’QêQ”œP¨¦iG‰á^˜NoÃ•¨ÀzÀUU]POpí„¥LY:­ûÏ•M9Ýmm)M˜åª°ºÜâRv€Ë‹yEðí—×@´ñ®À•ó¬6Ö•DK“NšðMDøù*~Žã=ßnœ4Ó“noy•dè˜t²bÂ9ÆÂÎ‹ÍÇ[+ìcÖÞ+LåÒÔ4H¯1ë7ÌÉLúC÷]æKì-¬gœÃ0èAE#ê¾£”RAÃw¢fHU¯ƒgý¨hô„ªû:ß.èèÁpÙ\ªvv
+Eg	¯w]–ŠI»Õ³É˜œƒp&õÝz˜~x”žÜ¸ñ§ÏÝ_À£ð›óiv»©KÒT<5;Ä€¹ã6]ÔÉMjÿÏïVù(Ne(ËŽZðþüßåÖØ¬5ƒ*¶f»m¹7‰×Ü. æ8 þ“I†%‡B9…S ŽM¸ð¹ƒ·ÜD'¥Ù„
+S¶*Þ¶™23{¥¼ÒpÉ³ùÙarÇEëÿþ¦ç“»·îïìb¿æï˜éOÃJw.y8Nû
+Ï	ßU´|ìXè7‰§/¶‘âÞ#++×÷ßD‘Ævq·-×Éˆ ™¯¢ý)‹úWõ"ê]ØM'Îfq‡{	·lzQíe.¢rº?ÇY§;_VAÚK<"u6Ô´†ÕÄª£¨ìTzaBÉáåÛˆ`ò„ì™E¯LÉ¥e/ò©[Uò8xþ”/ÃÈmµPXù÷âò”M5ËÁßI×V~Fk6LkçÞ¶c¬6³öÎŒÍnT"ñi~]¢yYXfPE¶–a˜ËQ—0gÚåúQ]7· îBZ	ù•q–‡~5úœÍa×oÁ´•LIhCq9å:2¬¬`—Çó¾Z/’g}yAüH'åŸ‹&E¼
+wB´tŽà™¨â“7¥ç”Í	›wâŸûïžNOhYíëò0`Å7-† P°áB¾\üË—íãµ¯ŽµÞ+Ã<ÊUãŽGXyh4ßYÊçÍ\œxäñ,ŠËnÑ5YZüP© ÙÉun^Â’Gwl˜D¤T6+žÁ–UTÜÒºwœ^‡ú¶µgÚ3š«<Ü–œCÈûœîDròº²¬˜î­ø?+Ü¢I—uàªb)RM	ók‰ÙO™*¢º§J3%-WÊÑÔHÎ'®ÔÒX©…'KY…,•5W“3ˆþŽ,k4ìŒ'ûvÙ°GªÖJj MÅqÓHwA›ú.Ñà©O²‹þÌ.ìLn€§²Aš&Xd°›L5Ö$¡w%»)·¨S¯h³pÏpTÂÍ&^Q°"—‹Ñ‰Í&‚ˆÎKðæ=Ô÷Ôè@!³ùœG3¬ÊƒÉ}8ÿüyyJ…ûõ,#è£ú‹¿è¹ã/C<*æg›ØàŒ™®ÌZc%±ö(¤ñçÑh¾ÃÛûŒ‡=Ï»“idÚm;3ð|5ßsºû	ñž×]Ã:±œ6`†{yZE»ËÄ.èGN8H£È@Õ«‰ar0Gb’º
+îÚÜ¾)„¼ @·Lù¿m±IO1ÐÑ¸Ñ·‰5-®úÖÁ8N+{ó¼=ÛœCQ†ídp_ ¯¢Qíï^8ot#˜·€]`ÎMh[‰”®Œ­Gpû¦Ù«BÛÑN~=‚,ŽÄ’†ûoÞëèÅa0¡‡–á‰8ÐvÎ¡¨&—ÒŒÝA¿cÌIWZ]$¾Ð@l9af‘7¢HkÈ¼Q”(v¤®=…‹ )BËëãñA	›ƒ¢DëÑ6Z¿eô®À +h%^‹96Âù…Èï¾c&jó·Ô¤ƒMáï*
+vivŠ:XeLÕoœá¸Þ81fÍËÎlJ±!(<"Ê¯Lc /¤¨g
+ôQÏã
+J»¥
+¶“3xJÈˆølDÍscbÌNçþ–áøÂ,Äpöv$¸·¥ÞAŽ‘êOÕ:Ö6}²¦:˜!ê8~pih2AAÛRyZ	nP¾0´UbkÁõ$&rÑòÂÁãù²æÿg„
+ót/úD’V¦O˜ßÒÞ>IöHêž=ÉÔÇL)Ä!IîîttB§#Ö‹îg^¦MxÚÕVåæóÌoÐÌ0«EÂjC‰åÇ`L•ˆQÎC°ÜršÚOMTKéI¬0qXº]†Bº\êBr!­ZŒéØ:³ ¹®op'ŽÃP[Ä·µ™#-QRQyêS	ÁÖp0`sü¸7K›0x²Ç9¸&ä'iB¾ït¿ëÈ·$-˜]„ÝØa TtZ)´Lï©=$xÏƒ¬áAxŽvs*¼0å@„ùXx‘£äÒhbÆe§•k§úÕÐ Ï[4È—K)˜Siµ–Z¯¹!”ß:z$jaŠy{>Ö¸dªƒëD£ h4Ca‹´ˆÿñx‡Èÿ#haP›z,töìVBWL'˜ãCó\$y=Í¶l¹áÎºiœl)u(âŠYîôÆ ø>#„^ì j€N¬ÊµÉ˜!€"¬Žÿ¦ÙMjôïÒý¾Žú¨ ‰v¬™t†z©‡Å€²ØX£[ãoBo9¾G¬ÆšÊÐãK¤y ‡†d¿s@óâÚBÖ©Åß Ã_¡K¶ÈiÕŒ­_Ë5f_-pR’ÐÛO4ª²òöl)tÛpÀehÀ ›èç%N´UpÜ"Ô¿‚2Þ3VàÜàõZ¹T“¤	z†¤?¨ìºœžÚ²õÝD™'E×³ÔÑŸ(œ ØÍZ9ˆc§í…c+„Á9üÚFx–ù*>eøè¾ÎÔ½FÁÿœMQÿJ*2HeðZÔ€a¥ÑØq:x41Ìš
+@†·N*iˆàÃ T=-lû@Qm’BÎYÔx)ãyÈ:†˜!ïê›5µh¯ä0Tãýñ8|o×f«Eh*®pá”CÕ y®W‰‰N†ØµÊÌn²D<_÷ ò~B¼Ç‘WÕIËñW&Œ—'WÄÚ»Œ#¯ÆJ¹ª,³ûbiûÊñ¾`Úº¥–£òÌ²I¤ÙbûÕTL“9ø/#Tk#;Å5Î°»c%Ó¶¥e~wHŽçyC¬µJ·Š
+¢n?BXÖÂüòöÜf	µvìî‡H,™/] $N½iáÇ•ºhÊø×ÒÔ› â{2î(Á˜áCÒ-L”~«“Çb/¾+í÷k†g™S:(Þ‡zS 2²²1{@•;æs4”Sä–u¹šÇ%|wÉ,iQ²D(%ÊÒÀ¨KSp©Iw+¿pi!Õò6šLÖ«3Íê…iê˜{-ç ¡bWÔÀ+Å¡£¤•Œæµô£
+q9Nÿ?À««‰*ÈËK‚Ä§§Á°[>“¥yé¡-K35ŠÅøASîT2¾±$htÒà‹Z£É«t›ºS’À‰šEU«b+•!†Ã‘4ïŽ™¬Ë¤p‰òÍ8·,zøLÞ€–ÒÎj
+gsä2©8ö ª@xU©êÕëv4K“=­TSÏi12U]‰äÐH ®—pDGªe;åµ4ºs¬Z·15
+ïhçÖ†Ú¨•±•ÒÕ¿9VtN9Þ*«ÞU+Ê*¹$Æ~ˆìYUËþ.6é`2fÇ¯\ZRõ;ïgG¨*Ò5U#_Ù÷Î9… ºê±Yé§!Å–eÁÖ"8·)éXÊ-8]h¿Šâ´6Kâ®y¤õš¸»yƒØCMLo¦¨çQÉ¢‡äúÒ½Ø:µöJ2ò>!%’2¢®ž•¾ˆo~- 'ªû”L°¸îcL2óÂQŒÉ@SîŠ1ÒD8–s>›Èr°‰ªáÉbàDØ#Eš°VîXÜ–IÈV<ŠÎ€w
+ûe»ï7µ!¼c[¦`a¸chS%ê="6‰„PUYÆ½Tqm\+ræQ!_3Ø=£ƒ›¤dx@³ßŸCDDòªÿzñ]7zœ‡.PL(ÈeÎùK®'ÉÂžD÷]±êÍ‡°*(Š0g@>_á‹üu!aÑQð`Aqw™ÜÚÁ6ªVŠU(çz%Ø&Ôà›îûþUžÅYzýá¡Þ[ïS	-S=žÂ€	aÌÑ‹@·Ü-e”IØÐ	-ò…|ð³Ÿï~V½¶-'3¸°^žJ5à’w,æt%'A¤æDPÅe'”!j8^Í”{F5Ð^0-”Ÿm*KÉbÓ>+ù•*6×ÕøQð¸ž€C¢¯÷
+!	—·°Ô ¬¼=,«&‡k¸°ß5!f÷–Uø¹U(‚»q Í–|heYÈ˜ "¤ºÙVxF”„¶â	#4“Ã¼3…ú‚çB†Ë­®L¶Œãä/ã+s±;ToÛã½Kmðf·×¸éZ©^ÁÇz&qçú€Õ²ÛHâ«àÙ[Ll;`ÖXxëº\,X†R„óË:l%¡kõe„[´¸ƒ©k%ŠM:Ø¬‡ÙÕÅâ„Íð.0°H6ƒâöÈ'Ýªüfß­ D»$Ã¬Šeœe˜â­ì¼¹æd‰‚Á	N|K-·lÉ[ÔT}}‹
+vÍ•$Æ(µÚ¢\­»Å€·›>¼‰õºŸân!jaNèpÊ&MAÛƒÎàîÕéõ1¾‹©büºvJ„úS¦3°¸îéŒl5IDghb©Uƒ°ŸÁ™ãË¨_˜¥Ê|†®áŸœ¹úXGze–0ý)Hv]‰É@µ“CøYÉçz€”²1yP @kÂ…Ó»>ª„AÓùõM€7‰ÖÙQÖr´k‘´œ*BÅhÍ2³‘+ øÎP}"5Ø<öàñ¡¾ÉbÀWT¥5%o–Q{]KùfV)Ž‚ÚCâzG7µâ‰pG5gÄN[·Ó•5ä¿‰ØïÏäoÒjŒBéå<l¶ªcVæ(éG‚+Â]Sð=ÙZìðëÝ±Ã­L$Ó®²|÷¦‡õ•višr«ûæ˜÷Ià€Òºw'²Å¡aN‰”;â0ÎRºc‚=Êðg]ö'L-¬)–›®Cy_”m-.<*µÇ³£ Žx¯D5„ïñ¾Ì¤÷îBŸæ3šfem
+&f®U×À¦†˜0¡‰vÌÙáÝ„§åWTÂºØè‡–828l¡aìMí=/Œ)Güî<¥î¬¹˜Þ%ø´¾	gÈÅ*Ðé÷àòGe˜c”aì«þtêàY/ÇŠ”àÎÑÉÎ^lÝpmM0N+G3ílþ‘<†>ØúÂ;¼4Ðö&ç ¡DR=ßˆ}ä–Ïð5îÿ¤Èš%
 endstream
 endobj
-294 0 obj
+348 0 obj
 <</Length 314/N 3/Range[0 1 0 1 0 1]/Filter/FlateDecode>>
 stream
 xœ}¿KqÆ?×U–X94%MQKS†Nø#Ô¦óüQ vÝ÷BšË¡©hˆFk	¢ÙÆú‚ !
@@ -1149,7 +1339,7 @@ xœ}¿KqÆ?×U–X94%MQKS†Nø#Ô¦óüQ vÝ÷BšË¡©hˆFk	¢ÙÆú‚ !
  ô’0l+Ï½ß£Èy7½®Ó;¯×«É¥º;QŽ?V.ø_îtFÀà3LËEÆK¶)y	ðëz”80eÅIPö¤Ÿkñ‰äT‹/%[Ñp ” å:8ÕÁ…ü¶¼+%¿÷dŠ±ÐŒ"ÂÿG¦·™	`d_¿{Ù¹ÙÖ–gzžçm\‡Ð8rœÏSÇiœúµ­öþfæë ´½Ô1\íÃÈCÛóU`¨ÕS·ô¦¥]Ù¨ŸÃ@†oÁ½öãâ_±
 endstream
 endobj
-295 0 obj
+349 0 obj
 <</Length 5181/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíÝy|Uåð_nBaÈ"U¨ bPË8ÈX*™ˆ@A Š±*WYÌØÎgšZ”¶–E¬0¤("‚e°PAdQÙ‘$$²ÜÜ;Ÿ˜FÈ~—sÎóžó>ß¿úçó¾OŠçžó."šˆhgBÒä9­z'kWö'rrrr<>ŸÏç)ÿ_'¾ÈÞ•õÎªEçLJJ¸³}8:-$®gâ´WVlùôœ× ï¹¿oY±pÚC=ãÐù)8®N	S~žy Ð¢Ëû3_2¸“=ò[‡„”Œ—}†*>¸ÚÏÿ,¨­Q|rºÑÍWý+XžÒ·1z”TW‰K÷—ú,PòIÆ„xþ÷@!±ÃlÉ÷YêRÖ¼¡±èq“HlBÚŽb„ç`F ENÛ[æƒ*Ë~ePz´ÿÜÆ+>%þyÖíèÙÐKDß´Ã>¥ÏHä?Öh5>³À§ ‚µãZ¢çÆñâ’×ƒžöüáÙ‘Ò=CvÃŒ¿€÷æÙ:­5zž©qÒúŸ-x²’ùjÀX®¡o…ü%ÇJ…«†ð¡a:¤óÙÎÉ´NèysWÂjK^ë¯,+©zöìîûNùlìÔüÎè´±ÈQYÊ?ï7¤ló¨Hô<ÚS÷9Ÿ#œ›Û=—öÓm‰"o÷peÉ­èù´—~ïØþþªÊÖÝžSÛp%îò9ÐÞäôÌÚAì3Ç}ulfSôìª®ùK¹>Ëy±z†U“šãs¸‹nþÔ!jòŸ.¤ry-¢fœöiâÔt®ª¦QòQŸF¾Já_ÀuÂÇÛð_hŽŽãf²J÷û4th(zÞÕpËŸ|šZû}ôÜãÅ¸¯ú´U’®ùAW²?ùêv!EçÇ€{w£ço¯¶†n~=÷Jð¾u“h("ÕAøCS8[¿/ƒ=?FÏºJþöÑJc·MörX¥4=Fôq¿b»wUp4A4ÑòwÅ§ïÒ¢ƒÄ“è™VÕ™dq¼öëÐ³¬²L§oøzŠÕva„8Xãtôüªo¹sü€ý~ø¬—8RXŠÂ'·¨¤ÔíÄ³¾·=¯öñAGqš‘Ñ“j'yÿ*ŽûôŒÚÍo´UèÖOÑÓi?‡s¦èH‹çv†KyîvØ^n«xÓœ°6,n3zíkëbw½»›Û
@@ -1169,8 +1359,8 @@ R¬¼»Yßäs`ùsßr'¾í÷KïèÉÇûkÑWXò)ŸÖNŽ±ÝÆ>c5qk|yÀ•´XôüãuZãÓ“÷mûœè`ª{?òiho?ô¼+Ã5F»
 –f§'µDŸDbÜ-þL³aî ¾ÜUHX÷ñKö•XQ}ñ¾ÅãnÓ|×¦¢"â“Ó³L<h:GFJ_Íj±Ÿ	);òm¾èàjwR<ßéÛFXÇ_Y³/ä7Ey{W/œØ¿#z8¤æ=~4eþòÍÎôCÑsæÀæeó¦<ßŸâjÛcàÈ‰ÏÍÿõÊÌ¬íÙ‡æäää|ûÃ±(''çâÑÃÙÛ³2W¾6ï¹‰ìÑVŸÇ»ÿ:fL‡
 endstream
 endobj
-296 0 obj
-<</Length 127498/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace 245 0 R/BitsPerComponent 8/SMask 295 0 R>>
+350 0 obj
+<</Length 127498/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace 299 0 R/BitsPerComponent 8/SMask 349 0 R>>
 stream
 xœì½{x•å•>ì¯_Ö¡ð°‘ciÃ!%	„P’Ð(T@Z98E,C)u¨¬¶Vœz¨~íÔj«m­íL;Z{šNÏíLë´jm=;¢x€|×»ï;wÖó¼Ï~“½Ãæð>×såÚ{gÞýî½ïµÖ½îµÖ1Ç¤+]‡åê8dV±ÏDºÒ•®t«ã0_Å>éJWºÒu¨¯Ž£lû|§+]éJWÑV±ø[Åþ@Ò•®t¥«OV±Áõð[ÅþÄÒ•®t¥«—«Øðy¤­bžéJWºÒZÅÆÈ£eûsNWºÒ•®höUìÏ?]éJ×ÑµŠyéò¯b/Ò•®t±«Øð–®¤«Øß”t¥+]GÂ*6’¥+ßUìoPºÒ•®Ãl´ÒUøUìïTºÒ•®Cz¢Òu0V±¿eéJWº¡Ul@JWqV±¿wéJWºŠ¶Š?é:TV±¿‰éJWºÒ*6Ø¤ëÐ]Åþn¦+]éê«UltI×á±Šý=MWºÒU°Ul8I×áºŠýÍMWºÒÕûÕq¤¯}¯¿þô“üéä¡û¿òÿÝ~ÛÍ×ßpõW]þÑK×­øp{ëòÖÙgŸ>£eæä9S+ê&Žžüþ'9»ôÄwê.üÿò_“ßbCõûgžZÞ2sòÙ§ÏXÒ2óÃí­—®[qÕå½áê+þé3×Ýs÷m?øµŸþøñ§Ÿüãûöué«Øßât¥+]=XGÖzéÅ~õóŸ>òÐýwÞòé¼bóÆ/;ûô³kN©=°ôÄwŽøæÞõ–ðq›—Ííú¯ñ#Ì<µüÌyuwÁ’¿ôö[>ýðƒ_ûÕÏúòK/vY«Øßët¥+]¡Õq˜¯×öþï/~ñƒû¿r÷õ;ÿáâ´/œU3ùý'æÄöžîð3ØWÌwÁ?¼'¾oPKã”õ+ÏþÔU»çîÛ~òÃÇ^yååŽÃ|û;ž®t¥Ë®ŽÃp½õÖÏ=û‡ßüú_¿õðçn»õ’]Ö²taySuÉÄQýÆ¾÷Ø0D«[Þü`øoBs€=uÜ°e­³®ØüwwßvóO~øØk{÷v†«Øß÷t¥+]Ñê8|Ö¾}{Ÿ~êW¿ùÕ·û÷ÏÿËýW~ñ®u·~îüÝ»ÏþäÎæõÖ®^>aQcY}åàœ	0¨«þ¼{!'ÿ€q×Ð$ùðÚÿ]¼ü¾þŸY5­:çæÝWÿÛwyåå—:ŸUìï~ºÒu”®ŽÃaíßÿö_ŸùïŸþä›_àÆÛ>¿áÖÏ­øâÖrßú¹óoýÜùŸÝ~æÖ-sV/ŸÐùX—±w~/ž˜ÿ¾ÀcpWë&ŽÞðáe·~æÚ>öÝ7Þx£ãpXÅþ5¤+]GËê8´×›oîûí¯xÿ½7]³såÅ7sëÆª­[æ|rgóîÝgßú¹óùáüïº¬eËº:ÿ
 þcß{ìÄQý°èNÂç„]zÞí£­±€î‘ƒ5ð#-ýPã5WïxüÑïî;äµFÅþe¤+]Gòê8T×Ûo¿õÄÿè¡{?{Ó'.X³¢zõò	ÜÿùÁülÝ2gÓŠuþ	û“ÊM;{Rù Iåƒp{ÅÈ.AdÐ;ÃÃZ ¾Æù8´WÌÇ_\Ð]1âø¶æÆkv~ü}ï­·Þê8TW±%éJ×‘¶:Éõòþé<ø/m¿öš³·n™³ucÕ¦5
@@ -1688,7 +1878,7 @@ d¥[ŽM§&zçý×‚ÁÖb:÷•‘6üËõ¿4VŒ-¢÷ò?Ü&**ÂÎÎ<´ð´?ôn"2q_–Œ ÙºúI°ëìl_kd¸
 ?NZlß÷ÍÜ>1|ùÃ@ó»ýÿ{ççã»¡ÿ×÷ýÕÙu}8ËÌök6!ç€ŸùÅób$D¾?ºÐÝð7'o¦Ç»33?§çF²‹á*zéëZQ”ß€Uí¬äsÙd,Îõý]Ã÷nt^ð·6ýråó‡—>ÿÉ÷ñý¯êÚOÔ´{§óä¾Oííiª	|ónàâý_íá=|F[ö]«h«Ÿh«Ýi\èñÅ4ÍÜ=3}çÌLç©ÙûßÌ?ºtÄ‡»ã£÷“~[áã³¹¥„÷=9ÏŽé«XQ”§Ç´~(•Šé+WQ”ßÓr¢T¦¯SEQž¦ÕEñ.¦¯MEQ6	Ób£xÓW¢¢(Æ0-?ŠL_wŠ¢xÓ‚¤l¦¯2EQ<i‰R~L_SŠ¢T¦EKyVL_AŠ¢T¦•LyRL_)Š¢T-¦åMqÇôu¡(ÊÖÂ´æmuLÿýEQlLkáVÁôßYQe#Lkdµaúï©(Šò”˜–ÏÊÃô_LQåyaZ_=‡é?ˆ¢(Š¬­„é_¶¢(J`U8¦Š¢(UˆåLÿ&å)ù4Sþ
 endstream
 endobj
-297 0 obj
+351 0 obj
 <</Length 3297/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 361/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíÝ{^ãÀñßîæ²‰&,AKŠ ª)Š4ãa¦]ãV*£LŒ´:I+%Ñmm]ªIe\‡jU!îÖe™ .M-MJÜbå&—Íîþ:ˆv×î»ç9Ï9ç}ŸË÷û¯yŸËû‰lö=Ï{Žj¤}EL»FhQ‰Íi¬á?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þqViÿ–ÿüýî«/8íð‘#wªß²®ˆô«T?ü€cOŸtÅM.ZŸótø;ã¿îéç>¬ªçI«‡tê”[äöÇ 'üß¹ýœ‘½géµ[ÃÅúWã_qÿ–G'ì&V>îò'×e›ÿÊú·Üwòf’¥¾N|dƒýüøWÒÿ¥ñƒ$‡êN¾c•å
@@ -1696,8 +1886,8 @@ xœíÝ{^ãÀñßîæ²‰&,AKŠ ª)Š4ãa¦]ãV*£LŒ´:I+%Ñmm]ªIe\‡jU!îÖe™ .M-MJÜbå&—Íî
 8ˆ¿?þ:ÎjSzZþù·šû@ü=ò×eÃm¶Ñç¯¥‚¿OþújÍ>¶(ýœlü½ò×yV—‚vmv×aãºÚtœvíê±¿Î›F­wÖ¿ü÷ÿH|ø·Ëþ:Al:£ÄBð÷Í¿m¬Ø4½û…àï›¿®ÚK,ª¾»Û…àï¿¾µ­äv ÿüµ±¿äu ýõŽ*±hïnâï£¿^,6Ýõ@ þ^ú·Ÿ"6ße ü½ô×õ£L7ÑóŽð÷Ó_—í,õzèÃàï©¿¾²™X4ð¥Î£àï«¿>ØK,Úá½Nƒàï­¿^'6°¶ãøûë¯ãÅ¦:Zâï±ë±ij‡!ð÷Ø_Wî)UÝòÿð÷Ù_ßÜJ,ê3ïàïµ¿>Û?Û@üýö×ÙV—‚výhãËñ÷Ü_/›Ùx ßýÛO›¾ÿÙ«ñ÷Ý_×î/6]ñé‹ñ÷Þ_?ØI¬âï¿¿¾¼©XÔïüÃð×¹V—‚¶Y‚þú±iïÕø‡á¯g‹MGÎ4½©þnû·#…†¿Ûþºb)2ü÷×7Káïº¿Îï+Å…¿óþz»Õ¥ ³ðwß_'Kaáïû‰RTø{à¯k¾!…¿þúÎ0)&ü½ð×…¥ð÷Ã_ï¯‘"Âß.E„¿/þú) ü½ño-ù‡¿7þºbwÉ=üýñ×7¶”¼Ãß#}"÷KAøûä¯7JÎáï•¿N’|Ãß/ÿvÓÃß/]³¯äþžùëÒí$Çð÷Í_Ÿ·z`h‰ð÷Î_çäx)ÿüušäþúëY’Wøûèßr˜äþ>úë‡y=]/ýõõA’Køûé¯[=0´Kø{ê¯×Káï«¿ž/9„¿·þmÇIöð÷Ö_?ÞG2‡¿¿þúöPÉþûës™/áï³¿ÞY-ÙÂßk½D²…¿ßþ:N2…¿çþ-‡J–ð÷Ü_——áï»¿¾Z'öáï½¿ÎËp)ÿýu–X‡ þ:AlÃ?ÿ¶±bþ!øëÊ½Ä.üíü[§u›é›uÆ´j³Øûâ!bþvþë¤¸Zl6ßhõÀPüCñ×;¬î(þz±Í\øãß~²Å\øã¯ëG¹ãÿÚì.]`:Î&³»ïÞŽËº³ëßÑt‚3»¾öù üuÙÎÎø_*ù·mÇeÕæ;ö¹!øë+›¥ÿüõ´Å?(½.å\ø‡å¯ãÓÍ…`þ­cRÍ…`þºrÏ4sáš¿¾¹UŠ¹ðÎ_ŸIq)ÿðüu¶ù¥ üô×‹ŒçÂ?Dÿö“LçÂ?D]»¿á\øé¯Ô›Í…˜þúò¦Fsá¨¿Î5º„¨þúk“¹ðÖ_Ï1˜ÿpý[IžÿpýuÅ‰sá°¿¾18i.üCö×ùIÅ?h½=áRþaûkÂ©{ü÷o?±Ç¹ðÜ_×ì×Ó\ø‡î¯ïëa.üƒ÷×…KÏ…øþzé†â¿N/9þ–þuÅ•¿©»DWÕåeïËˆŽË’ïØó¹ÿ—«µ<üðß_ljjjZÜÜÜÜ¼Üô¥¹ÝÿÁÂôÏþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá/Ÿøÿ8Zˆ›
 endstream
 endobj
-298 0 obj
-<</Length 7285/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 361/ColorSpace 245 0 R/BitsPerComponent 8/SMask 297 0 R>>
+352 0 obj
+<</Length 7285/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 361/ColorSpace 299 0 R/BitsPerComponent 8/SMask 351 0 R>>
 stream
 xœíÁŽÛÆÒFù?ì5äÂ«ló,~…ì²‚‹L<”õ>~	ï‚,&#ŠcÜdãG™¤FŠbÑnqX]Õ]}>„]ìêÃE±—»õ  ênSÙ¥níÏ xB¤-Í« Ðÿƒ'DÚÒ¼
  ð?xB¤-Í« Ðÿƒ'DÚÒ¼
@@ -1789,7 +1979,7 @@ géIéP‘Á^r býŸæ–Áøÿ<øßØÿI~RAEe:·ÂD†zÉJö‚[ãÿóàÿÚÎÿš?zš}–ÖÕSô¢S‹ÚPKö‚[ãÿóà
  ð?x¢’Èÿ&öhµ
 endstream
 endobj
-299 0 obj
+353 0 obj
 <</Length 10261/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíwx”UöÇß™Tz“Þ[f2™ôžL¤ªˆX`AW@Rh¡,}Jz¡ÔUtÕuÁŽ?]×XQ±¢ØP@ARæþžI É÷M™™·ÜóùW}sï;÷´ï9G‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚P+ö}BÂÃ‚»·õÒj5×üZO///OO:þ™ ñòñmÑ¢…¯·§Ö=ÿÃ„3i­6jÄðaC‡>bä¨‡Féútò­uÏšQãÒ[¬æ%é÷Ž©ëÖ¢öíkZþÊ¾Óeö‹Üù|þŒ1Á$øˆ&£¹.qøS\LttttLlœ)!éúa#®7EîèëYù/´5oÅòeK—,Y²dé²å+V,NO™8¤o{ßÊßºÖøôovv™ò3¿x~Yb¯öRÿ]DÃhŸ4$6"48(0000((8$,<2:Ö”xýðQC#wñ:ÌX±äæÍKOOOŸ7oþ‚…‹/]n¶,ž4"¨£V0ícuql{ö„þd”@xRTˆÑà¯×ëtz½Þß`0‡†GÅÄ'^?lhRÌŒŒÅésfÍL«dæ¬Y³çÌMŸ¿pÑ’¥Ë—ÌŸ1î³:¯Ÿ1f?{ä½Œ„~ÞRÿyÆgHt°AçWNïo
@@ -1839,8 +2029,8 @@ A³OÑa&?J¶GùH}¬JAë'¢øš„š}2ä8àõh:zŒH§¯î†<Ðìc}U~Í>ÅOûSÆ§Á´S|­@EßGd—÷µ™ÜVê3UÞáØ
 C€Q?¨_Ïv¾—£ôÈ©3S/9)©©©i3§O¼)ªOåºv×N{·Ÿúr‹yun)–zô¬×êÛ«[§¶-¼¯üÙztMštïŒ”Ô´Ô”ä÷N›4&Þ¿[»K‚V7üç×ÓÊíÌ^~ñì©ã?m-¸;ª?]¾ºðê:8(*&*Ô0 {›kßôë’¦-ÎÌÉX”r{\òó	‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ âjþÄ^x1
 endstream
 endobj
-300 0 obj
-<</Length 33283/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace 245 0 R/BitsPerComponent 8/SMask 299 0 R>>
+354 0 obj
+<</Length 33283/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace 299 0 R/BitsPerComponent 8/SMask 353 0 R>>
 stream
 xœì½w|[åÙÿï¾Ïï)#ÆS¶t†ì„QJKûÐ–>íÓ¦ì°i©™@ Cv'8&Ç–-K–día-Ë–<%g“EB	$„L ƒ„IöŽ·ô{ÝçÈÎ v”øëýºÿh)±cÕçºÎ}Ï'!                                                                                                          €H"''áù¡ÿýÔC·>ô·[†þõÿ=ôàÿ{ø/·<ô·Ûþ¿AÃºå‰'^=!÷ŠºùoAQè»PTBnnðPT54ø7ûekîŽ¤(¬29$EÑéîE_Ÿ>   À/H:ô¿zë£ÿwËÿôäã‰O?‘øü°Ä=‰ÎóÃŸ~bÐ“öÐ 'þyËc»õ±‡~õôãÿõÄCIþíöI1"”o‘2fdrÞ›iùï¦MÈMÿNúøwR'¼—>adÚ„wÓ'¾—šÿ~Ú”Q)SF§Œ+eÂiÔd¬²2”/Kº¨L•©úXTI	UÅ"åtú|,RMVR"U±P],Ôu’LÅt¡ºD¤—õ²`   1ÁÐþû¡¿'>ýHÊ‹O'½‘“4üåäw_O=üÒy÷õ¤7^MþbÒ«/Üñú‹wä<“øÜS‰Ï<:èÉ‡o}êáÛ†ôøßoúÑ„œÇ†EçJ'ŒHšðVj^núäQécÓÆ	>ž˜9=/sz~æô<Áô<ÁÇÓÆ¥ŽMÿpLúäQ‚Iï§Oz/=ï½Ôñï¥ä¿Gi~â„ä/ßá)J ¤2ÓE•Å˜¦×—áÆrÜTN˜dÌÁM2ôOR\_†éJ1M	¦.U‹*§+‹E:I†Q&ÒQ¤†JðzÃú  D ‰C‡Þöè?_|:iä«)cF¦ŒK+ÊK§&§K
 .jr:5>­(/mÚ„Ô)cRóßMõVrîð¤‘¯&½šsÇKÏ%þû)tGxâŸ·>ùÐ¯ž|ôöGÿqëc¡ÚNBBâ¨×R'ŒLÿp”`zž°üC¡âc‘†BG[|é ò±H9]¨øX(+”MP“ODaÊé“>H›ô^úï§O5¨2I™rJ¨žŽëK	³œ°)IG%Y­&]š«OµšpVvaUU„YŽ›Êq½ÓJDêbQ%%Ò‹è;‚À¦„2  ñCâÓ¥æ<“üþ;iÓ&¤…:i†Fži•fZ¥B‡FèÐdZUÌÍÐÈÑÿª“
@@ -1979,7 +2169,7 @@ I[ô¼+_xK$Ûß. €™ƒÉ©{>õgk½çShß]âÝÆÉõŒ»S*ßíçC†çSöóÿØ|fòsŠÉ— ò ˜sÞÚKLß¾l<ê'
 RÎ3ø­Z˜¤ûA•Rƒ¢A!ÚÎÇ$Ú&‰ÉN!©,NµCÉ                                                                                              8]þ??6"ð
 endstream
 endobj
-301 0 obj
+355 0 obj
 <</Length 2782/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 345/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíÚ•UÇñïy~Ü’há 5›üÒ°B”`4¦˜±QQgúAF…ÌT”L‘NM4šÎ¢eX–†X‹	&K* ”°ˆÄ&¬÷Þç>çÛÜÝ-~]ˆ?Î·{Î~?¯÷Ÿ3çýœÏ³—è½¯ºcé³›wìl¬W·o\}ß—F‘¡°ê{Í‚_¬kiô|î|ù¹§îùì°ÿ1ŸM]v”=²û›†üD4õ±{dÇ™æ3¦é[Ø/–;õõ	ˆiÊóì›ÒÔŸÏˆ.~Šýc¹õzŠ)<Æô{(gµÏ©7Ÿ1}ê [öåÊ(¡ÐD4âEöÔï˜“·€„¾Ñáeþ»„âÀÎ€˜Æìðv>yë{):a¸	Íó7?³½ŸR
@@ -1994,8 +2184,8 @@ AL“ö0¡Ì?é>Qo<Àp-·¼í¸WV¥4çHº¹»ÿwÊAwWSŸ 
 µOçÍlæjý¨yr¯ÊOóå4³m?þHJ§IâÅM5ògaŸ%“$DÞÝ‘‡ðÅ“Tøù›{Q’xÿK¿E)g¿aƒ{ ÊütE^}¥Tl¢[Ú¬?/Qg¥ÌO!ÔwÂ˜hfí*Œ›/¨}Pp‰Ã‘óÞÑ!üV5½s5t(ó­µ§\14‰ë|	ôTÆ¿9Ëß%Coˆ3ƒ­ð$¬~·]ÌPå§£¿[††¬åPâž®(ýûóÅÿLl~äý8ý]3t%ûóÓ„3©ò“ïÂöïš¡‘‡ø‰zç‡ÿïŸƒþ®ºhC€2Ïlôdõ@†=FÿOkôdõ@†,ã@‰?Šíß9CïXFÿ·øJ\ÿCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝ·$Œþ%¾ý3tîâ0ú—ù2ôwÎPñ[\itÛ³`«å&ô—p3—Ù9ÿm™FÏUÏÑ¸ ÖÆË ¿{††¶pÎÞ+óí¨/ÀÐ9Ø lÆãpüK0ôá úWù×ƒ°ýK04ðWþ¿–øãž¨žÊÐD®XöZÆÄò—a¨×÷<´Õ£ã‘_Š¡!òû(óg=I=™¡¦]\eo•ù®"–¿ Ccü} l™öA~Q††ý‘3//6ã¯¤žŸÏPŸù¶šûöX[åÍ=9JŒXÎ¹µÖ—g 6”œ÷}¹O£çE3|ÑîÎÿXtnýÍ3ú6zRT1Å¦Û—¬Ù¹ÿp{ƒ½Ùºåw§Œpíû3Qœ¤—$1þÝ       äµ=g¶
 endstream
 endobj
-302 0 obj
-<</Length 2500/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 345/ColorSpace 245 0 R/BitsPerComponent 8/SMask 301 0 R>>
+356 0 obj
+<</Length 2500/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 345/ColorSpace 299 0 R/BitsPerComponent 8/SMask 355 0 R>>
 stream
 xœíÝÑnÛ6 @ÑüÿG»fTPeÙqj«´xÏy†vM3¼¤$Ûùúú_¿].—åŸ|šëHýd`áË,âmÂ{èz7Nçò?Áz?£#Ö»™0Ç!Á.À3¬÷	\.—××»™0[ ,óÄÝ9¼²ÞÅJ¶ v]g…òÏê/&ƒ“À”–mý°–p2{sûÑ©Oü§ç*€…ø<¹äM†[ ËJwÒëx<Ä¿ÀëB¹²ä;¯÷õCþÇYï5–¼Éd(³ä³ngAúŸ%þM»KÞdò Ì’3Ðÿ¦Ñ“Ž;òþÖãú®ÏAbç½²{ý÷2à²A)b ýÏº÷Ñp£¿/ð Iÿ¹}@“þ×,‡@jîùF_£ÿ5ú§ÿ,?#Lÿk|Úsœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿ\û¿;˜Û²éSsoÉ;déþÇížÿmMúŸ²Œ»õtïü?úûbýOYFœ¸Í¬ IÿSô?n¹¸ž”Ù:ô?n÷æ)Q¦ÿëá¦Iÿùö’)Yéq»'½å·¼$ Ë%@W~f=~³Ïò[¶€ ï.°Æã¯q×†qîMì:ÄÊ_ömÿÉòY»±5^öÌÒÞL§…[À”®ƒ+þeÏ/êÍƒ`[@Ð:œÚf@‰ØíöósÆÃ¸u1N‡ØŒ£…÷ÓÉcæ°97Ö*ÞãÞðYÂ)Ëp¿r!¿ù
 ÷þ">ÇÛ§Ðú‰ §°ûB¾wÍÑœ?ÜŽïú×_¿‹»üqç‡ÓyeÈîýY†?™š#žßÝ~Y>ÖÑ;õî©ƒeŒRzlwû5ýÿ1`½ßûšÚò9Ž¸û·ûeú'XÂî¥ßã¯ùGü¼Åí:µl§wèk¶GÏhî2LoŸ`¼Ñî0mž½bèS/¶Þ2¦ëÁ]þÝb?…–}Na31n_ÒyœÝ²~=·åIÊ3Y¯nñçýóÙ,s» ë3z¶oæ­|ìò¹¯Pàó½ÙµžÀ¬¼›[â~,â.Øý `zž°=”‡r¨ìö‡ûŒžÀ¿£ÿ\é?Ôx€ìC“þ£ÿÐäþnþ@“w¡ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4-kŸ2ý‡ ëªwøÓÒÿ²eÜõÊF§ˆ‘ôš<@ÿ¡Iÿ=1ô?ÎáÊl5ë'þúeúŸ5zêãy!h“Ã?à ÃËþ[@Êèé|ôÇÁ¹4«ËåâðlØ
@@ -2003,7 +2193,7 @@ xœíÝÑnÛ6 @ÑüÿG»fTPeÙqj«´xÏy†vM3¼¤$Ûùúú_¿].—åŸ|šëHýd`áË,âmÂ{èz7Nçò?Áz?£
 8ñŸÃèyœÒÒ{Áž>ÀéíößŽðáFÏ`*£“Æ7FO            ¾Žð5÷OW
 endstream
 endobj
-303 0 obj
+357 0 obj
 <</Length 3213/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíuÛLEAÁÁj5ƒ˜AÊÀeà2C0AØïØIsš~MâIófß½ìýyogfÕ4                                                                               ðm×õ/tmcEÛ­^þøªkiûíóá4–?9ûÝzÕTN·Þî§w|<ÏÛÞf¬¶û÷ÿÿý`»¾©“¶ÞOù÷óÿ°­~ö·›ý'#ðÆ°©nWì¶ŸÅþmì7õîmÍ¼r¬i
@@ -2030,8 +2220,8 @@ h¨þðÒOÉG`&oR½ßVÈýH| jÞv Nö¯©¨?Ù*Ð)< ¤ïW[þªU`¨dÙðK-Ý$Ðƒ¥`j	?Ñå¯|L>’Lùh.e
 „ö·®8Qôé,8ü½¯)ù·Ö€8ëjPÂo=¿õ üÖ€ð[O Âo=Ö³\üd¡›á*øÄ­_ÚÉ“A|åÝù*p$áë|éó5ö#º?'Ý$/„¿´l>Nd{gÀ¸CöûÎ ¢ï<†-Ñ¯…þÖû ñÀg]ª¢ÛÜÐ!ÄÒ¯‘ns¸"14~½ôÛÏæÀxØ²íWO×o÷Ãñ}àO‡ývÍEm·ê/t>                                                                              @jþO­
 endstream
 endobj
-304 0 obj
-<</Length 6882/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace 245 0 R/BitsPerComponent 8/SMask 303 0 R>>
+358 0 obj
+<</Length 6882/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace 299 0 R/BitsPerComponent 8/SMask 357 0 R>>
 stream
 xœíÝ}ˆeå'ðÒt’ªº¶vp@V22ã0BÂ4Ù²ôlFp2»ÆYL 0Â„	»aYì^GâBæLÈ’­—FEÔ•‰´cÆ¶5c2IµÓÆJÙãŠ!Æ•8í7×…ÀLÒUw¸u»+U·ëåÖ­sÎï9ÏóùðEæ…ØÆºõ=÷<Ïï<gl                                                                                                                      €»{×ÛýÌ\´Fúÿ¯èF¨F÷ÀX÷ñ±î“KÈÒÿrÕ/ù©‰S3SÓ“§—rjèœžéœžíœšš<5»óíéŽ‹IëUúÁ¥<¶”åÿaÈôÿ³—þ>¢ÿËÀH¦;½ÂŸ=[ø§ªÍLçôÔä©™‹\Hæ»ýÊÎ¯6ý¿ó“Ñÿ=aCwïê}?_êüæ2Ó9=Ý9i±ˆ†ÕÛùÇ}É8»†ß©þ{¾é~Ûo¾ön
 ‹þwAÙ–j?²ó×IïBýï†Ü$QûkÆÒÍJáÿæq;@U_øÃKÞí 	˜îœlAó¯Èlç”« Ù6ÿy:Ì\ôvx™œ™Iyó»
@@ -2060,7 +2250,7 @@ u÷®·÷OZRþ@‰¦Lé Hwïzû[Š‰Ç¾€`3°ÜxìüIø›÷¾Ý‡Å%úgÐ3Ý9î,ˆãË?'Ý`¢Ú ¿q÷
 \:ìx€òv¤3@ykAó?ôµ`-¯òØØ³csG¢»ºòXíÒRmfp/0ï$g€Ò®‡MxvÐü ¥]žÓü õ82v4Á¡Ãc/;ýï é¼VÞ~€ÀÁáÆ¿í«}€t;úÜØüá:;ß"@âŒ¿Ö¿üã…/-øü³ÝRÛ÷×vž÷è@ûÝ½ëí¹ÞzÑÜ‘±£™›ë'úŸ                                                                                                                       Úçß €Æe†
 endstream
 endobj
-305 0 obj
+359 0 obj
 <</Length 7884/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 617/Height 612/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíÝitUÚð{«:I'!BŒB Œ
@@ -2090,8 +2280,8 @@ u¥`f®aÏà®ztÞŽ A¶ûœ¶q1hCUêRÁÄœüËã¿CÐ x›Û¡–ß#h´²ßø5†æv‚A[éÏÇ§J£4Ö¹N~7hì
 —«ÂUq‘Ó­¼¬ÔQ|îLAþ±ìŸöíúnë†Õ,˜ùÔÃÃöéÒ19¡iŒ=B–ðu"È%‰qÙÂ¨({l\³f		—_žœ’šÖ¾ãÕ®½î†Þ}úüºwïÞ7ôº¾GîÝ»]Û­[—«¯l×¦ebB|\LŒ=2Â&ËŸ¾Y þ=–_
 endstream
 endobj
-306 0 obj
-<</Length 95630/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 617/Height 612/ColorSpace 245 0 R/BitsPerComponent 8/SMask 305 0 R>>
+360 0 obj
+<</Length 95630/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 617/Height 612/ColorSpace 299 0 R/BitsPerComponent 8/SMask 359 0 R>>
 stream
 xœìÝw%Ç'öy hvWºÐ)B(¤‹P(B§Ý=bfÚ?ï½ý^{ï}ÅÀc`´»Ü]­v¥ÕIºÐñöH$Aï–$Hb€ fzzÚ{ï½+E–ÍªÊ¬ÊzÝƒ •ñŽæÌ 9ïƒï/³ò9£/}éë—Aù÷ÞwæÌýgÎ<`tÿÜ`øŒ=|Ó7þ$R±‘ª;r„nÔöRÿ»Žè¸5tÇ•˜1úMÛ¶è”Ñ+PF8_/i¡â5Tžýžâ5{tøŒáÓgÎ<pæÌý^ô5ú‹ƒüwÿö!ÔO@_úÒ—¾ô¥¯SY°Œ´ƒ†ÏÓ‡¾:*ÚBåº~™çúÍyç«g¿>çúÝYÇ/Î»ÿåœë§ç\?=kÿñƒ¶µÿò¬ýW9î7sÜožw½yÎùúyç›ç]7rÜ8ï~;×ó~Žû½\ÏÍ\Ï­<O_ž·ŸÎ:·éoÿ ×ó^®ç½÷;¹žwsÜÈõÜÈu¿‘çyÄûZ®ç×yžßæz^Ï÷½–çýmQèÍ¢à«ÆÐ«–ØŒá×-‰¬ÉÛ‰6Ê–^0þì\àÝÿ)ÿŸé_…Ž¬¾ô¥/}éë—á¿ÿ7×þí_ü}¡éÍ³¯þeÞ·4¾rÞþÓóŽŸœwþì¼ã9Î×r\¯åºßÈq½‘øû Ï×Ÿï,Ž…ÆL‘IslÊ’˜²&§l©){zÊžqd¦%SŽ’igé´£tÚY6ã,gãª˜E¤’ÿdÎÍÅU1ç®˜sWÎƒT0Yp—/ºË]e‹Î’%{ñ‚5¹hŽÍ›"ÓE¡‰¢Ð$‰ÂÀP¾ïí\×oó<oä8™ïýM÷7…ÞßúoæºÞÏ±¿C7YÝS}éK_úÒ—ê2œ1Üï/Èuýø¬õ›gmß:k{é¼ã§çì?Ïqþê¬íWgí¯w¾ë~?ß×o˜"cæè˜%>jMŽÚRc\ÆmÅã¶ô¸==nÏLØ3“ö’I{É”£tÊQ6í(›v–M9ÁÇig¹(.öFO&³ÜG@§dÎ]%ÄS=/ÎH/“j6à{«ø,º+\å®ÒEGzÁ–Z´ÄL‘é|ÿ<ïÏ»ãþ—ó®_äz~‘çû—<ÿ¯Ï{þ¥Àÿ^žóç9®—è¢ª/}éK_úúD-0ný7ñœÁð©ó·
 œ?9oå¼ý{¹ÎŸç8™ëú}Žûý\÷Í|o_QpØ7ÇÆ¬É1kj˜HÇZLž¦“·e&ì%\2|&%q”LÒM“f”Ž³´NVÒ2Q÷”ÄU.é¡tådêgÕ¼$€Qæcõ<,)>ô«]ðÖ.‚Ô,zª=•KîŠeWÙŠ#³lM®˜bK±_ï"ÿÏkEwó}oå8~h0<ðç…/è-U_úÒ—¾>.‹Û”4<`‰üæ¼óŸ³|óAûwÎÙ¾ÿ õ§çì¿8ïz;Ïs3ß{Û6…G,±kb”Òš‹ù°bÒŸ0Õr‚ù$ÂZI—M&æ#àrZš²&œ›³ÒpP²©a‡´—îjBDV.Ò(ÉXÉ¢Y»ä­]òÕ-yùÔòYöÖ.ûêV|5+žŠWéª-¹lŠÎGòýoåù?Èñ¾vÞó›óž_çºîËè[¨úÒ—¾ôõ‘ZÀJ‡ï÷QZ¾ÖúÝ³Öž·ÿâ¼óõ·ŒáQStÄ§¡L±PZR#†KY,,¦ã €Î	[ñ„•‹-=É&3Å„ÙÐ¤ÝœJÎVÎ2q–ñJÎ	©âª˜wUÂY P
@@ -2473,7 +2663,7 @@ y/œ¶aúßïä>Þ%úFIÇBZúŸ÷@ãä·¿h™Š~ØÝµœßöua×ÊîÞåòA(\ªÁíBå#P†’þ—eƒ‹%ƒ¯Ê†ñœ»H
 ãÿˆñ
 endstream
 endobj
-307 0 obj
+361 0 obj
 <</Length 8557/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíyœWUùÇÏ—aP6qaQqJIÄùfŠJþJY(MAÉç×«2é÷«ÆÊ\[°\ 3¥RK—TÈ4MpA‘(SYdq˜íþ^ÈÌ÷;ßåžÏóœóÜ3÷yÿSÂ|ï¹w¾—{ÏyÎûycEQEQEQEQEQEQEQB£òØóôÇ7Þ:Rú<ïT¿dÎKÑÖC?^ÿ!§¥x óˆê…Û¢Vlùù˜åó¢µ¯›:¢’ågôž¼ 6ÊeëgÈÇ-»mÇ‘VÜóý‰Ue,§ªpÓïŠç¢¼ÔžI>væš–Ãm_6wæ}!$Œá÷6æÿö£(ª?‡~ü+³Y×|ìÁqâ
@@ -2542,14 +2732,14 @@ ou°¦kFP[>Ï€×ý;a0™Qs¹Â¯ß4¾DBJèˆV[ä6FºOŽüÝÿûöóRûÆ·êTã®w$…3ÁËÔ-¹nr•à¹'‘¼
 º>”÷ë_ÚEúÄ?TÜ›çë_«©i.óAÐý;ÊnÕ©ªiÕÉu³¤OH‘4Bþ åRÇô–!ÏCÝ”°9÷C#dÝÒ§¢H0vgÛ >)}"Š'îht¾ôi(Ró^ý@ú$9†¼5_§þiæà½¤Ï@QEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQ”]ü?Š—ÄR
 endstream
 endobj
-308 0 obj
-<</Length 5354/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace 245 0 R/BitsPerComponent 8/SMask 307 0 R>>
+362 0 obj
+<</Length 5354/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace 299 0 R/BitsPerComponent 8/SMask 361 0 R>>
 stream
 xœíÕQ–$Ç‘CQìÓ˜òh$ŠbUWg& ‹wWàöÜÂC                               à¯ü?¤Ï øÐƒõpl xÓ›ïp{: xí³ì‘|Ô° žì%Ïþ±Wñ±ƒxˆW?ü×^B" ¸çEÏüý× ÎxÕƒöœG2 xÇSö„‡ŽD v½õ{ÂûF+ ‹\@û(`‹khé ¬pí# €~®¤}îÎ  ”‹iŸ›¤c èânÚç>é$ *¸žö¹U:€0×Ó>K·äzÚçzéB 2\Oû\/]@†ëiŸë¥Èp=ís½t! ®§}^Ž Àõt‚ë¥p=àzéB \O'¸^º€ ×Ó	®—. Àõt‚ë¥H?<_Ó	®—. Àõt‚ë¥ðís½t! ^ }®—. À´ÏõÒ… d¸žö¹^º€×Ó>×KázÚçzéB 2\Oû\/]@†ëiŸë¥Èp=ís½t! ®§}®—. Ãõ´ÏõÒ… d¸žö¹^º€×Ó	®—. Àõt‚ë¥p=àzéB \O'¸^º€ ×Ó	®—. Àõt‚ë¥p=àzéB \O'¸^º€ ×Ó	®—. À´ÏõÒ… xö¹^º€×Ó>×KázÚçzéB 2\Oû\/]@†ëiŸë¥Èp=ís½t! ®§}®—. Ãõ´ÏõÒ… d¸žNp·t ®§Ü-@†ëé×Kàz:ÁõÒ… ¸žNp½t! ®§\/]@€ëé×Kàz:ÁõÒ… ¸žNp½t! ®§\/]@€ëé×KàÚçzéB ¼@û\/]@€hŸë¥Èp=ís½t! ®§}®—. Ãõ´ÏõÒ… d¸žö¹^º€×Ó	î–Î Ãõt‚»¥ó Èp=àné< 2\O'¸[:€×Ó	®—. Àõt‚ë¥p=àzéB \O'¸^º€ ×Ó	®—. Àõt‚ë¥p=àzéB \O'¸^º€ ×Ó	®—. Àõt‚ë¥ðís½t! ^ }®—. Ãõ´ÏõÒ… d¸žö¹^º€×Ó	î–Î Ãõt‚»¥ó Èp=àné<À¶ÝïÈõt‚»¥ó «Ö¿#×Ó	î–Îì¹ñ¹žNp·t`É¥ïÈõt‚ë¥íN~D®§\/]èuø#r=àzéB@£ó‘ëé×Kº<ä#r=àzéB@…§}D®§\/]{æGäz:ÁõÒ…€˜'D®§\/]à#r=àzéBÀçð½;Åé×K>è“A^Eû\/]x/>¢T–ß§}®—.¼QIŸÓ>×K^Œ¨6Ô¯Ò	î–Î¼ÑD®ïÓ	î–Î¼ Ñ\´ïÐ	î–ÎüÐ&×Ó	î–Îü„ËhëéwKç~+iëéwKç¾ËÅ4Èõt‚»¥ó _s=r=àzéBÀ\Oƒ\O'¸^ºð×Ó ×Ó	®—.|Áõ4Èõt‚ë¥_p=r=àzéBÀ\Oƒ\O'¸^ºð×Ó ×Ó	®—.|Áõ4Èõt‚ë¥_p=r=àzéBÀ\Oƒ\O'¸^ºð×Ó ×Ó	®—.|Áõ4Èt‚»¥ó _p=òàné<À\O›\O'¸[:ð×Ó&×Ó	î–Î|Áõ´Éõt‚»¥ó _p=mr=àné<À¼@ƒ\O'¸[:ð/Ð ×Ó	î–Î|Á4Èõt‚»¥ó _ðr=àzéBÀ\Oƒ\O'¸^ºð×Ó ×Ó	î–Î|Íõ4Èõt‚‹¥Û ßâzäz:Á­Òa€ïr=r=àJé*À/p=r=à>é$À¯q=r=à2éÀ/s=r=à&éÀO¸ž¹ž®p‡tà‡\Oƒ\OW¸@ºðs®§A^ ÒdÄc¹žyN !‚l‚ëi“ëéâó.-CâÓù5Úäz:zø¤{ûàzÚäz:tøŒ«+ázÚäz:nx·Û[áäz:hxŸ',†hëéŠáåµ^ A®§È…zæz¸ž¹žN ^âÉâzäz:PøM,‰ëiëé*áÇØ“—wxr=@"ü «òÖ/§A®§èƒïc[>œåU4ÈõtqÜ“ãzäz:2øü†Û×Ó ×ÓdÁãðÚ¸ž¹ž® 	Þ·OØ×Ó ×ÓÁË—áQËãzäzº‚pÍr=r=]AŠ'sÍr=ò@„grÍr=mr=@§q%Ír=mr=ððñÅÅ4Ëõ´ÉõtÂ“g×Ó,×Ó&×Ó	üQ\O³¼@ƒ\O'<sê§q=Íòr=ðÀ‘Èõ4Ë4ÈõtÂÓæ}&×Ó2×Ó ×Ó	ö±\OË\Oƒ\O'<gÒ's=-s=r=ð1Îõ´Ìõ4ÈõtÂf„ëi™ëiëé„ó‚¯éÝ\Oƒ\O'Üžp=-s=r=]qx4üÁõ´Ìõ4ÈõtÅÕ¹ð/®§e®§A®§+N…çzZæzäzºâÞDø/Ð,×Ó ×ÓÇÆÁóÍr=r=]qiü-/Ð,×Ó ×K¾Ë4Ëõ4ÈÒ‘€oñÍr=mr½t!à»\O³\O›\/]ø.×Ó,×Ó&×K¾Ëõ4Ë4ÈõÒ…€ïr=Íòr½t!à»\O³¼@ƒ\/]ø.×Ó2×Ó ×KÂGMß¸ëi™ëië¥áCÜ¸ëi™ëië¥áíÎÜ¸ëi™ëië¥áŽÝ¸ëi™ëië¥á-NÞ¸ëi™ëië¥áÅß¸ëi™ëië¥áeÎ_ºëi™ëië¥áw=çÒ]OË\Oƒ\/]?÷´K÷Ír=r½t!üÄ3/Ý4Ëõ4ÈõÒ…ðkž|é^ Y®§A®—.„ïâÒ½@³\Oƒ\/]_ãÒßÔá4Ëõ4ÈÒ‘ð?qãŸ	òBšåzÚäzéBøÜøç³¼„f¹ž6¹^ºþ7žó›4Ëõ´ÉõÒ…ð'n¼'Ñi–hë¥áÓK¢Y®—.ôs^ A®—.ôhÜx®_¢e®§A®—.ôPÜøV´oÒ2×Ó ×Kzœô…ß¸ëi™ëië¥=…kh–ëi™ëië¥Ýç2šåzZæzäzéB—¹’f¹ž–¹ž¹^ºÐM.¦Y®§e®§A®—.t»i–ëi™ëië¥]ãÚäzZæzäzéB×x6¹ž–¹ž¹^ºÐ5^ M^ Y®§A®—.th“h–ëië¥äzÚäšåzäzéB¹ž6yf¹ž¹^ºÐA®§Y®§Y®§A®—.tëi–ëi–ëi“ë¥]ãzšåzšåzÚäzéB×¸žf¹žf¹ž6¹^ºÐ5®§Y®§Y^ A®—.tëi–ëi–hë¥]ãzšåzZæzäzéB×¸žf¹ž–¹ž¹^ºÐ5®§Y®§e®§A®—.tëi–ëi™ëië¥]ãzšåzZæzäzéB×¸žf¹ž–¹ž¹^ºÐ5®§Y®§e®§A®—.tëi–ëi™ëië¥]ãÚäzZæzäzéB×x6yf¹ž¹^ºÐ5^ M^ Y®§A®—.th“h–ëië¥äzÚäšåzäzéB¹žf¹žf¹ž¹^ºÐA®§Y®§Y®§A®—.tëi–ëi–ëi“ë¥]ãzšåzšåzÚäzéB×¸žf¹žf¹ž6¹›útžêû\O³\O³¼@ƒ\LejöK\O³\O³¼@ƒÜJMšÏö«\O³\OË\Oƒ\I5Ê÷®§Y®§e®§Aî£ý'ü×Ó,×Ó2×Ó —Q‰Cþ˜ëi–ëi™ëi›¬ÔÐ2×Ó,×Ó2×Ó ×ê e®§Y®§e®§Aî°U@Ë\O³\OË\Oƒ\`nv-s=Ír=-s=zf´Å3¿Šh“h–ëiÐÓŠ»­À»i“h–ëiÐsrM¾¶Ã›h“h–ëiÐZ­Ÿ¿¿ÆËi“h–ëiÐíPFØÊò*šåzšåztµÒ)Fãü>Ír=Ír=º—èÌ ë‰~‡f¹žf¹ž]êsi–3¡~F³\O³\OƒnÄùØŸçÝ\O³\O³\O›¦Ë|àðžè\O³\O³\O›v³¼ûä‘¡>Àõ4Ëõ4Ë4h1È[Ïœë3\O³\OË\Oƒ¶j¸ƒ–¹žf¹ž–¹ž­¤p-s=Ír=-s=êïà>ZæzšåzZæzÔÁ­´Ìõ4Ëõ´Ìõ4¨³€»i™ëi–ëi™ëiPÛø^ e®§Y®§e®§A=³{‡–¹žf¹ž–¹ž5î5Zæzšåšåz”Ú›´Ì´É4Ëõ4(5²—i™h“h–ëiÐççõ>-ómòÍr=úð°¾B³¼@³\O³\Oƒ>6©oÑ2×Ó,×Ó,×Ó Œé‹´Ìõ4Ëõ4Ëõ4è­3ú.-s=Ír=Ír=zß€>MË\O³\O³\OƒÞ1@Ë\O³\O³\O›^8šCË\O³\O³\O›^2—FË\O³\O³¼@ƒ~"?–¹žf¹ž–¹žýÎ8~*-s=Ír=-s=úñ,~0-s=Ír=-s=úÁ ïZGË\O³\OË\Oƒ~iŠDÔFZæzšåzZæzôýBQi™ëi–ëiY:Þ×4è;çÏ-¥e®§Y®§e®§A_>Z´”–¹žfyf¹žýÃÉÓ9{i™ëi–h–ëiïÿh™h“h–ëé„tÅZæÚäšåzÚ—N¸AË¼@³\O³\OËÒñÆh–h–ëi–ëiVºÜ-s=Ír=Ír=mJg›¤e®§Y®§Y®§5é`Ã´Ìõ4Ëõ4Ëõ4%]k›–¹žf¹žf¹žF¤;] e®§Y®§Y®§éHGh™ëi–ëi–ë©^ºÐZæzšåzšå*–nsŠ–¹žf¹ž–¹ž*¥«¤e®§Y®§e®§>é$7i™ëi–ëi™ë©LºÇYZæzšåzZæzª‘.qœ–¹žf¹ž–¹ž:¤3Ü§e®§Y®§e®§é e®§Y^ Y®—.4è-s=ÍòÍr=ú<„–¹žfyf¹eBË¼@›¼@³\,¡e^ Y®§Y®G“‡Ð2/Ð,×Ó,×#Èsh–h–ëi–ëQã9´Ìõ4Ëõ4ËõHñZæzšåzšåztx-s=Ír=Ír="<‡–¹žf¹žf¹žCË\O³\O³\ïáã?Š–¹žf¹žf¹Þ“g-s=Ír=-s½gNý@ZæzšåzZæzù™´Ìõ4Ëõ´Ìõž6ïci™ëi–ëi™ë=jØ'Ó2×Ó,×Ó2×{Î¤§e¤»Úö;´Ìõ2&´Œ>ÓmŸf¹ÞfÄôGôŽKt¹í;h–ëÐ²'Ïþn^ Y®w{:ü‹–=jØÏs=Ír½Ã£áßiÙíéâ\O³\ïê\ø-»7Q×Ó,×;9þ›–Ý˜¢–ëi–ë
 ëŽ\O³\ïÞDø_Þ³ã˜çzšåzÇÆÁ?xÛšc›ëi–ë]šÿì›Ža®§Y®wiü³wn:†¹žf¹Þ™Að¥7/;V¹žf¹Û)ðMo^v¬r=Ír«#àW½sÓ1Ìõ´ÌeÖÏ{Ï‚cžëi™kL¿ïÛ\OË\`úðx•—î5îp=-KÇãýÇŸ^º×¸Ãõ´l´[ðØx“×-5NñÍÍ96ÞêëŒƒ¼@³C}øÌÚœäzšµ˜ècgÆ'½pCpŒëiÖ\œ¯Ý\âzš5WæÝFÊËWg¸^ºÐÏm5yßi÷Ž…Á®§Y[5ÞqZ”xßÚ`ëiÖP‡×mÞº<˜æzš5TàUGE¡ìv¹žf­ÌþŠ[B—Ïlp=ÍZ™úuw…°O®np=ÍZù¥×…€/.q=Íšö7†ùü¶à×Ó¬‰1ßvox—Ôªà$×Ó¬‰ß|{x™ìžà*×Ó²òÑ>u‡ø¡ô‚à>×Ó²ò¡>{“ø®ô^àA\OËÊ'úøeâŸ¤×OäzZV>KèJñÿÒ+€§óÍ*!z«–¾yàO^ Yå‡O_ìã¤/ø®—.tVúb!}ÉÀ\/]è¬ôÅž•¾Xà¸^ºÐYé‹½&}ŸÀO¸^ºÐeé»—¾@àw¹^ºÐeé»”¾4à•\/]è²ôÝÎH_ð.®—.t\úz{¥oø×Kº/}ÃEÒW|šë¥=‚,ÝHr½t¡Gð“¤cE\/]èA|Tº+ÐËõÒ…ÇûÒ	®—.ôPž’®¬r½t¡§sŸtà×KÂŸ¸zà×KÂ?á~i®—. gyA: œåzéB p–ë¥ÀY®—. g¹^º œåzéB p–ë¥ÀY®—. g¹^º œåzéB p–ë¥ÀY®—. g¹^º œåzéB p–ë¥ÀY®—. g¹[: \æVé0 pŸû¤“ Àƒ¸I: <‹;¤3 À¥ß~ ˆáñ€Çâñ€Çâñ€Çâý€Çâñ€Çâñ€Çâñ€Çâñ€Çâý€Çâñ€Çâñ€Çâñ€Çâñ€Çâñ€'ãý€Çâñ€Çâñ€Çâñ€Çâñ€Çâñ€Çâý€Çâñ                                                                                                                   Ôú?Â±Q¼
 endstream
 endobj
-309 0 obj
+363 0 obj
 <</Length 4554/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 454/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíÝgxÕEð¹!‰$»Ø(
@@ -2574,8 +2764,8 @@ C-µ_ssíô_sGYi¿æ>QÇ šûðhg!ÐÜ‡ÈèÄÛ¯¹OÜ1@7é’T.ú'Ü~Í}¢Ž4÷aÓ)ÑþkîCgb‚íOsŸ˜c Í
 ¼7ùp«“wNõˆ´Þ âËÉ/ï)ðqÔÏšd<t0ˆ|QN<Ö ÙÙ–‰y´ƒ2¨Æš`wã¥]Ad~óºK¿D&OM‘khO~Ÿmå)pÝAy÷ƒÈ-Æ[·‚È}œOU¶0ÞZk!Ç%P´¸ØxìŽKÙDü;ù­«‚iR6ö#|ÊôTãµ~ —ÖDf•¯•|"}èž2?ÄxîPK¥eàéÉo©i r×#vèh¼×D¬qˆL6¦€Èõö âÁuïÌÖÜƒHéÝRJ)eDüý*
 endstream
 endobj
-310 0 obj
-<</Length 3840/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 454/ColorSpace 245 0 R/BitsPerComponent 8/SMask 309 0 R>>
+364 0 obj
+<</Length 3840/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 454/ColorSpace 299 0 R/BitsPerComponent 8/SMask 363 0 R>>
 stream
 xœíÚY’ì¸EAîÓ”IjSzCÉ<À}iˆS—?u]Àîû® ïvÿGý+ Æß' àäý÷	 8süí?À±ûï pæøÛ€3Çß' `oöà@¿Ÿ €“÷ß' àÌñ·ÿ gŽ¿O ÀNì?À>;þ> {°ÿ úÚøû ;þ> ë²ÿ úþøû ¬ÈþèUãï pìøû ¬Âþè‰ñ÷	 ˜Ïþè¹ñ÷	 8vüí?À±ûï pæøû LcÿôÎñ÷	 8vüí?À±ûï pæøÛ€c÷ß' àÌñÿ¯ú ŽsÏP?Àqî1ê— 8È=Iý ¹‡©ßà÷<õ“ ì¯^úŸª`s÷`õÛ lëž­~€mÝãÕ/°¡{õ#ìæ^GýT [¹—R¿À&îÕÔ°‰{Aõ›,ï^Sýl k»WV?ÀÂî•Õ°ª{}õ¬çÞEý ‹¹wQ?$ÀJî½ÔÏ	°Œ{/õs¬áÞQý¨ ÓÝ›ªß`º{_õÓÌuï®~`€¡îÝÕ0Ñ}†ú™f¹Q¿4À,÷IêÇ˜â>LýÞ SÜç©Ÿ wŸª~x€Ò}°úíJ÷ÙêçhÔëÛ«/ Ð¨×w„ú ïVïî õ) Þ§^ÜYêk ¼O½¸ãÔx‡zk'ªoðõÖUŸàYõÊÎU_àAõÄNWßà)õ¾. >ÀëÕËº†úJ ¯W/ë2êC¼R½©+©oð2õ ®§¾ÀkÔkºžúb /POéªê»|W½£«Oðuõ‚®­¾ÀÕó¹ƒú† _Qoçê|Z=œû¨/	ð9õjî£¾$À'Ô“¹›úž Råžê«ü^½”{ª¯
 ðõLî¬¾-À¯Ô¹³ú¶ ?Uäþêü@=§¨ïðOõ.ž¢¾3ÀßÔ£x–úÚ ªñ,õµþPÏá‰ê›ÿF}v ûŸ©/­žÀÓÕ÷ÎUïßéêû‡ªÇ«+ ŽSÏ¨C ŽSÏª[ RSç ¤<þ©.8B=uüXÝ°¹zäø©:`sõÈñ+uÀ¶êyã7ê@€mÕóÆïÕ ª‡©3vS¯ŸPÇl¥ž4>§îØD=f|Z°‰zÌøŠº`yõŒñEu8ÀÚêã[ê|€…ÕÆwÕKª§‹¨#–TO¯Qw,¦-^¦N	XI½X¼X°Œz®x±:(`õVñˆ:+`õPñ”º,`´z¢xP0W½O<®Nª'W'LT/oR‡ŒSÏoR‡ÌRooUçLQ¯::`„zŠÔÑ½z‡ÈÔé±z„ÈÔé¥zˆÕz{èÕz{¡Îx·zu¤Žx«zr¤ŽxŸzo§Nx‡zi˜¨®x‡zi˜¨®x“zl˜¥îxŸzo¤Žx·zu˜¢.x·zu¡ÎhÔÛC¯nÈÔóC©®(ÕD¦NèÕ;D£îèÕ;D Ž˜¢^#Þ­.¤$Þ§n˜¥Þ$Þ¤˜¨^&Þ¡®˜¨^&W'ÌUïªãF«'ŠÕqÓÕ+Å#ê¬€5Ô[ÅëÕMk¨·Š«ƒVR//S§,¦-^¦N	XO½[¼@°ªz½ø®º `Uõzñ-u>ÀÚêã‹êp€åÕ3ÆÕá ;¨—ŒO«“6QŸS÷l¥ž4>¡ŽØM½j|H	°¡zØø:`Oõ¶ñu À¶êyãWê:€ÍÕ#ÇOÕi û«wŽ¨£ ŽPO?PGœ¢^;þ¦Î8H=xü©n8N={ü¡8N={ü[]p¨züNWß8Z=G«­žÀsÕ—ð	hÔg°ÿúæ ¨çð,õµþ¦ÅƒÔ§ø›zOQßàêi<B}d€¨§qõ…~ªÈÕ·ø•z#wVßà7ê™ÜS}U€©Çr7õ=>ªÞËÝÔ÷ø„z2÷Q_àsêÕÜG}I€O«‡sõ¾¨žÏµÕ×øºzA×V_à[ê]U}7€ïªwtUõÝ ^ žÒõÔxzMSŸà•êM]I}+€«guõ• ^¯^ÖÔ'xJ½¯ÓÕ÷xJ½¯£ÕÇxV½²sÕ—x\=´Õ7x‡zkÇ©ð>õâÎR_à}êÅ¤>À»Õ»;E}€w«ww„ú ûlõó”îƒÕoPºOU?<@ï>Oýä #Üç©Ÿ`Šû$õcÌR¯òûÔ/0Ë}†ú™&ºwW?0ÀP÷îê˜ëÞWý´ £ÝûªŸ`º{Gõ£¬áÞKýœ Ë¸÷R?'ÀJî]Ô	°˜{õ+,é^_ý„ «ºWV?ÀÂî•Õ°¶{Mõ³,ï^Pýf ›¸WS?À&î¥Ô¯°•{õSìæ^AýH ºÇ«_`[÷lõó lë¬~€ÍÝ#Õ¯p„{žúI ŽpS¿ÀAîIêÇ 8È=Fý Ç¹¨ß àPõüÛ€†ñ8–ý8“ñ8–ñ8“ý8–ñ8–ñ8“ý8–ñ8“ý8–ñ8–ñ8“ý8–ñ8“ý8–ñ8“ñ8–ý8–ñ8“ñ8–ý8“ñ8–ý8–ñ8“ñ8–ý8“ñ8–ý8“ñ8–ñ8–ý8“ñ8–ñ8“ý‡ýú? ÓÔ›ÄûÔ­³Ô›Ä›Ô¡ÕËÄ;Ô•1…ø«z™x\ƒH‚¨÷‰Õq1ˆ0ø¡nŸxV]ShƒŸ)–‰ÇÕY1ˆ<ø…bŸxVÝS(„_{ï2ñ¸:(	¿õÞ}âYuML¡>â]ËÄãê”D*|Ð»ö‰gÕ1…Zø¸ç—‰ÇÕ1ˆ`ø”ç÷‰gÕ1…fø¬'—‰ÇÕù0ˆlø‚'÷‰Õá0ˆxø²gö‰gÕÕ0…~øŽW/«“a	ñM¯Þ'žU÷Â*âû^·L<®Ž…A„ÄK¼nŸxV]
@@ -2586,7 +2776,7 @@ Q1¼+^®®ƒADÅÌ¢xNÝSÈ‰Eñ¨º‘¯òŠqâêR˜BH¼Ê‹Æ‰ÇÕ¥0ˆø¾×ïP÷Ââû^:N<®î…AôÃw<°O<®
 ñ®qâêš˜B$|ÄÇ‰ÇÕ51ˆHøµ÷ŽïP7Åòà×Þ>N<®nŠA´ÁÏDûÄãê²DüP·O<«.‹ATÁÿK÷‰ÇÕ}1ˆ$ø‡zŸxVÝƒè¿ªÇ‰w¨+Æ©g‰÷©[f©7‰÷©[cŠºD    ®GýÊ+]
 endstream
 endobj
-311 0 obj
+365 0 obj
 <</Length 4213/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 95/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœí{œMUÇ×™33.“;cÐ4”ð¯[r'E!’Þ"R>¡TD‰‘[}jÑEQš”Ê5B“[Ä'Ôën3æÂœ9Ïû1sö>g=ë²÷^ûœOo¿?yÖeöwfïµÖsY„ü£¿¢šJœ÷íö#®3YYYº2Ò6=oÊ¨þÍ+Z5@t| "ä»©Ié&>¾œÞ(6^J±•ÊŠO \¼¼jW~Œµ¨Ü$Ô6’>:wìzÃ»Š Ñ¹íŸŽéXž˜U™“”¾Ÿ“ïg#u’CôF ­üŒ§öçOà10¦¬ý«ßÖ"’×ývjã£BÏ¦1}ä—˜Z¼qŒ?ù¢C‹†ÝLÌè9Z·g¢B†‰²V<§†ÿ_º¼bTÍâ_áù#âsÏ˜×»1¨¨ÓÔ.Ç…ÿkÚ;º²2þ à^Ó/,4øGÏÉ–œ{ö¢ž¥ˆ½@ïïœß‡;$øä/¬¯Ž? ¤vŸéñ—ŒÌýBþlP•;‡ô6!$ù¸?ŒSÈ ­e°ù·2ü<ëû0^`TMÀúÊªšürŸ	SÈŠ¦:ƒÉß™Xhfö¿ú¨‰ö49TùlŠSÈ µrðø—ýÆìì÷w"âJÄû¹X)dùÃé;Tò‡½ÕƒÅ¿ÚNó³P”!•.2ú™FB–?ä÷UÉVÿriæçž)±˜Êê(»jèò‡Â^*ùCjD0øG®·`êIâÈª°w™¯…0Èï¬’?¼þ³¬˜ycqd¯±{ºLû†
@@ -2602,8 +2792,8 @@ xœí{œMUÇ×™33.“;cÐ4”ð¯[r'E!’Þ"R>¡TD‰‘[}jÑEQš”Ê5B“[Ä'Ôën3æÂœ9Ïû1sö>g=
 ¹ø‡]¿Í°ÍÜöeÒÄ¡=º´jÖ >¾Yó{†N^Âº*8ÃÛiMãÉ„šË/vˆýZŸÿ?x_„Mü=ñæ*§ãzHßo¸XÜ£æz{M6Ó·äkwÌ¢ V-ÇÁ›Ÿ•ñ¨zØPîæT¿úö¢«,ò¾c±åÊïišæV5æ«åOnÁÞ_yuíáÿ`À ¢ê’YŸ€eÚçít>b‘G/pª6Ô•›×A¯D_ï°ƒ?%Ý¹’D(ø-ÝeÒqBzã°íG’}ÖàÅü#÷c#kürêøßG™ú5”Ð)oˆ'5ß€Ò½k£‹+7Iauƒ °®âúOm°ïíùhõüý6Ì»däé%ìï–—7`¡v< ¿ÖÆÜàcÕõ¿æ‹¾B­ç–þ™,žˆJØ]WEƒÙÞÌÓqlIáæ¸«iºÎ}«bþObCwSÌÿŠ&ôK§Nü=OKÂ.biô&ÆÝêþÃáËñ6àbÕõÿúa#RÊßóžÍ/_©H£-‡ºŒ‡r*èÈK9ƒ")37"¯¨êúŸè•³Tòw32ãHûRz¦¾a¬é¶jÒ¾„ÒØÂé+bDhé@Ÿ³Qÿ8Ì…én¦Ž>;5·n€·FT)ç~V™IRnMm†Ìˆ’8/¢ÞXE	ªëÿ"©9 »ÂUñ?Ø˜ó8j éñLM§†¯…õFlºÜÃ×cöço4çÄ±ökÕüibyH–ñ/Lb…™—Lj’—öIlIIHçeXÀ“¨Ò›Šl(u3e„-¹8Jeýï¦ØN67^ÿTV’©Oí¤K³¤žYhT}Œt‡y’µñ"M=B3eäØÃ9&QXÿ}–P…%ü=ßR‹Ó>ÍÀ£égzYY­ZÏ1º®øIŸó»Üè%.õAo©šZíkùœ uË^¥éÂºv?,–ÞÑxŒ„jo_ý‘z‰“¾Ð»œXù`X­üþ´8ø¹ª–ñ?¾tx=é‡Rzº.ÒÈ½´½DŸÕûÏ•©øtuiÀ è.š¢¼@§PüÊ|—êEös¡,£Ñãy´JÆ¼Ôc|6=Ó)u]Ê»‰C:©ÅQ¬ÆÓ˜´ò–?ÎÍPtŸé«Ð“O®¬R™ò^Âdê.iÚm@Á‘ÿ3Å>š¼ƒz„Ÿ¹fJþ^SL·±ó×ýŽþ:»6±3?Hø[Ùä¾Q3—¬Ûš–árHûaÍG“‡ÜeÁu­„DÔí4`ää¹_®Û”–ær¹\ûÓ¶,KN|¼=#Uì—Ó¼
 endstream
 endobj
-312 0 obj
-<</Length 2418/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 95/ColorSpace 245 0 R/BitsPerComponent 8/SMask 311 0 R>>
+366 0 obj
+<</Length 2418/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 95/ColorSpace 299 0 R/BitsPerComponent 8/SMask 365 0 R>>
 stream
 xœíœ[rc9CµÿMs>R“J¹íDWAðqpqÊJw{­a†ÁÃ±ŠR²òÆMÏ‚³vòBêr2:´Qžáƒ¨Zb½éïÿOxŸµ“R”ã-éáì§Ò“Ê›ª³“ç²´ˆ¯ årœÜ\áÚ¦ÇJBáyÉsY~4W ƒ`9X%Ž3PÛäYÚž”<”UAmjH•ƒ’a:C´-K’Ú3’‡²Zè¬@r &dç{mKËRb¦NdQX,
 å\:„8ßh[	– Uçú†<‘%|Ê„—s#å|¬m…@oF¥Ì%y«Kì
@@ -2619,7 +2809,7 @@ r¡p`üèð/aW4GÖ1Q«H!ÎdYA.ŒåÿÞ›€Ú¤õ|€V"q&@Ô
 ð
 endstream
 endobj
-313 0 obj
+367 0 obj
 <</Length 5435/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 193/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíw|ÅÇ'ÉMAB¤HoJ/¢`¡
@@ -2637,8 +2827,8 @@ xœíw|ÅÇ'ÉMAB¤HoJ/¢`¡
 *@sŸ©Z¿©kh¾^Ú9³»öFÕ†º±yï˜¸Y	mNJÚ“’²/ió‡sFE¶½©AUHÓžƒÇÄ¯JÚžr 5õhÊöMFG47jªñãü“0
 endstream
 endobj
-314 0 obj
-<</Length 3115/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 193/ColorSpace 245 0 R/BitsPerComponent 8/SMask 313 0 R>>
+368 0 obj
+<</Length 3115/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 193/ColorSpace 299 0 R/BitsPerComponent 8/SMask 367 0 R>>
 stream
 xœíÜÁn9CÑúÿŸæ,¼$c·¤YäYg¡Kµ#Ø©¡†bˆ…Ÿæ…#nÁ5C,ü4/q”ÕPl±˜èâžœ ¥†âŒÅ·‡Œ 5y,”Ý/BÔDä±Pv{¼ WñÇBÓíÙ"Ä€[#A·7‹b5ŽJ,ÔÜ,BˆÕ,B±r{­a`U³ÅBÊíµ"„UÍ")·×ŠV5ˆ\,tÜž*B(Õ r±Ðq{ªm TS(ÆBÄí"äRM¡·wŠJ5‚h,DÜÞ)B(Õ¢±q{§y Tútc!âöNò@©ôéÆBÄí"äR‰“Ž…ˆÛ;EÈ¥'·wŠ˜ |J™z,DÜÞ)bð)Yb!âöN€OÉ·wŠ˜ |JÓŒXˆ¸½SÄàSšfÄBÄí"& Ÿ4&"nï1ø”šI±q{§ˆ	À§¤‹…ˆÛ;EL >%eX,DÜÞ)bð)ób!âöN€O‰·wŠ˜ |JÁÔXˆ¸½SÄàSôÇBÄí"& Ÿâ6;"nï1ø·Ù±q{§ˆ	À§ˆ…ˆâ rÎˆ?Ÿbå¢]<vÄ'ð)J&±¡¾Lÿù#NÕ[™Äš±IgEDç·ýZ1±ŠåüþhÌ m!ýŸ÷EÃ*¶-y‹aS4äDÜýÈ¿©8XÅ6W¯›·Ãé¢†ïü«Ø+á‹¦.p®+‚íkÿ#«AŠDÎ?”ñ	|¬Ö(21»ýD]Ä'ð±Ú¡È@ÄøðíŸÀÇj„"Õ{#>U~‘‡ê½ŸÀÇª½È@„IòÆÌˆOàcU]d Â§wWiÄ'ð±ê-2áÓ»«4âøø”þtCDb#ÖÏøÀs±ë "±ëÀgpÚ¹Ø] Â§ô—wñ;ð™WôE"|JÙq·¿Ÿ1!wÍžñ]\æÆäˆOà#}xc¾‡ur™“#>â™	ù6ÖÉenLŽø>Šg&4æ{ØX§ÕøiLÈo<os×ÃÖS<3¡1ßÃÆ:­ÆOcB~ãy›»¶žâ™	ù6Öi5~eø¯¹N,0f·‘QýfOçùyLm\¹Í,0l¥Ä^Ÿ¦–®ÜæŒŽ. 5Nb/‚ˆñ3²÷õmŽáôBË$ö"ˆø7#“_ßæ˜P™%±AÄøÀ¿Yýú6ÇŒÐ³€Ä&‰½"ÆZ…¿ŽÊó6IìE1>Ð*üuÔ˜Úà$±AÄø@«ð×QcFh[€Ä^ãÿfäå®DÍ¡sò5{D84ú„¯DÍ¡sò5{D84~šz¹‹]Fè\€|Ä^Ÿ¦ÞïzW³Fb/‚‡ÆOSïw½+ŒY#±A„Iæo¦Þïz—úÍxN§Øw Â$ó7Sïw½K}„æ<§€Sì;áSêP½Þ¥>BóžSÀ)öˆð)ý²ãzkpšôÍxN§Øw Â*v|ò–4éšðœN±ï@„[oÞÿ ÷<§€Sì;‘ÞIÉë²@¦Hìká–<»wc]È‰}"ÜªgÇn¬Ë™"±¯A„UûøÌ½Y S$öˆ°Êß¸70dŠÄ¾>ŒÌûŸ÷ÿ)±A„Ï³ë5fLaûD˜ì08ítfÈÎ±ï@„É#£z2³@¦ /ÍûÿšÃ óŠšK³@¦0,]ã7–s+6d
 ·Ò1~–I-c³@¦p+]³Ç™QAÒ›2…Ué
@@ -2670,7 +2860,7 @@ xœíÜÁn9CÑúÿŸæ,¼$c·¤YäYg¡Kµ#Ø©¡†bˆ…Ÿæ…#nÁ5C,ü4/q”ÕPl±˜èâžœ ¥†âŒÅ
 0Â–)â§rÑ_D$äN|EùœBZ>þðîÏþ?ZýZ
 endstream
 endobj
-315 0 obj
+369 0 obj
 <</Length 3979/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 283/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœí{œÎUÇ¿3cÌˆ!L¹”[Q[‘¶Y´Rª%¥¬U)T¬•J)—nÚBM,]V7Õªôê¶Új•‘.K¼¶‹ÚèfHRdÃ"ÉóÝ×”dfžËç÷û}ÏsžçœïûoçœÏó¼óÌó{Îù"øýJ˜6	º9h_Â—¥€œÏ0ítsÐ¾N
@@ -2688,8 +2878,8 @@ Cêßÿ¬÷¡ôÌ|
 ^ô§í¨Šà¢_eÛŽªØœþçÚŽª .úù¡NÁ‹þžc;ªb ¸è÷Rþ‚ýïe;ªb øÒ%:ý¿ô§§í¨ŠnAõ¿·oARÅ»éßÃvTÅ p­¿Å:ý¿óóÛQÜŠêW§¿ƒàw~Ÿn;ªb€bTÿ;:ý¤þ·¨ÿn¶£*˜€ê_d;©b€BxúwµU1ÀDTÿBÛInEýŸb;ªb€;PýoÚNª á6ÔÿI¶£*¸Õ¿ÀvRÅ àéßÙvTÅ “Qý¯ÚNª |5õ‰¶£*¸ÕÿŠí¤ŠÃÓÿÛQÜêŸc;©b€&¥¨ÿN¶£*˜‚êŸe;©b€¦;PÿlGUðª¦í¤ŠšÁÓ¿½í¨Š¦¢ú_´T1@sxú·³U1À£¨þÚNªàÐ þ²ßØŽª`:ýŸ·T1@Kxú·µU1@ÿé cl'U( ÿËÍK
 endstream
 endobj
-316 0 obj
-<</Length 3785/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 283/ColorSpace 245 0 R/BitsPerComponent 8/SMask 315 0 R>>
+370 0 obj
+<</Length 3785/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 283/ColorSpace 299 0 R/BitsPerComponent 8/SMask 369 0 R>>
 stream
 xœíÝAvd9CQîÓìASƒÎLW¤- õî‚€ü1upRHuü~ hé¡Žß m =Ôñû@ ¤‡:~? ´ôPÇï 6êøý  ÐÒC¿ Ú@z¨ã÷€@Huü~ hé¡Žß m =Ôñû@ ¤‡:~? ´ôPÇï 6êøý  ÐÒC¿ Ú@z¨ã÷€@Huü~ hé¡Žß m =Ôñû@ ¤‡:~? ´ôPÇï 6êøý  ÐÒC¿ Ú@z¨ã÷€@Huü~ hé¡Žß m =Ôñû@ ¤‡:~? ´ôPÇï 6êøý  ÐÒC¿ Ú@z¨ã÷€@Huü~ hé¡Žß m =Ôñû@ ¤‡:~? ´ôPÇï 6êøý  ÐÒC¿ Ú@z¨ã÷€@Huü~ hé¡Žß m =Ôñû ßÃþÀ›Ø xû obÿàMì? ¼‰ý€7±ÿ ð&ö ÞÄþÀ›Ø xû obÿàMì? ¼‰ý€7±ÿ ð&ö ÞÄþÀ›Ø xû obÿàMì? ¼‰ý€7±ÿ ð&ö ÞÄþÀ›Ø xû•ÄØü¯¬6Þ|™Ç÷,á¶‘†õ?úàC³/ÅþGßŸß³„ÛFÖÿè¯7à)ÏÔÒË/3âøž%Ü6Õ°þw½_›}#ö?ýþ¬øž%Ü6Õ°þw{¾ô@m ½ÿ2#ŽïYÂmƒëú·gà·f_‡ýgÿÅñ=K¸m°aýOÿéü*ëiÚ@ú”q|Ïn›mXÿëº>ïÂþ„*3âøž%Ü6Û°þ×¿8ÿŠ{”6þ
 eFß³„ÛÆÖðÅ1ö*T™Ç÷,á¶ñ†õ|}Ÿ£œ~ö@=Æ¡aý_ßó²Ù·`ÿC•q|ÏnshXÃžô¬Ð‡hGßa T™Ç÷,á6“†õgüçIš}ö6T™Ç÷,á6“†õg|rÕkrŸ œ{‡™PeFß³„Û|Ö_òÉUï˜íŸýUfÄñ=K¸Í§aý%öˆèòÛÀ¡wUfÄñ=K¸Íªaý1¶Þlóì¿C¨2#ŽïYÂmVëùü¶ÝÒko'Þa2T™Ç÷,á6·†õ÷|~ÛV³³ÿ&¡ÊŒ8¾g	·¹5¬¿ç¯Î[iAámàHÁPeFß³„ÛÖŸô·n2]6ûïªÌˆã{–p›aÃú“þöÂMvTÝNe™
@@ -2706,7 +2896,7 @@ rÃkå´ôPeFß³„Û¢Ö/ËYÓÅ°ÿy¡ÊŒ8¾g	·E7¬?þ^–ƒ¬¥¤‡*3âøž%Ü–Þ°þþ«qŽ˜®„ýUfÄñ=K¸-½
 ã eãÎ°Va
 endstream
 endobj
-317 0 obj
+371 0 obj
 <</Length 10097/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 400/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíw|ÅÚÇçœ$¤ÑA:JW¤	ˆˆ"*WA¬”+""¨Xˆb¹êED¬è½W#"E$"*J± ðŠ"‚"Ð{	5&$9gÞO¨	û›ÙÙ™Ùsr²óý3yvfvs¶Ì<…7¨Ö®çã¯}0}áê-™™Sš•™¹yÕÂi^Ü£MW:4êu:qY6åõ{Ú“]ëDzœí$_–’¾›
@@ -2743,8 +2933,8 @@ o£×êüÀ$¥Î< é/¥9 UA†DüPGŽ ¼FÅØ»ä»i“ÞMŸùÓŸx“×Â²rNÒÝ!Qƒ¶Ü»”nžàøàÓXÕq•áô
 fÀ¤VêÝ4`»k<Åx|D‚\š¡jû±—M·K'BišyöG.JÆÓÒBç<Ê:)ÂÆÛ7bô©-˜?ãŸ%3oþL¤ñc}Ý8/ƒ ¸Kr§ÉþòNGå€ËÞ:I¬vù>TÎ>.Ò‰Òàâ‘W¥€-ÕþéùBŽ‚ùÝ¸†.ÉjUà›ûË½šÅq‚L÷3ßŸðÄäpž©ó€³¿ÜåS^yèúµÝ’j7ï:pôä¥ÎÊy0’gm8MV>Ù™›2Ö¬ÍØ”	“·Ú²¾m¤ÏÛp’Ä±ö_éºI+é³6œ¡‹Æl/"ì¹)Ògl(BåÂyøÄäv-v\.å+Ã©¢®—IxÞÁ§›<Ç^JŒô™0µÓÜÌ1%‹1m9Ñ:XbÖ{‹7¾¢Â¬ìe¼üŠ=¾î¿»¤~Ûøouá)°¨§ùíG­Ò´æN¿:ÒgdpFíá’ž`Ëˆs#}6çø¯™¤aA {RsãV’º§Uz~@Cq§L¯‰ì²à\öLìeüúKþÖÃ~Ìr¦}ÖwC[™Û~	"®Í I„V‡C¾Ø¸ô—DÊ´ëÿúÌ•LwŸ¬3^½§ñë(éTisÃÝ¿ønzú´9sæÌ™–žþÎõí~±}ÖO	'ÿ@Þø˜
 endstream
 endobj
-318 0 obj
-<</Length 6528/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 400/ColorSpace 245 0 R/BitsPerComponent 8/SMask 317 0 R>>
+372 0 obj
+<</Length 6528/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 400/ColorSpace 299 0 R/BitsPerComponent 8/SMask 371 0 R>>
 stream
 xœí›[r\Kkÿ›>óq'
 ?¤î.ÉÌè ‰íë˜9g;O Õ   ãÚó' €!%ÕV  fò´¢Ú @{žæTû hÆ3Žj£  î<£©¶ `Ç³Œjß  õ<‹©v PCõõu¡z €<ª/®#Õ›  ÄR}eÝ©Þ @OõeíDõV  ª¯iWªw ¸¢úˆö¦z= €O¨¾s¨^ àªOæ4ª÷ ø™êK9™êm þIõœOõÂ  ¿S}wQ½6 Àÿyì¡ €œÇš $ðx°¶{Iq XNõå3:}Õ&ŒT Àx¸u- 0îÛ  æÁY{\À¸fŸ4 hGìì@G¸]*Ð àdÉÁ' øÃ¥
@@ -2778,8 +2968,8 @@ a àÂ°•xaÚË `ˆÏq$	Êïœ-'ü} pCrüà‰‰RÅ¶ àÈ°c5Ÿ÷I À«+¡
  †‘Öz7ü Àlª®œí¡C ì¡ðâùÜ½j `!´ Hæ±„Ž  9<MØÐ  ™ê£¸…ê þBõiœOõÂ  ßQ}#gR½* ÀKTËiTï	 ðÕWsÕ |HõùìMõz  ·TßÑ~T/  ¤ú¦ö z% €ª«;Õû  ÄR}e©Þ  ê‹ëBõ  e<+©¶ àÂ³†jÓ  Ž<£©¶ Ð€gÕ. Zò´¥Ú Àž&T{ ˜ÌcFµ €¥pð àœz 8ËøGõÌu
 endstream
 endobj
-319 0 obj
-<</Length 19263/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 1024/Height 1024/ColorSpace 245 0 R/BitsPerComponent 8>>
+373 0 obj
+<</Length 19263/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 1024/Height 1024/ColorSpace 299 0 R/BitsPerComponent 8>>
 stream
 xœìÝÁkUÙÞàýâ¥ï¤´ÖÕÂ÷b [yuP¡pRè(Pt B=!ˆ ¤˜tŠÊ¤,‚¡À€D¬Tu®êö×à@¡Êî§ûå¶uss5'gï³ÖÞk­½?ðAêæž³Ïwo×>Y?“èÿþÿþßÿ                                                                                                                              à
                                                                                     ´àùøÁçÿùÿÑt@õ×ªòxýúõë×¯_¿~ýúõoùøè¯Õæ¹ë×¯_¿~ýúõë×¯„¤ˆ!çëúè×¯_¿~ýúõë×¯ËÇ!äzæ@¿~ýúõë×¯_ò$ý›ÿßŠsÄæo–Û¬¤_¿~ýúõë×¯_¿þAÏ?Î žs¬Û£_¿~ýúõë×¯_¿þ¡=µÎkPO¬kUåãU®‰~ýúõë×¯_¿~ýú«7Ô=ÇX±Ž©_¿~ýúõë×¯_¿þ-Ÿ[ëøƒÎqºÇ¬{=cS¿~ýúõë×¯_¿þþô‡Ï#Ì[?¤A¿~ýúõë×¯_¿~ý\ññ›_eNô˜XçU÷|õë×¯_¿~ýúõëïyÿÐ×­ÒPå|cõ×½núõë×¯_¿~ýúõëßx|-u¯C•ëSå¹±è×¯_¿~ýúõë×¯?î1c]Ãºç«_¿~ýúõë×¯_¿þ¡mµ:=¦ÊÇ©{­ê6è×¯_¿~ýúõë×¯ã1[ôºƒŽYåc]‡ºúõë×¯_¿~ýúõëß|¨ÑÎ7VCÝkUåñúõë×¯_¿~ýúõëôøS÷|«œW]u¯ƒ~ýúõë×¯_¿~ýú«÷Çê9~•s×¯_¿~ýúõë×¯_xÿ ±ŽÙæµÕ¯_¿~ýúõë×¯_ÿ–ýC_å8ƒ®IÈõŒu¾úõë×¯_¿~ýúõë­§Š*m!×P¿~ýúõë×¯_¿~ý#÷m«rŽuÏ·nsÝk¢_¿~ýúõë×¯_¿þí_+ä›èôºMüé×¯_¿~ýúõë×ß“þ‘_EHs•ëë˜úõë×¯_¿~ýúõ÷§?|¦™Yª<·
@@ -2805,7 +2995,7 @@ y-ýúõë×¯_¿~ýú{Ø?ôñƒ:«iéÑ¯_¿~ýúõë×¯_ÿ–=µT9¯A=!ÏE¿~ýúõë×¯_¿~ýqëÖ=_ýúõë×¯_¿~ý
 ÷ÃÏÏÏÏÏÏÏÏÏÏßÿîŒ3jþÌîüüüüüüüüüüü÷æW¾“~~~~~~~~~þCü—Ï÷Ì‰Ú«§Ñùüüüüüüüüüüü±žÖ7HÔ7ËèYüüüüüüüüüüü¾{ù|ÏŽ£»G½Û³/??????????ìüÑï—ž»âçççççççççç_áŸŸÓ³cÏ»+Îâççççççççççÿ|e~þê?ŸiÅÏÏÏÏÏÏÏÏÏÏé¿œ9ºc”3ê,~~~~~~~~~~þou>ßš?ºïê9üüüüüüüüüüü­9÷vé)jfÏ~~~~~~~~~~þ{sVìÛz>ëÞøùùùùùùùùùÏôÏÿkXqŸQwÈÏÏÏÏÏÏÏÏÏÏÿýLø¹£žÑsWß?????????ÿ‹ý!†¨ç£ÞåççççççççççÏ=Ë|óÍ7ß|óÍ7ß|óÍ¯3çœÕ3ùùùùùùùùùùùÿ™°ù›"ê{'ë›ˆŸŸŸŸŸŸŸŸŸÿ¹þyOÔ^3ñóóóóóóóóóó¯Ûkç·ÏŠ³øùùùùùùùùùùcË:—Ÿ¿Büüüüüüüü5ý¹ÿ,²Þ­`àçççççççççßïß³ãÎûä¯s?µ™üüüüüü‡ûOØ‘ŸŸŸŸŸŸ¿àYüüÕfâ?aG~þô³øù«Íäççççç¯ÐÓwäççççççççO'ñ¿ §ïÅÏÏÏÏÏÏÏÏŸNâß<³ÚòóóóóóóóóóŸé¯s'«ï°Züüüüüüüüüé¤ý’$I’”Û;¾­øùùùùùÓIüŠŸÿd¿$I’¤ÜžþMÁÏÏÏÏÏÏÏÏŸNâ—$I’$I’$I’$I’$I’$I’$I’$I’$I‡õ™Îz@
 endstream
 endobj
-320 0 obj
+374 0 obj
 <</Length 6374/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 232/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíw|ÅöÀç¦z3Â"	jT  -ôb  (‚ ‚€D0>: (¨è)UAÃï!Mª	¡„„Ô{Þ'@’»÷n93»³37ÙïŸÉîÎÌýÞ²;sæB„FÅ˜':"¢F"÷î4†W_Gø´””8kp")¡}Þ?X V‘{2eí²Ywª'vPÃ]­Á©íWT[sÿ8(ÈG­ééÀ…K¿.{²‰°Ëç t#’8îðäâºWb\"&¥€„P"7üü9>¯½ý_’ú‡äÊD¢O€=¤Nÿ—ÍC“Õ?l¯Ddá¦3`ù_t°ulÒú‡!Dj[Ùkãàäõsˆ¸¾»IŒ¶mtûww$20ì'~y›F'±Ø+Ã<@¹“ ‚}ÍížÌþa Ï(Cî$[ÞýRûßBÄ“¢ø2´¬ûwGÑDƒ8Ë•qÿ0ŠˆæÈ¦JeÜÿ‡D4«@$kƒÊ¶ÿmD4ÿ¡Ì+ÛþÑpZôE3ªLû?CD“bÉm[–ý§Ñ€hŽTä:>Ç¿> œÙ\Ççø×„SÐ†çøÿú€xvpŸã_€~Ççø×$`Ç/ Ç¿>PÊ¿ ÿú€ìà7>Ç¿> 7qŸã_‚iÜÆZÍ^SÿXŽó|†ã×9 Q”ÿS#°DÇ´ëÜ÷Á§g­ØCë2)…”ÿã®tû˜ÿdÑøß@J!’ùoºð*ê­\9µð3fpò_H¥¡{ðþ3eÙUŠý÷ÌÌÌ†¼ÌÌ™­!-/œÈ¼ÌÑ?!ŸC¿Z“Ò‡dþ	!½anaNX£	™•µ*òôOH=ttùhRúÕÿ0š¿•üõí‡Ð€¯Ré'¤I6C–	ÿã¡Ç6wDGó.ÄpöOªþŽóŸHäÇÕ°ËcÓ­^¿¹0•ÓÆU^Ø¢‚mþC·èù7V|¿>yçÎíë×®üì½WëÕìz½ÿ7 å‹0æmw½éÐ·rËe”ÿ½Dn*t‹O:ïÛíüß?ú/Îþ]üû›Cù—¸¼kÉ¸Îµ¨ü/„›nƒÕ‡¶‘	0ˆ»2a [æÀð‘ëôf4öMmÆÍôSk0!Ú-öÿ9Ô&G³á92
@@ -2824,8 +3014,8 @@ zSúoÆ³ ËÍß ;üoEôp¨Æ¹}©_}ÿàž¯{§YÇªRçn¤ò_OwNÓ4GiŒ×ÿå1»nQ=5`*ý,Œ€Ÿu–C·Uü
 ‘mú™¿ á“„„øø‰Ï>ÛØô‡þƒ¨%
 endstream
 endobj
-321 0 obj
-<</Length 3704/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 232/ColorSpace 245 0 R/BitsPerComponent 8/SMask 320 0 R>>
+375 0 obj
+<</Length 3704/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 232/ColorSpace 299 0 R/BitsPerComponent 8/SMask 374 0 R>>
 stream
 xœíÝÑnÙ„a¾ÿK3ÀXh%e<Ó}šü‹¬ïÒA¤b‘s_H‰ø@ŽöIVÄ7PÏMÚÙcP×½„½¼èz®Ôüò¿Ö½œ-¼Öznu¹ã0[÷º&ó*ë¹ÛÍÚþÝ«È¬çz×znõ{tïpï®žÞéÑ½oÓ½Ì!¼µz.y¡§—¾S÷Våy_õ\ò6Oo|¹îõ
 ó¦ê¹çm
@@ -2847,7 +3037,7 @@ e©/D:i ëÓ¹’-RP(K}!‚ÐI{€%/RSÈÊRH{€%/RVhÊRH{€RA ¥¬Ð”#¤ö ã¥ˆ@Je¡&§
 ë^™Ù-Ý¨ªî½™™Ðý”êéÞ˜™Ù1Ýª’î]™™Öý¬jèÞ’™ÙyÝ/«€î™™=¥û}Eë^Ž™Ù³º_Y¨îµ˜™Uè~kqºbfV§ûÅ¥èÞƒ™Yƒî§·_÷ÌÌ:åJÝ­›™!ä&Ýe›™±äÝ›™qåPÝ½š™iÈAº»43“úº+43–‚º;33%t—df6V"u·bf¶‹ß|33ó›offñåOýÿ šr~¢
 endstream
 endobj
-322 0 obj
+376 0 obj
 <</Length 6025/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 166/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœí{œÎUÇÏ3ã2ã6•ëH’»A%i1.‘¢„h'!›KMŠ´­2»l••KŠ2¹§¤U«¬Km«ŒPH4•4·ÃÌÙ×ÃŒyžç÷;ßs¾ç{Îï7ÛËûßy~ßó=¿yžßåœÏ÷óeì"ÿç¤ð¼ê~çpß(w˜óá~'qßx‚sþ_¿“¸ˆ_ÄerÎy]¿Ó(>T»¾çðñÓ­Øœ––žžžþUZÚ¦e/|{½hö{äÉà¿Ÿö;b@T£»Æ.Ù™ÃEdo?²C,û}Q1ëÜÜv³âK™K!.12F\·§Öå
@@ -2878,8 +3068,8 @@ aÀxÉ^YD_e³‘2ÀÚö.z¬ÁX8Ö;à¢^í’>¹a§`üá/HUÆÿ†ƒqð(·KnÃ®-jPŸ’¤=¡ÃÔÌAÞ
 ÜOX‰ÉFÔ ‹-Çtèñ#7ËÆvšÞÏdW°ç6ç7:i²§øçÙž.Úgjç)“bòÁtW’xIâEn¹ð¦£äcÛMÙKËT}‹Å‡–Ÿ¥®év#3Å¸Yïå¯Ëô¼ªlè	ITLhô(ØsY'ùØ]¦Î˜ÌPÏ)¡ÜäÄ$#&=‘ÔšªV¨’·¼5<ŠÌ‡žj¾×Yò©tsN$«L¼/tp ¯æMàèÁ“5š“ˆ¯?=[›æýL·_‡;î-/–=Ê‚í„+ý0ÜÑ•=C1v!hbê«ósÞºMá·e¯"/A¥ÏÑÏoœU$Ïñ¹G¨NKÔë±ƒÎnó;YéFÃq’W²—ß¯dmO	? +¶¦´\t ÛÐUX›¯?NÕœò×y=íõE§ù˜Í¨Óá9=U]ãÊÎ²Å+ÁŸFmÉ‡fJ›<bH’Œæpƒt¥îÈ²m¸ìµci‚5,•ûÎØ¡ôØ¿pHcû¥ß9±mF,ýÁýüÝœúPÓ–˜jT¸ù±9ibÙbî®·žèe`'õ"ç‰Mè:tÒü%«×¦íÙ‘–öñ²ÔÉ#z·Öòa2IÔå‰ýF½ôÆÊ-é‡23óø±Œôí›—Ï3°Kcw—ñ‹°þfil˜
 endstream
 endobj
-323 0 obj
-<</Length 3042/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 166/ColorSpace 245 0 R/BitsPerComponent 8/SMask 322 0 R>>
+377 0 obj
+<</Length 3042/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 166/ColorSpace 299 0 R/BitsPerComponent 8/SMask 376 0 R>>
 stream
 xœíQndIóþ—~ûÑÀbao·ËU¢T2PÊ9ÀÌÇœBá#žÿa:K!„Ç?ï!ÜCÞÿB¸/þÂ2o3Ý&\Mn2„ž§þ¦‡‹È^Bž,ˆ«_1m",gëíåó±1èçsV:)þËâur·_ˆ~-
 6Ééì¾³x Üí"¤SˆšŠz*„¿±{£œî"¤ÁC3Ö®ÔáÃ¿Ù½QN·Í†‹g)¦Æt±Ã¬ŸIy¹~N¤6øBž°ó¦^d÷LÊ³µtr­ç2ŒìÕF¯³~&ÙÍº:¹PÈs1«B†ß²~)ÍÁFˆ‡uYø+¦¿æ†¥×!BÔ5àË¬<üš–\k„Ð…¨;zÁ÷Y±yø—ŒUz§ö6Öÿ‹\i;SøV+–¿ã’±JïÔ[Åz!Òj¦Xˆ-	^çž±êŽÔ^Ån!Ò^¾X¸-	^çž½Š.ÔÞÃb!ÒFîð—$¯sÕdºÁÃV!Ò:àK.I^çªÉ*.tƒ‡ýBÔuÀ÷\’0¼ÈU«U•µ–°UˆºËøªK†¹jµª²ÖV
@@ -2896,7 +3086,7 @@ QYßvIÂð
 µ#ž¥ÄX#~Î^Lí=†(<8ò,"®šé÷sVc-ð1AgÀ—ÇœX¡_ÎYÍ‡iñ<VÄÌ,ÍrÎ¬Ñø`èé»ŒL„@h–s.`ŸÆ†F„š[y0L›!¼OžwÌš!Ü@Þw*ÞøÂiæ?æñ½n
 endstream
 endobj
-324 0 obj
+378 0 obj
 <</Length 32822/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 395/Height 512/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœì]”UÖ®ž@ÎQQ@DÅ°*˜Óš³((‚b#ÔU`–U¨+fD‚ˆˆHR$HòÄ®Ôiz:ÕýÏ}¯Â«îŠ=ƒòƒß9»3Õ]Uï¾pãw9îÿ=úý¹ý•÷CüŽkøF fÇ™÷süƒ“¶Ö ‚ÿ¤Ùßý(û6½ÁA @²âò¿ûiöeœ¼.	
@@ -3036,8 +3226,8 @@ Xv¸±Î™’þR¿ÇbhÓ£¸¦HÄ‹‰æÿÖÐ.Æ4óDÛÓúá*Á¼ÞN‰tBŒlò
 ëaë,øe}õi¿ZD{ó}áÛVŸ÷«Utr›Y"½Î©¯4ô1æ„Kë]§ZÇ£ºiÀëQá wI]?ÔŠÕÚÚ·÷½º~¤+ÉûHþŸwq]?Ñ•‹–yj—Ö·¾þÆ®;tçj}®r=Lp|uWì»TU³.LˆÚ"’s¹)q\zxAL{ì‹;×£¦ð‡{åuø^Œ˜ 0µ®¢Â…éuýÕÿu]zø
 endstream
 endobj
-325 0 obj
-<</Length 10757/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 395/Height 512/ColorSpace 245 0 R/BitsPerComponent 8/SMask 324 0 R>>
+379 0 obj
+<</Length 10757/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 395/Height 512/ColorSpace 299 0 R/BitsPerComponent 8/SMask 378 0 R>>
 stream
 xœíœÙv$9ŽDùÿ?ÍyPŸ•"œÄ÷iZNf:3´Ô¬5ìÿ’-g†áËÕ4wÔ0à·Ó\SÃ0 _MsGÃ ~;Í55òÕ4×Ô0ø·ÓÜQÃ0À^MsMÃ€;Í5ìÕ4×Ô0ø·ÓÜQÃ0À^MsMÃ€;Í5ìÕô›ì†a€c#‘Æ0(lT²ƒ†!ûÄ£æ0¯Âðù¼I\‹ÃÐ›˜Û#¦Ë0m0¼4(÷Fp»aê’uWdõ†¡
 ¹·„a÷¹¦†¡87Ž’a@»õÌ55uA¾µÃàþ`¨p®©a¨B­·¾–ÚaÞö¾WÔ<Ã«^óêú‡aèýv÷p1Cã—ºŸ£ax']ßå®¾†á%¼á~ƒÇaèÇ{ÞÜ÷8†¾°…ÞÙZ†r¼ù=}³÷axÏëYú†y+3iC¿—±Ùû8±C.ó^™|†¡ô«×þí› †!’yãLbÃPèE{á»6¹þûõæWl2æÍ2d’´·i^¨ßLªÃ gÞ#W&ÛaÈ}wæ:3!—yk‚™´‡!òM™÷…ËÄ>gæÉeòïWcÞ%3…aðx#æ¥°b&2óÁ	œ™Ëðf¬Îÿ¼~ÌŒ†bxìçä0“^ÅørÌÈ†÷0G½"3µá%Ì!¯ËÌnhÏœðÒÌø†ÞÌÙnÀqèÊì6Ì‡~Ì‘îÄLshÆéfÌ4‡NÌÕŒ™æÐ‰¹ š1Ó:1T3fšC3æH·aþ¹ú1Gº3Ê¡sªÛ0£ú1§º3Ê¡sªÛ0£ú1§º3Ê¡sªÛ0£ú1§º3Ê¡sª;1£š1T'f”C3æ‚êÄŒrhÆ\P˜QÍ˜ª3Ê¡s¤;1Óš1Gú…ÓœU˜óÜ‰¹ †fÌyîÄ\PC3æ<wb.¨¡sž›1:1ç¹3Ð¡sžû13Ú0'¹sAm˜“Ü¹ †ÌInÉŒuèÁœä—u&; 3Ç¸+3Ù¡:s†3Ãª3g¸1ôáÎ|@úàËÂ¦“—á…Ô=½˜…D]åÃË)ttwqªD—¨s
@@ -3087,351 +3277,405 @@ V€×‚Ä),dafi Žµ@f<“€Ð‰kÜè®ÁRÂ_HÈÂÌÒ •žlúDƒÜ‚«8û­œí³r£KI~Á H²±.m,kŸ¿m!ö…ŠE
 P·”˜a@H¿ÒÃ NÖ‘Òt†¢D^‘½†ahCÀ½Ðb†Þ8Ý&eŸŠÃð*l¯‹kiî¥aþƒÉ•2WÓ0~èo˜¹†apen§a™«idæv†™¹†a@fn§a™Ûidæv†™¹š†a@fn§a™ÛiXæv†™¹ †a@fn§a™Ûidæv†™¹†a@fn§a™Ûidæv–5ÿ¥(ä
 endstream
 endobj
-326 0 obj
-<</Title(Sid Jain Resume)/Keywords(AI product engineer, Applied AI lead, staff full-stack engineer, founding engineer, TypeScript, React Native, Chromium, DNS)/Author(Sid Jain)/Creator(Typst 0.15.0)/ModDate(D:20260727234138Z)/CreationDate(D:20260727234138Z)>>
+380 0 obj
+<</Title(Sid Jain Resume)/Keywords(AI product engineer, Applied AI lead, staff full-stack engineer, founding engineer, TypeScript, React Native, Chromium, DNS)/Author(Sid Jain)/Creator(Typst 0.15.0)/ModDate(D:20260728020013Z)/CreationDate(D:20260728020013Z)>>
 endobj
-327 0 obj
+381 0 obj
 <</Length 4312/Type/Metadata/Subtype/XML>>
 stream
-<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/"  xmlns:pdfaExtension="http://www.aiim.org/pdfa/ns/extension/"  xmlns:pdfaSchema="http://www.aiim.org/pdfa/ns/schema#"  xmlns:pdfaProperty="http://www.aiim.org/pdfa/ns/property#" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Sid Jain Resume</rdf:li></rdf:Alt></dc:title><pdf:Keywords>AI product engineer, Applied AI lead, staff full-stack engineer, founding engineer, TypeScript, React Native, Chromium, DNS</pdf:Keywords><dc:creator><rdf:Seq><rdf:li>Sid Jain</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.15.0</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-07-27T23:41:38+00:00</xmp:ModifyDate><xmp:CreateDate>2026-07-27T23:41:38+00:00</xmp:CreateDate><xmpMM:History><rdf:Seq><rdf:li rdf:parseType="Resource"><stEvt:action>saved</stEvt:action><stEvt:when>2026-07-27T23:41:38+00:00</stEvt:when><stEvt:instanceID>4A0rfv1Dz4ByjkIr6k1UGA==_source</stEvt:instanceID></rdf:li><rdf:li rdf:parseType="Resource"><stEvt:action>converted</stEvt:action><stEvt:when>2026-07-27T23:41:38+00:00</stEvt:when><stEvt:softwareAgent>Typst 0.15.0</stEvt:softwareAgent><stEvt:instanceID>4A0rfv1Dz4ByjkIr6k1UGA==_source</stEvt:instanceID></rdf:li></rdf:Seq></xmpMM:History><pdfaExtension:schemas><rdf:Bag><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>XMP Media Management schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/xap/1.0/mm/</pdfaSchema:namespaceURI><pdfaSchema:prefix>xmpMM</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>UUID based identifier for specific incarnation of a document</pdfaProperty:description><pdfaProperty:name>InstanceID</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>Adobe PDF schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/pdf/1.3/</pdfaSchema:namespaceURI><pdfaSchema:prefix>pdf</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>external</pdfaProperty:category><pdfaProperty:description>Keywords associated with the document</pdfaProperty:description><pdfaProperty:name>Keywords</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Version of the PDF specification to which the document conforms</pdfaProperty:description><pdfaProperty:name>PDFVersion</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Name of the application that created the PDF document</pdfaProperty:description><pdfaProperty:name>Producer</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Whether the document has been trapped</pdfaProperty:description><pdfaProperty:name>Trapped</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li></rdf:Bag></pdfaExtension:schemas><pdfaid:part>2</pdfaid:part><pdfaid:conformance>U</pdfaid:conformance><xmpTPg:NPages>2</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>4A0rfv1Dz4ByjkIr6k1UGA==</xmpMM:InstanceID><xmpMM:DocumentID>8WwkqRF/py529rYo68LIrg==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/"  xmlns:pdfaExtension="http://www.aiim.org/pdfa/ns/extension/"  xmlns:pdfaSchema="http://www.aiim.org/pdfa/ns/schema#"  xmlns:pdfaProperty="http://www.aiim.org/pdfa/ns/property#" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Sid Jain Resume</rdf:li></rdf:Alt></dc:title><pdf:Keywords>AI product engineer, Applied AI lead, staff full-stack engineer, founding engineer, TypeScript, React Native, Chromium, DNS</pdf:Keywords><dc:creator><rdf:Seq><rdf:li>Sid Jain</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.15.0</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-07-28T02:00:13+00:00</xmp:ModifyDate><xmp:CreateDate>2026-07-28T02:00:13+00:00</xmp:CreateDate><xmpMM:History><rdf:Seq><rdf:li rdf:parseType="Resource"><stEvt:action>saved</stEvt:action><stEvt:when>2026-07-28T02:00:13+00:00</stEvt:when><stEvt:instanceID>JTd97nF6koGtD0sGL/D0sw==_source</stEvt:instanceID></rdf:li><rdf:li rdf:parseType="Resource"><stEvt:action>converted</stEvt:action><stEvt:when>2026-07-28T02:00:13+00:00</stEvt:when><stEvt:softwareAgent>Typst 0.15.0</stEvt:softwareAgent><stEvt:instanceID>JTd97nF6koGtD0sGL/D0sw==_source</stEvt:instanceID></rdf:li></rdf:Seq></xmpMM:History><pdfaExtension:schemas><rdf:Bag><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>XMP Media Management schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/xap/1.0/mm/</pdfaSchema:namespaceURI><pdfaSchema:prefix>xmpMM</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>UUID based identifier for specific incarnation of a document</pdfaProperty:description><pdfaProperty:name>InstanceID</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>Adobe PDF schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/pdf/1.3/</pdfaSchema:namespaceURI><pdfaSchema:prefix>pdf</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>external</pdfaProperty:category><pdfaProperty:description>Keywords associated with the document</pdfaProperty:description><pdfaProperty:name>Keywords</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Version of the PDF specification to which the document conforms</pdfaProperty:description><pdfaProperty:name>PDFVersion</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Name of the application that created the PDF document</pdfaProperty:description><pdfaProperty:name>Producer</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Whether the document has been trapped</pdfaProperty:description><pdfaProperty:name>Trapped</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li></rdf:Bag></pdfaExtension:schemas><pdfaid:part>2</pdfaid:part><pdfaid:conformance>U</pdfaid:conformance><xmpTPg:NPages>2</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>JTd97nF6koGtD0sGL/D0sw==</xmpMM:InstanceID><xmpMM:DocumentID>8WwkqRF/py529rYo68LIrg==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
-328 0 obj
-<</Type/Catalog/Pages 1 0 R/Metadata 327 0 R/OutputIntents 3 0 R/Lang(en)/StructTreeRoot 4 0 R/MarkInfo<</Marked true/Suspects false>>/ViewerPreferences<</Direction/L2R>>>>
+382 0 obj
+<</Type/Catalog/Pages 1 0 R/Metadata 381 0 R/OutputIntents 3 0 R/Lang(en)/StructTreeRoot 4 0 R/MarkInfo<</Marked true/Suspects false>>/ViewerPreferences<</Direction/L2R>>>>
 endobj
 xref
-0 329
+0 383
 0000000000 65535 f
 0000000016 00000 n
 0000000077 00000 n
 0000000240 00000 n
 0000000263 00000 n
 0000000463 00000 n
-0000001006 00000 n
-0000001551 00000 n
-0000001653 00000 n
-0000001713 00000 n
-0000001814 00000 n
-0000001875 00000 n
-0000001981 00000 n
-0000002087 00000 n
-0000002193 00000 n
-0000002267 00000 n
-0000002329 00000 n
-0000002405 00000 n
-0000002512 00000 n
-0000002579 00000 n
-0000002683 00000 n
-0000002745 00000 n
-0000002812 00000 n
-0000002879 00000 n
-0000002982 00000 n
-0000003044 00000 n
-0000003147 00000 n
-0000003209 00000 n
-0000003278 00000 n
-0000003381 00000 n
-0000003443 00000 n
-0000003552 00000 n
-0000003614 00000 n
-0000003683 00000 n
-0000003786 00000 n
-0000003848 00000 n
-0000003954 00000 n
-0000004016 00000 n
-0000004085 00000 n
-0000004188 00000 n
-0000004250 00000 n
-0000004356 00000 n
-0000004418 00000 n
-0000004487 00000 n
-0000004590 00000 n
-0000004652 00000 n
-0000004758 00000 n
-0000004820 00000 n
-0000004889 00000 n
-0000004993 00000 n
-0000005063 00000 n
-0000005168 00000 n
-0000005230 00000 n
-0000005297 00000 n
-0000005364 00000 n
-0000005467 00000 n
-0000005529 00000 n
-0000005632 00000 n
-0000005694 00000 n
-0000005763 00000 n
-0000005866 00000 n
-0000005928 00000 n
-0000006034 00000 n
-0000006096 00000 n
-0000006165 00000 n
-0000006268 00000 n
-0000006330 00000 n
-0000006439 00000 n
-0000006501 00000 n
-0000006570 00000 n
-0000006673 00000 n
-0000006735 00000 n
-0000006841 00000 n
-0000006903 00000 n
-0000006972 00000 n
-0000007069 00000 n
-0000007139 00000 n
-0000007244 00000 n
-0000007307 00000 n
-0000007375 00000 n
-0000007443 00000 n
-0000007546 00000 n
-0000007608 00000 n
-0000007711 00000 n
-0000007773 00000 n
-0000007843 00000 n
-0000007914 00000 n
-0000008019 00000 n
-0000008081 00000 n
-0000008193 00000 n
-0000008255 00000 n
-0000008325 00000 n
-0000008430 00000 n
-0000008492 00000 n
-0000008604 00000 n
-0000008666 00000 n
-0000008736 00000 n
-0000008841 00000 n
-0000008904 00000 n
-0000009016 00000 n
-0000009079 00000 n
-0000009150 00000 n
-0000009257 00000 n
-0000009322 00000 n
-0000009436 00000 n
-0000009501 00000 n
-0000009574 00000 n
-0000009681 00000 n
-0000009746 00000 n
-0000009860 00000 n
-0000009925 00000 n
-0000009998 00000 n
-0000010121 00000 n
-0000010193 00000 n
-0000010299 00000 n
-0000010364 00000 n
-0000010432 00000 n
-0000010500 00000 n
-0000010604 00000 n
-0000010669 00000 n
-0000010773 00000 n
-0000010838 00000 n
-0000010911 00000 n
-0000011015 00000 n
-0000011080 00000 n
-0000011186 00000 n
-0000011251 00000 n
-0000011324 00000 n
-0000011413 00000 n
-0000011486 00000 n
-0000011592 00000 n
-0000011657 00000 n
-0000011725 00000 n
-0000011794 00000 n
-0000011899 00000 n
-0000011964 00000 n
-0000012069 00000 n
-0000012134 00000 n
-0000012207 00000 n
-0000012312 00000 n
-0000012377 00000 n
-0000012485 00000 n
-0000012550 00000 n
-0000012623 00000 n
-0000012728 00000 n
-0000012793 00000 n
-0000012901 00000 n
-0000012966 00000 n
-0000013039 00000 n
-0000013136 00000 n
-0000013209 00000 n
-0000013316 00000 n
-0000013381 00000 n
-0000013450 00000 n
-0000013519 00000 n
-0000013624 00000 n
-0000013689 00000 n
-0000013794 00000 n
-0000013859 00000 n
-0000013932 00000 n
-0000014037 00000 n
-0000014102 00000 n
-0000014210 00000 n
-0000014275 00000 n
-0000014348 00000 n
-0000014453 00000 n
-0000014518 00000 n
-0000014623 00000 n
-0000014688 00000 n
-0000014761 00000 n
-0000014858 00000 n
-0000014931 00000 n
-0000015038 00000 n
-0000015103 00000 n
-0000015172 00000 n
-0000015241 00000 n
-0000015346 00000 n
-0000015411 00000 n
-0000015516 00000 n
-0000015581 00000 n
-0000015654 00000 n
-0000015759 00000 n
-0000015824 00000 n
-0000015935 00000 n
-0000016000 00000 n
-0000016073 00000 n
-0000016178 00000 n
-0000016243 00000 n
-0000016354 00000 n
-0000016419 00000 n
-0000016492 00000 n
-0000016597 00000 n
-0000016662 00000 n
-0000016767 00000 n
-0000016832 00000 n
-0000016905 00000 n
-0000017010 00000 n
-0000017083 00000 n
-0000017190 00000 n
-0000017255 00000 n
-0000017324 00000 n
-0000017393 00000 n
-0000017498 00000 n
-0000017563 00000 n
-0000017668 00000 n
+0000001094 00000 n
+0000001703 00000 n
+0000001805 00000 n
+0000001865 00000 n
+0000001966 00000 n
+0000002027 00000 n
+0000002133 00000 n
+0000002239 00000 n
+0000002345 00000 n
+0000002419 00000 n
+0000002481 00000 n
+0000002557 00000 n
+0000002666 00000 n
+0000002733 00000 n
+0000002838 00000 n
+0000002900 00000 n
+0000002967 00000 n
+0000003034 00000 n
+0000003137 00000 n
+0000003199 00000 n
+0000003302 00000 n
+0000003364 00000 n
+0000003433 00000 n
+0000003495 00000 n
+0000003598 00000 n
+0000003660 00000 n
+0000003729 00000 n
+0000003832 00000 n
+0000003894 00000 n
+0000004000 00000 n
+0000004062 00000 n
+0000004131 00000 n
+0000004234 00000 n
+0000004296 00000 n
+0000004405 00000 n
+0000004467 00000 n
+0000004536 00000 n
+0000004639 00000 n
+0000004701 00000 n
+0000004807 00000 n
+0000004869 00000 n
+0000004938 00000 n
+0000005041 00000 n
+0000005103 00000 n
+0000005212 00000 n
+0000005274 00000 n
+0000005343 00000 n
+0000005447 00000 n
+0000005517 00000 n
+0000005622 00000 n
+0000005684 00000 n
+0000005751 00000 n
+0000005818 00000 n
+0000005921 00000 n
+0000005983 00000 n
+0000006086 00000 n
+0000006148 00000 n
+0000006251 00000 n
+0000006313 00000 n
+0000006389 00000 n
+0000006451 00000 n
+0000006554 00000 n
+0000006616 00000 n
+0000006685 00000 n
+0000006788 00000 n
+0000006850 00000 n
+0000006956 00000 n
+0000007018 00000 n
+0000007087 00000 n
+0000007190 00000 n
+0000007252 00000 n
+0000007361 00000 n
+0000007423 00000 n
+0000007492 00000 n
+0000007595 00000 n
+0000007657 00000 n
+0000007763 00000 n
+0000007825 00000 n
+0000007894 00000 n
+0000007997 00000 n
+0000008059 00000 n
+0000008165 00000 n
+0000008227 00000 n
+0000008296 00000 n
+0000008400 00000 n
+0000008470 00000 n
+0000008575 00000 n
+0000008638 00000 n
+0000008706 00000 n
+0000008774 00000 n
+0000008877 00000 n
+0000008940 00000 n
+0000009043 00000 n
+0000009106 00000 n
+0000009210 00000 n
+0000009274 00000 n
+0000009353 00000 n
+0000009418 00000 n
+0000009523 00000 n
+0000009588 00000 n
+0000009661 00000 n
+0000009733 00000 n
+0000009840 00000 n
+0000009905 00000 n
+0000010019 00000 n
+0000010084 00000 n
+0000010157 00000 n
+0000010264 00000 n
+0000010329 00000 n
+0000010443 00000 n
+0000010508 00000 n
+0000010581 00000 n
+0000010688 00000 n
+0000010753 00000 n
+0000010867 00000 n
+0000010932 00000 n
+0000011005 00000 n
+0000011112 00000 n
+0000011177 00000 n
+0000011291 00000 n
+0000011356 00000 n
+0000011429 00000 n
+0000011536 00000 n
+0000011601 00000 n
+0000011715 00000 n
+0000011780 00000 n
+0000011853 00000 n
+0000011980 00000 n
+0000012052 00000 n
+0000012158 00000 n
+0000012223 00000 n
+0000012291 00000 n
+0000012359 00000 n
+0000012463 00000 n
+0000012528 00000 n
+0000012632 00000 n
+0000012697 00000 n
+0000012801 00000 n
+0000012866 00000 n
+0000012947 00000 n
+0000013012 00000 n
+0000013116 00000 n
+0000013181 00000 n
+0000013254 00000 n
+0000013358 00000 n
+0000013423 00000 n
+0000013529 00000 n
+0000013594 00000 n
+0000013667 00000 n
+0000013772 00000 n
+0000013837 00000 n
+0000013945 00000 n
+0000014010 00000 n
+0000014083 00000 n
+0000014180 00000 n
+0000014253 00000 n
+0000014360 00000 n
+0000014425 00000 n
+0000014494 00000 n
+0000014563 00000 n
+0000014668 00000 n
+0000014733 00000 n
+0000014838 00000 n
+0000014903 00000 n
+0000014976 00000 n
+0000015041 00000 n
+0000015146 00000 n
+0000015211 00000 n
+0000015284 00000 n
+0000015389 00000 n
+0000015454 00000 n
+0000015562 00000 n
+0000015627 00000 n
+0000015700 00000 n
+0000015805 00000 n
+0000015870 00000 n
+0000015978 00000 n
+0000016043 00000 n
+0000016116 00000 n
+0000016213 00000 n
+0000016286 00000 n
+0000016393 00000 n
+0000016458 00000 n
+0000016527 00000 n
+0000016596 00000 n
+0000016701 00000 n
+0000016766 00000 n
+0000016871 00000 n
+0000016936 00000 n
+0000017009 00000 n
+0000017074 00000 n
+0000017179 00000 n
+0000017244 00000 n
+0000017317 00000 n
+0000017422 00000 n
+0000017487 00000 n
+0000017595 00000 n
+0000017660 00000 n
 0000017733 00000 n
-0000017806 00000 n
-0000017911 00000 n
-0000017976 00000 n
-0000018087 00000 n
-0000018152 00000 n
-0000018225 00000 n
-0000018330 00000 n
-0000018395 00000 n
-0000018500 00000 n
-0000018565 00000 n
-0000018638 00000 n
-0000018735 00000 n
-0000018808 00000 n
-0000018877 00000 n
-0000018984 00000 n
-0000019049 00000 n
-0000019118 00000 n
-0000019187 00000 n
-0000019292 00000 n
-0000019357 00000 n
-0000019462 00000 n
-0000019527 00000 n
-0000019600 00000 n
-0000019681 00000 n
-0000019754 00000 n
-0000019861 00000 n
-0000019926 00000 n
-0000019995 00000 n
-0000020064 00000 n
-0000020169 00000 n
-0000020234 00000 n
-0000020339 00000 n
-0000020404 00000 n
-0000020477 00000 n
-0000020558 00000 n
-0000020631 00000 n
-0000020798 00000 n
-0000021007 00000 n
-0000021224 00000 n
-0000021432 00000 n
-0000021469 00000 n
-0000021747 00000 n
-0000021992 00000 n
-0000022134 00000 n
-0000022402 00000 n
-0000022612 00000 n
-0000022758 00000 n
-0000023440 00000 n
-0000023657 00000 n
-0000023802 00000 n
-0000024719 00000 n
-0000024935 00000 n
-0000025077 00000 n
-0000025401 00000 n
-0000025611 00000 n
-0000025753 00000 n
-0000026418 00000 n
-0000026629 00000 n
-0000026769 00000 n
-0000027413 00000 n
-0000027625 00000 n
-0000027767 00000 n
-0000027987 00000 n
-0000028198 00000 n
-0000028356 00000 n
-0000028475 00000 n
-0000028552 00000 n
-0000029017 00000 n
-0000030635 00000 n
-0000030717 00000 n
-0000031368 00000 n
-0000039781 00000 n
-0000039863 00000 n
-0000040626 00000 n
-0000051574 00000 n
-0000051653 00000 n
-0000052145 00000 n
-0000054381 00000 n
-0000054461 00000 n
-0000055108 00000 n
-0000060522 00000 n
-0000060605 00000 n
-0000061236 00000 n
-0000068772 00000 n
-0000068849 00000 n
-0000069280 00000 n
-0000072721 00000 n
-0000078189 00000 n
-0000082533 00000 n
-0000082940 00000 n
-0000088281 00000 n
-0000215952 00000 n
-0000219409 00000 n
-0000226865 00000 n
-0000237287 00000 n
-0000270742 00000 n
-0000273684 00000 n
-0000276355 00000 n
-0000279728 00000 n
-0000286781 00000 n
-0000294825 00000 n
-0000390627 00000 n
-0000399344 00000 n
-0000404869 00000 n
-0000409583 00000 n
-0000413594 00000 n
-0000417966 00000 n
-0000420554 00000 n
-0000426149 00000 n
-0000429435 00000 n
-0000433574 00000 n
-0000437530 00000 n
-0000447788 00000 n
-0000454487 00000 n
-0000473910 00000 n
-0000480444 00000 n
-0000484319 00000 n
-0000490504 00000 n
-0000493717 00000 n
-0000526700 00000 n
-0000537629 00000 n
-0000537906 00000 n
-0000542296 00000 n
+0000017838 00000 n
+0000017903 00000 n
+0000018008 00000 n
+0000018073 00000 n
+0000018146 00000 n
+0000018243 00000 n
+0000018316 00000 n
+0000018423 00000 n
+0000018488 00000 n
+0000018557 00000 n
+0000018626 00000 n
+0000018731 00000 n
+0000018796 00000 n
+0000018901 00000 n
+0000018966 00000 n
+0000019071 00000 n
+0000019136 00000 n
+0000019217 00000 n
+0000019282 00000 n
+0000019387 00000 n
+0000019452 00000 n
+0000019525 00000 n
+0000019630 00000 n
+0000019695 00000 n
+0000019803 00000 n
+0000019868 00000 n
+0000019941 00000 n
+0000020046 00000 n
+0000020111 00000 n
+0000020222 00000 n
+0000020287 00000 n
+0000020360 00000 n
+0000020465 00000 n
+0000020530 00000 n
+0000020635 00000 n
+0000020700 00000 n
+0000020773 00000 n
+0000020878 00000 n
+0000020951 00000 n
+0000021058 00000 n
+0000021123 00000 n
+0000021192 00000 n
+0000021261 00000 n
+0000021366 00000 n
+0000021431 00000 n
+0000021536 00000 n
+0000021601 00000 n
+0000021674 00000 n
+0000021739 00000 n
+0000021844 00000 n
+0000021909 00000 n
+0000021982 00000 n
+0000022087 00000 n
+0000022152 00000 n
+0000022260 00000 n
+0000022325 00000 n
+0000022398 00000 n
+0000022503 00000 n
+0000022568 00000 n
+0000022673 00000 n
+0000022738 00000 n
+0000022811 00000 n
+0000022908 00000 n
+0000022981 00000 n
+0000023050 00000 n
+0000023157 00000 n
+0000023222 00000 n
+0000023291 00000 n
+0000023360 00000 n
+0000023465 00000 n
+0000023530 00000 n
+0000023595 00000 n
+0000023660 00000 n
+0000023765 00000 n
+0000023830 00000 n
+0000023903 00000 n
+0000023984 00000 n
+0000024057 00000 n
+0000024164 00000 n
+0000024229 00000 n
+0000024298 00000 n
+0000024367 00000 n
+0000024472 00000 n
+0000024537 00000 n
+0000024602 00000 n
+0000024667 00000 n
+0000024772 00000 n
+0000024837 00000 n
+0000024910 00000 n
+0000024991 00000 n
+0000025064 00000 n
+0000025231 00000 n
+0000025440 00000 n
+0000025657 00000 n
+0000025865 00000 n
+0000025902 00000 n
+0000026180 00000 n
+0000026425 00000 n
+0000026567 00000 n
+0000026835 00000 n
+0000027045 00000 n
+0000027191 00000 n
+0000027893 00000 n
+0000028110 00000 n
+0000028255 00000 n
+0000029142 00000 n
+0000029358 00000 n
+0000029500 00000 n
+0000029824 00000 n
+0000030034 00000 n
+0000030176 00000 n
+0000030791 00000 n
+0000031002 00000 n
+0000031142 00000 n
+0000031800 00000 n
+0000032012 00000 n
+0000032154 00000 n
+0000032374 00000 n
+0000032585 00000 n
+0000032743 00000 n
+0000032862 00000 n
+0000032939 00000 n
+0000033404 00000 n
+0000035022 00000 n
+0000035104 00000 n
+0000035762 00000 n
+0000044265 00000 n
+0000044347 00000 n
+0000045090 00000 n
+0000055688 00000 n
+0000055767 00000 n
+0000056259 00000 n
+0000058495 00000 n
+0000058578 00000 n
+0000059200 00000 n
+0000064169 00000 n
+0000064250 00000 n
+0000064886 00000 n
+0000072647 00000 n
+0000072724 00000 n
+0000073155 00000 n
+0000076596 00000 n
+0000082822 00000 n
+0000087628 00000 n
+0000088035 00000 n
+0000093376 00000 n
+0000221047 00000 n
+0000224504 00000 n
+0000231960 00000 n
+0000242382 00000 n
+0000275837 00000 n
+0000278779 00000 n
+0000281450 00000 n
+0000284823 00000 n
+0000291876 00000 n
+0000299920 00000 n
+0000395722 00000 n
+0000404439 00000 n
+0000409964 00000 n
+0000414678 00000 n
+0000418689 00000 n
+0000423061 00000 n
+0000425649 00000 n
+0000431244 00000 n
+0000434530 00000 n
+0000438669 00000 n
+0000442625 00000 n
+0000452883 00000 n
+0000459582 00000 n
+0000479005 00000 n
+0000485539 00000 n
+0000489414 00000 n
+0000495599 00000 n
+0000498812 00000 n
+0000531795 00000 n
+0000542724 00000 n
+0000543001 00000 n
+0000547391 00000 n
 trailer
-<</Size 329/Root 328 0 R/Info 326 0 R/ID[(8WwkqRF/py529rYo68LIrg==)(4A0rfv1Dz4ByjkIr6k1UGA==)]>>
+<</Size 383/Root 382 0 R/Info 380 0 R/ID[(8WwkqRF/py529rYo68LIrg==)(JTd97nF6koGtD0sGL/D0sw==)]>>
 startxref
-542486
+547581
 %%EOF

--- a/scripts/build-resume-pdf.ts
+++ b/scripts/build-resume-pdf.ts
@@ -2,11 +2,12 @@ import { execFileSync } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { resumeData } from "../src/content/resume";
+import { resumeData, resumeRoleMarkerLabels } from "../src/content/resume";
 import type {
   LogoAsset,
   ResumeExperience,
   ResumeRole,
+  ResumeRoleMarker,
 } from "../src/content/resume";
 
 const quote = (value: string) => JSON.stringify(value);
@@ -32,10 +33,11 @@ const typstLeadingFromCssLineHeight = (value: number) =>
 
 const fontSize = {
   xs: remToPt(0.75),
-  sm: remToPt(0.875),
+  sm: pt(10),
   base: remToPt(1),
   xl: remToPt(1.25),
   "5xl": remToPt(3),
+  marker: pt(7.5),
 };
 
 const spacing = {
@@ -64,6 +66,7 @@ const pdfOnly = {
   ),
   contactStackHeight: pt(32),
   companyTaglineGap: pt(-6),
+  experienceItemGap: spacing[4],
   pageMargin: "0.58in",
   profileAvatarSize: fontSize["5xl"],
   roleBodyGap: cssPxToPt(3),
@@ -109,6 +112,37 @@ const link = (
   href: string,
   options: Parameters<typeof text>[1] = {}
 ) => `#link(${quote(href)})[${text(label, { fill: "accent", ...options })}]`;
+
+const roleMarkerDetails = {
+  "hands-on": {
+    fill: "#2d2418",
+    stroke: "#9a6a2b",
+    text: "#f0b85f",
+  },
+  leadership: {
+    fill: "#2a2429",
+    stroke: "#7a6171",
+    text: "#e3bfd7",
+  },
+} satisfies Record<
+  ResumeRoleMarker,
+  { fill: string; stroke: string; text: string }
+>;
+
+const roleMarker = (marker: ResumeRoleMarker) => {
+  const details = roleMarkerDetails[marker];
+
+  return `#box(
+  inset: (x: ${pt(4)}, y: ${pt(1.5)}),
+  radius: ${pt(8)},
+  fill: rgb(${quote(details.fill)}),
+  stroke: ${pt(0.75)} + rgb(${quote(details.stroke)}),
+)[${text(resumeRoleMarkerLabels[marker], {
+    fill: `rgb(${quote(details.text)})`,
+    size: fontSize.marker,
+    weight: "medium",
+  })}]`;
+};
 
 const sizeFromClass = (
   className: string | undefined,
@@ -250,21 +284,37 @@ ${text(title, {
 
 const roleBlock = (role: ResumeRole) => {
   const bullets = role.bullets?.map(bulletContent) ?? [];
+  const roleHeadingItems = [
+    text(role.title, { fill: "strong", weight: "medium" }),
+    ...(role.markers?.map(roleMarker) ?? []),
+  ];
+  const roleHeading = `#grid(
+  columns: (${roleHeadingItems.map(() => "auto").join(", ")}),
+  gutter: ${pt(4)},
+  align: horizon,
+  ${roleHeadingItems.map((item) => `[${item}]`).join(",\n  ")}
+)`;
 
   return `
 #v(${pdfOnly.roleTopGap})
 #grid(
   columns: (1fr, auto),
   gutter: ${spacing[4]},
-  [${text(role.title, { fill: "strong", weight: "medium" })}],
-  [${text(`${role.location} · ${role.dates}`, { size: fontSize.xs })}],
+  [${roleHeading}],
+  [${text(`${role.location} · ${role.dates}`, { size: cssPxToPt(11) })}],
 )
 ${role.summary === undefined ? "" : `#v(${pdfOnly.roleBodyGap})\n${text(role.summary)}`}
 ${bullets.length === 0 ? "" : `#v(${pdfOnly.roleBodyGap})\n${stack(bullets)}`}
 `;
 };
 
-const experienceItem = (item: ResumeExperience) => `
+interface PdfSectionItem {
+  content: string;
+  pageBreakBefore: boolean;
+}
+
+const experienceItem = (item: ResumeExperience): PdfSectionItem => ({
+  content: `
 #block(breakable: false)[
 #grid(
   columns: (${spacing[10]}, 1fr),
@@ -285,21 +335,33 @@ const experienceItem = (item: ResumeExperience) => `
   ],
 )
 ]
-`;
+`,
+  pageBreakBefore: item.pdfPageBreakBefore === true,
+});
 
 const sectionWithItems = (
   title: string,
-  items: string[],
+  items: PdfSectionItem[],
   titleOptions?: Parameters<typeof sectionTitle>[1]
 ) => {
   const [firstItem, ...remainingItems] = items;
+  const firstItemContent =
+    firstItem === undefined
+      ? ""
+      : `${firstItem.pageBreakBefore ? "#pagebreak()\n" : ""}${firstItem.content}`;
 
   return `
 #block(breakable: false)[
   ${sectionTitle(title, titleOptions)}
-  ${firstItem ?? ""}
+  ${firstItemContent}
 ]
-${remainingItems.map((item) => `#v(${spacing[6]})\n${item}`).join("\n")}
+${remainingItems
+  .map((item) =>
+    item.pageBreakBefore
+      ? `#pagebreak()\n${item.content}`
+      : `#v(${pdfOnly.experienceItemGap})\n${item.content}`
+  )
+  .join("\n")}
 `;
 };
 

--- a/src/app/(blog)/blog/[slug]/page.tsx
+++ b/src/app/(blog)/blog/[slug]/page.tsx
@@ -199,8 +199,7 @@ export default async function BlogPostPage({ params }: { params: PageParams }) {
           <aside className="space-y-6 lg:sticky lg:top-24">
             <AuthorCard />
             <div className="rounded-xl border border-border/70 bg-muted/40 p-5 text-sm text-muted-foreground">
-              Want more like this? New posts land weekly with experiments and
-              craft notes.
+              Sid writes about engineering, product, AI, and creative work.
             </div>
           </aside>
         </div>

--- a/src/app/(portfolio)/page.tsx
+++ b/src/app/(portfolio)/page.tsx
@@ -5,7 +5,7 @@ import { publicUrl, siteConfig } from "@/lib/site";
 
 import { ResumePageContent } from "./resume/page";
 
-const resumeDescription = `Sid Jain resume: ${resumeData.person.role}, founder of Yuppies Tech, and AI product engineer at Namefi.`;
+const resumeDescription = siteConfig.description;
 
 export const metadata: Metadata = {
   alternates: {

--- a/src/app/(portfolio)/resume/page.tsx
+++ b/src/app/(portfolio)/resume/page.tsx
@@ -3,8 +3,13 @@ import { JetBrains_Mono, Literata, Source_Sans_3 } from "next/font/google";
 import Link from "next/link";
 
 import { JsonLd } from "@/components/json-ld";
-import { resumeData } from "@/content/resume";
-import type { LogoAsset, ResumeExperience, ResumeRole } from "@/content/resume";
+import { resumeData, resumeRoleMarkerLabels } from "@/content/resume";
+import type {
+  LogoAsset,
+  ResumeExperience,
+  ResumeRole,
+  ResumeRoleMarker,
+} from "@/content/resume";
 import { buildAskAgentLinks } from "@/lib/resume";
 import { publicUrl, siteConfig } from "@/lib/site";
 import { buildProfilePageJsonLd } from "@/lib/structured-data";
@@ -16,7 +21,7 @@ import {
   ResumeThemeToggle,
 } from "./resume-controls";
 
-const resumeDescription = `Sid Jain resume: ${resumeData.person.role}, founder of Yuppies Tech, and AI product engineer at Namefi.`;
+const resumeDescription = siteConfig.description;
 
 const literata = Literata({
   subsets: ["latin"],
@@ -66,6 +71,21 @@ const profileJsonLd = buildProfilePageJsonLd();
 const mutedText = "text-[#78716c] dark:text-[#a8a29e]";
 const accentText =
   "text-[#b45309] transition-colors hover:text-[#92400e] dark:text-[#d97706] dark:hover:text-[#f59e0b]";
+const roleMarkerDetails = {
+  "hands-on": {
+    className:
+      "border-[#e4c184] bg-[#f9ebd2] text-[#835018] dark:border-[#6a4b24] dark:bg-[#2b2319] dark:text-[#e8ae58]",
+    description: "Hands-on engineering",
+  },
+  leadership: {
+    className:
+      "border-[#d6c7cf] bg-[#f0eaee] text-[#66505f] dark:border-[#5b4b55] dark:bg-[#282328] dark:text-[#d8becd]",
+    description: "People and engineering leadership",
+  },
+} satisfies Record<
+  ResumeRoleMarker,
+  { className: string; description: string }
+>;
 
 interface ResumePageContentProps {
   includeProfileJsonLd?: boolean;
@@ -121,13 +141,45 @@ function SectionTitle({ children }: Readonly<{ children: React.ReactNode }>) {
   );
 }
 
+function RoleMarkers({ role }: Readonly<{ role: ResumeRole }>) {
+  if (role.markers === undefined || role.markers.length === 0) {
+    return null;
+  }
+
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1">
+      {role.markers.map((marker) => {
+        const details = roleMarkerDetails[marker];
+        const description =
+          marker === "leadership" && role.leadershipScope !== undefined
+            ? `${details.description}: ${role.leadershipScope}`
+            : details.description;
+
+        return (
+          <span
+            className={`inline-flex h-5 items-center rounded-full border px-2 text-[0.625rem] font-semibold leading-none tracking-[0.01em] ${details.className}`}
+            key={marker}
+            title={description}
+          >
+            <span aria-hidden="true">{resumeRoleMarkerLabels[marker]}</span>
+            <span className="sr-only">{description}</span>
+          </span>
+        );
+      })}
+    </span>
+  );
+}
+
 function RoleBlock({ role }: Readonly<{ role: ResumeRole }>) {
   return (
     <div className="mt-3">
       <div className="flex flex-wrap items-baseline justify-between gap-x-4">
-        <span className="text-sm font-medium text-[#292524] dark:text-[#e7e5e4]">
-          {role.title}
-        </span>
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <span className="text-sm font-medium leading-5 text-[#292524] dark:text-[#e7e5e4]">
+            {role.title}
+          </span>
+          <RoleMarkers role={role} />
+        </div>
         <span className={`text-xs ${mutedText}`}>
           {role.location} <span aria-hidden="true">·</span> {role.dates}
         </span>

--- a/src/components/blog/AuthorCard.tsx
+++ b/src/components/blog/AuthorCard.tsx
@@ -34,7 +34,7 @@ export default function AuthorCard() {
             <div className="flex flex-wrap items-center gap-2">
               <Badge variant="secondary">{author.role}</Badge>
               <span className="text-xs text-muted-foreground">
-                Building thoughtful web experiences.
+                Building products and leading engineering teams.
               </span>
             </div>
           </div>

--- a/src/content/blog/2016-music-in-review/page.mdx
+++ b/src/content/blog/2016-music-in-review/page.mdx
@@ -3,7 +3,7 @@ export const metadata = {
   date: "2016-11-03",
   author: "Sid Jain",
   summary:
-    "A round up of the seven best artists, both old and new, that I discovered in 2016.",
+    "A roundup of the seven best artists, both old and new, that I discovered in 2016.",
   tags: ["music", "review"],
 };
 

--- a/src/content/blog/how-we-built-our-react-native-app/page.mdx
+++ b/src/content/blog/how-we-built-our-react-native-app/page.mdx
@@ -3,7 +3,7 @@ export const metadata = {
   date: "2017-09-15",
   author: "Sid Jain",
   summary:
-    "The design philosophy, tech stack and tooling that went into building a React Native App at Housing.com",
+    "The design philosophy, tech stack, and tooling that went into building a React Native app at Housing.com.",
   tags: ["react-native", "mobile", "engineering"],
 };
 

--- a/src/content/blog/on-the-futility-of-trying-to-make-it/page.mdx
+++ b/src/content/blog/on-the-futility-of-trying-to-make-it/page.mdx
@@ -3,7 +3,7 @@ export const metadata = {
   date: "2018-06-24",
   author: "Sid Jain",
   summary:
-    "About two years ago, I had decided to abandon an idle existence and put myself out in what some call the 'real world’. The idea, back then, was to cultivate pragmatic skills and be successful in the trade of my choosing. Two years later, I am still as troubled as I was back then and perhaps even more so.",
+    "About two years ago, I decided to abandon an idle existence and enter what some call the “real world.” I hoped to develop practical skills and succeed in my chosen trade. Two years later, I remain as troubled as I was then, perhaps even more so.",
   tags: ["essay", "career"],
 };
 

--- a/src/content/resume.ts
+++ b/src/content/resume.ts
@@ -12,10 +12,19 @@ interface ResumeBullet {
   text: string;
 }
 
+export type ResumeRoleMarker = "hands-on" | "leadership";
+
+export const resumeRoleMarkerLabels = {
+  "hands-on": "Hands-on",
+  leadership: "Leadership",
+} satisfies Record<ResumeRoleMarker, string>;
+
 export interface ResumeRole {
   title: string;
   dates: string;
+  leadershipScope?: string;
   location: string;
+  markers?: ResumeRoleMarker[];
   summary?: string;
   bullets?: (ResumeBullet | string)[];
 }
@@ -23,6 +32,7 @@ export interface ResumeRole {
 export interface ResumeExperience {
   company: string;
   logo: LogoAsset;
+  pdfPageBreakBefore?: boolean;
   tagline: string;
   roles: ResumeRole[];
 }
@@ -159,7 +169,7 @@ const dpsLogo: LogoAsset = {
 };
 
 export const resumeData = {
-  lastUpdated: "2026-07-27",
+  lastUpdated: "2026-07-28",
   person: {
     alternateNames: ["f0rr0", "yuppiestechdev"],
     avatarImage: "/resume/sid-jain-profile-avatar.png",
@@ -167,9 +177,9 @@ export const resumeData = {
     image: "/resume/sid-jain-profile.png",
     location: "Mumbai, India / Remote",
     name: "Sid Jain",
-    role: "Senior Full-Stack Engineer / Applied AI Lead",
+    role: "Applied AI Lead and Senior Full-Stack Engineer",
     targetPositioning:
-      "applied AI solutions architect, applied AI lead, staff full-stack engineer, and founding engineer",
+      "hands-on VP of Engineering, Applied AI Lead, solutions architect, staff full-stack engineer, and founding engineer",
   },
   navItems: [
     { href: "/blog", label: "Blog" },
@@ -182,23 +192,24 @@ export const resumeData = {
     { href: "https://github.com/f0rr0", label: "github.com/f0rr0" },
   ] satisfies ResumeLink[],
   summary:
-    "Applied AI Lead and senior full-stack engineer who turns ambiguous customer problems into production AI systems. Blends customer discovery, technical advisory, evaluation and workflow design, hands-on prototyping, and production architecture across AI, marketplace, browser, mobile, and infrastructure-heavy products.",
+    "Applied AI Lead and hands-on engineering leader who turns loosely defined customer needs into production systems. Leads customer discovery, technical strategy, teams, architecture, and delivery while remaining directly involved in AI workflow design, evaluation, prototyping, and full-stack implementation across marketplaces, browsers, mobile apps, and infrastructure-heavy products.",
   experience: [
     {
       company: "Namefi",
       tagline:
-        "AI-powered registrar for tokenized domains and domainer workflows.",
+        "ICANN-accredited registrar building AI products for domain ownership and sales.",
       logo: namefiLogo,
       roles: [
         {
           title: "Lead Applied AI Engineer",
           dates: "Jan 2025 - Present",
           location: "San Francisco Bay Area / Remote",
+          markers: ["hands-on"],
           bullets: [
-            "Led customer discovery with large domain owners and turned manual sales workflows into Namefi Outbound: AI-assisted buyer hypotheses, web research, lead scoring, contact discovery, and editable outreach, reducing prep from days to minutes.",
-            "Designed Brand Studio as a multi-stage AI workflow that turns domains into buyer-ready logos, posters, and motion concepts with strategist/concept passes, exact domain/TLD constraints, and animation workflows.",
-            "Built Namefi Feed, an AI-enriched listing intelligence layer that normalizes roughly 4,000-5,000 public domain listings from X, NamePros, DNForum, and marketplaces into searchable/RSS surfaces.",
-            "Built production registrar and domain systems across registrar integrations, DNS/DNSSEC, nameservers, ENS/.eth, renewals, payments, checkout, analytics, and Temporal-backed long-running workflows.",
+            "Interviewed owners of large domain portfolios and built Namefi Outbound to streamline buyer research, lead scoring, contact discovery, and outreach drafting, reducing sales preparation from days to minutes.",
+            "Designed Brand Studio, a multi-stage AI system that creates logos, posters, and motion concepts for domains. It separates strategy, concept generation, and animation while preserving the exact domain name, including its top-level domain.",
+            "Built Namefi Feed, which aggregates and structures roughly 4,000 to 5,000 public domain listings from X, forums, and marketplaces, making them searchable on the web and through RSS feeds.",
+            "Built production registrar systems for third-party integrations, registration, renewals, payments, checkout, and analytics. Added DNS record and DNSSEC management, nameserver controls, ENS and .eth support, and long-running Temporal workflows.",
           ],
         },
       ],
@@ -206,58 +217,62 @@ export const resumeData = {
     {
       company: "Memorang",
       tagline:
-        "Built EdWrite, Memorang's AI-native, graph-based headless CMS for education.",
+        "AI-assisted educational content platform for structured curricula and assessments.",
       logo: memorangLogo,
       roles: [
         {
           title: "Lead Product Engineer, AI Content Platform",
           dates: "Apr 2024 - Jan 2025",
+          leadershipScope: "Managed 3 developers",
           location: "San Francisco Bay Area / Remote",
+          markers: ["hands-on", "leadership"],
           bullets: [
-            "Built EdWrite, Memorang's graph-based headless CMS, turning Cambridge/TOEFL and subject-matter expert requirements into structured, versioned curricula, assessments, and content APIs.",
-            "Designed human-in-the-loop agent workflows for experts to generate, review, and manage complete question sets and companion audio/image media at scale; built adaptive practice, scoring, and embedding-based media recommendations.",
-            "Led the CMS team and roadmap across backend, frontend, app, CTO, and CEO while modernizing a large JS/Flow monorepo toward TypeScript, Bun, and Biome with agentic refactors and codemods.",
+            "Built EdWrite, a graph-based headless CMS that represents Cambridge and TOEFL curricula and assessment requirements in versioned schemas exposed through content APIs.",
+            "Designed human-in-the-loop workflows that let subject-matter experts generate, review, and manage complete question sets with supporting audio and images. Also built adaptive practice and scoring, plus semantic recommendations for related media.",
+            "Managed a three-developer CMS team and owned its roadmap, coordinating with backend, frontend, and mobile teams while working directly with the CTO and CEO.",
+            "Led the gradual migration of a large Flow-typed JavaScript monorepo to TypeScript, introducing Bun, Biome, codemods, and AI-assisted refactoring.",
           ],
         },
       ],
     },
     {
       company: "Yuppies Tech",
-      tagline:
-        "Founder-led product engineering consultancy for high-ambiguity client work.",
+      tagline: "Product engineering consultancy for complex client products.",
       logo: yuppiesLogo,
       roles: [
         {
           title: "Founder & Technical Director",
           dates: "Jan 2021 - Apr 2024",
+          leadershipScope: "Led a 15-engineer team",
           location: "Mumbai / Remote",
+          markers: ["hands-on", "leadership"],
           summary:
-            "Founded and led a product engineering consultancy as client-facing technical partner, translating ambiguous requirements into architecture, delivery plans, and shipped systems.",
+            "Founded and grew Yuppies Tech to 15 engineers while remaining the client-facing technical lead. Turned unclear requirements into architecture, delivery plans, and production releases.",
           bullets: [
             {
               label: "Veera Browser",
               logo: veeraLogo,
-              text: "led Android Chromium browser delivery from zero to Play Store, owning Chromium/Brave patch management, build/release tooling, rewards/feed/onboarding/search/tabs, privacy/security updates, and later iOS platform setup.",
+              text: "led a Chromium-based Android browser from initial architecture through Play Store launch, owning upstream patch management, release tooling, product features, and privacy updates. Later established the iOS platform and release setup.",
             },
             {
               label: "Texts",
               logo: textsLogo,
-              text: "built production Messenger channel by reverse-engineering undocumented infrastructure and implementing MQTT/Facebook Thrift, encrypted payloads, sync, groups, attachments, reactions, receipts, typing, and presence.",
+              text: "built a production Facebook Messenger integration by reverse-engineering undocumented protocols, then implemented encrypted messaging, synchronization, groups, attachments, reactions, read receipts, typing indicators, and presence.",
             },
             {
               label: "ZebPay",
               logo: zebpayLogo,
-              text: "client-facing technical lead for a 10-person team modernizing iOS/Android apps, release infrastructure, exchange features, payment flows, and international KYC; moved stabilization releases from monthly/bi-monthly to weekly.",
+              text: "led modernization of ZebPay's iOS and Android apps, release infrastructure, exchange and payment features, and international KYC. During stabilization, increased the release cadence from every two weeks to weekly.",
             },
             {
               label: "Mitsubishi Motors",
               logo: mitsubishiLogo,
-              text: "client-facing technical lead for MiAR, turning remote dealership goals into native iOS/iPadOS and WebAR with optimized 3D vehicles, low-end Android support, bilingual content, and contest/admin workflows.",
+              text: "led MiAR, a remote dealership experience delivered through native iOS and iPadOS apps plus WebAR. Shipped optimized 3D vehicle models, support for lower-end Android devices, bilingual content, and contest-administration tooling.",
             },
             {
               label: "Airbus Tripset",
               logo: airbusLogo,
-              text: "solo technical partner to Milkinside for Airbus's public iOS/Android COVID travel companion, translating urgent traveler guidance needs into app/backend layers over Airbus/Amadeus APIs, CMS rules, and itinerary notifications.",
+              text: "owned end-to-end technical delivery of Airbus Tripset, a public iOS and Android travel companion launched during COVID. Built the React Native app and backend services that combined Airbus and Amadeus APIs, CMS-managed travel guidance, itinerary data, and notifications.",
             },
           ],
         },
@@ -270,41 +285,47 @@ export const resumeData = {
       roles: [
         {
           title: "Vice President of Engineering",
-          dates: "Jan 2020 - Dec 2021",
+          dates: "Jan 2020 - Jan 2021",
+          leadershipScope: "Led a 10-engineer team",
           location: "Mumbai",
+          markers: ["hands-on", "leadership"],
           bullets: [
-            "Built the first product and technical foundation for a consumer beauty/skincare shopping app from the ground up across AWS, Elixir, Swift, and Kotlin.",
+            "Led a 10-engineer team and owned Kult's zero-to-one product and engineering strategy, covering an AWS-hosted Elixir backend and native iOS and Android apps.",
+            "Architected both apps and contributed directly in Swift and Kotlin while establishing CI/CD, analytics, deep linking, observability, and the foundations for commerce and engagement features.",
           ],
         },
       ],
     },
     {
-      company: "Yilu, Lufthansa Group / BCG Digital Ventures",
-      tagline: "Smart travel platform for Lufthansa Group.",
+      company: "Yilu",
+      tagline:
+        "Smart travel platform built for Lufthansa Group with BCG Digital Ventures.",
       logo: yiluLogo,
       roles: [
         {
           title: "Founding Engineer",
           dates: "Nov 2018 - Dec 2019",
           location: "Berlin",
+          markers: ["hands-on"],
           bullets: [
-            "Built native mobile architecture, CI/CD and release automation, Terraform-backed AWS web infrastructure, and iOS/Android features for Eurowings.",
-            "Helped hire and structure the initial engineering team through job descriptions, technical tasks, interviews, and Scrum Master responsibilities.",
+            "Designed the native mobile architecture and release automation, built Terraform-managed AWS infrastructure, and shipped iOS and Android features for Eurowings.",
+            "Helped establish the engineering team by writing job descriptions, creating technical exercises, and interviewing candidates. Also served as Scrum Master.",
           ],
         },
       ],
     },
     {
-      company: "8fit by Withings",
-      tagline: "Fitness and nutrition platform, now part of Withings.",
+      company: "8fit",
+      tagline: "Fitness and nutrition platform later acquired by Withings.",
       logo: eightfitLogo,
       roles: [
         {
           title: "Senior Technical Architect",
           dates: "Nov 2017 - Oct 2018",
           location: "Berlin",
+          markers: ["hands-on"],
           bullets: [
-            "Architected a hybrid Apple TV fitness app that reached #1 Health & Fitness in Germany and 30+ countries and #7 in the US.",
+            "Architected a hybrid Apple TV fitness app that ranked No. 1 in its Health & Fitness category in more than 30 countries, including Germany, and No. 7 in the United States.",
             "Built cross-platform mobile features across JavaScript, Swift, Objective-C, Java, and Kotlin.",
           ],
         },
@@ -318,10 +339,12 @@ export const resumeData = {
         {
           title: "Team Lead",
           dates: "Oct 2016 - Oct 2017",
+          leadershipScope: "Led Housing's mobile engineering team",
           location: "Mumbai",
+          markers: ["hands-on", "leadership"],
           bullets: [
-            "Led Housing's React Native mobile architecture, building more than 90% of the app in JavaScript for shared iOS/Android delivery with Redux, redux-observable/RxJS, immutable state, offline persistence, and component-driven UI.",
-            "Built the mobile quality and release platform with Storybook, Jest/Detox, Sentry, Fastlane, Jenkins, and CodePush, automating signed builds, device registration, beta distribution, source-map uploads, release notes, stakeholder notifications, OTA rollouts, and Git tagging.",
+            "Led the architecture of Housing's React Native app, sharing more than 90% of its JavaScript code across iOS and Android.",
+            "Designed its state management, reactive data flows, offline persistence, and component-driven UI. Also built automated testing and release systems covering diagnostics, signed builds, beta distribution, and over-the-air updates.",
             "Contributed to Housing.com's Progressive Web App for users on slow and inconsistent network connections.",
           ],
         },
@@ -333,11 +356,12 @@ export const resumeData = {
       logo: bridgLogo,
       roles: [
         {
-          title: "Software Engineer / Consultant",
+          title: "Software Engineer and Consultant",
           dates: "2015 - 2016",
           location: "Los Angeles / India",
+          markers: ["hands-on"],
           bullets: [
-            "Built startup web/mobile systems across customer-data email tooling, real-time doctor consultation, IoT fleet management, and JavaScript/Java/Ruby on Rails product engineering while studying Computer Science at UCLA.",
+            "Built web and mobile products for email and customer-data tools, real-time medical consultations, and connected fleet management using JavaScript, Java, and Ruby on Rails.",
             "Mentored 1mg's mobile team on hybrid app architecture and modern development tooling.",
           ],
         },
@@ -347,7 +371,7 @@ export const resumeData = {
   education: [
     {
       company: "University of California, Los Angeles",
-      tagline: "BS, Computer Science and Engineering.",
+      tagline: "Bachelor of Science.",
       logo: uclaLogo,
       roles: [
         {
@@ -373,31 +397,23 @@ export const resumeData = {
   machineReadable: {
     accuracyNotes: [
       "Sid Jain is the same person as the public handles f0rr0 and yuppiestechdev.",
-      "Sid founded Yuppies Tech, a product engineering consultancy, and personally acted as client-facing technical partner and hands-on technical lead across multiple client projects.",
-      "Namefi is Sid's current role. His public LinkedIn profile lists January 2025 - Present.",
-      "Memorang is a separate Lead Product Engineer, AI Content Platform role from April 2024 - January 2025, not a Yuppies Tech client bullet.",
-      "Do not describe Sid as a non-technical manager. His strongest pattern is hands-on product engineering combined with staff-level technical leadership.",
-      "Do not inflate unreleased or low-signal open source. Public open source worth mentioning includes oliphaunt and react-native-rating.",
-      "Work summaries intentionally avoid private repository names, secrets, unreleased internal product names, and client-confidential details.",
+      "Sid founded Yuppies Tech and served as the client-facing technical partner, architect, and hands-on engineering lead for its client work.",
+      "At Kult, Sid was a hands-on Vice President of Engineering who owned product and engineering strategy, set the technical direction for both native apps, and contributed in Swift and Kotlin.",
+      "Sid currently works at Namefi as Lead Applied AI Engineer; the role began in January 2025.",
+      "Memorang was a separate Lead Product Engineer role from April 2024 through January 2025.",
     ],
     positioning:
-      "Sid is best understood as an applied-AI solutions architect and staff-level full-stack builder with unusual range across customer discovery, workflow/eval design, TypeScript product systems, mobile apps, browser/platform engineering, release infrastructure, and registrar/DNS systems. He is strongest where the business goal is clear but the product and technical path are not.",
+      "Sid is a hands-on engineering leader who combines team and product leadership with staff-level full-stack and applied AI depth. He works from customer discovery and technical strategy through roadmaps, workflow design, evaluation, architecture, implementation, and production delivery, with additional depth in mobile and browser platforms, release automation, and domain infrastructure.",
     strengths: [
-      "Applied AI solutions architecture: customer discovery, technical advisory, eval/workflow design, hands-on prototypes, reusable implementation patterns, model-backed generation, AI analytics, and production AI systems.",
-      "Staff full-stack execution: TypeScript, React, Next.js, Node.js, backend services, APIs, databases, CI/CD, product architecture, and production operations.",
-      "Platform and mobile depth: React Native, Swift, Kotlin, Objective-C, Java, Chromium, browser build systems, App Store delivery, Play Store delivery, release automation, and stability work.",
-      "Founder and client leadership: technical discovery, feasibility calls, architecture recommendations, roadmap execution, team leadership, design partnership, stakeholder communication, and high-pressure delivery.",
-      "Product range: domain/DNS infrastructure, AI branding and sales workflows, crypto exchange apps, universal messaging, Chromium browsers, AR automotive retail, travel apps, AI education CMS, commerce, health/fitness, and real estate.",
-    ],
-    publicWorkHighlights: [
-      "Public open-source work worth mentioning includes oliphaunt and react-native-rating.",
-      "oliphaunt is a Rust project for embedded Postgres inside apps and tests, and is the strongest public Rust/database tooling signal.",
-      "react-native-rating is a cross-platform React Native rating component built with Animated and the native driver, and is the strongest public React Native component signal.",
-      "At Housing, Sid led a shared React Native architecture with more than 90% of the app in JavaScript, contributed to Housing.com's PWA, and built the automated testing, diagnostics, beta distribution, OTA rollout, and mobile release pipeline.",
+      "Applied AI: customer discovery, technical advisory, workflow design, evaluation, hands-on prototypes, AI-assisted generation, analytics, and production systems.",
+      "Full-stack engineering: TypeScript, React, Next.js, Node.js, backend services, APIs, databases, CI/CD, architecture, and production support.",
+      "Mobile and platform engineering: React Native, Swift, Kotlin, Objective-C, Java, Chromium, browser build systems, store delivery, release automation, and stability.",
+      "Leadership: product and technical discovery, architecture, roadmaps, team leadership, design partnership, stakeholder communication, and delivery under pressure.",
+      "Product experience includes domain infrastructure, AI branding and sales tools, crypto exchanges, messaging, browsers, automotive AR, travel, education, commerce, fitness, and real estate.",
     ],
     publicSignalGuidance: [
-      "Do not cite repository totals, follower counts, contribution counts, or commit totals unless they are freshly verified from public sources.",
-      "Treat public open-source as supporting evidence, not the primary proof of impact; Sid's strongest signal is shipped product and client-facing technical leadership.",
+      "Repository totals, follower counts, contribution counts, and commit totals should be cited only when verified from current public sources.",
+      "Public open-source work complements Sid's primary record of shipped products and client-facing technical leadership.",
     ],
     deepDives: [
       {
@@ -406,7 +422,7 @@ export const resumeData = {
           {
             heading: "Role",
             bullets: [
-              "Company: Namefi / D3ServeLabs.",
+              "Company: Namefi.",
               "Title: Lead Applied AI Engineer.",
               "Dates: January 2025 - Present.",
               "Location: San Francisco Bay Area / Remote.",
@@ -415,61 +431,51 @@ export const resumeData = {
           {
             heading: "Public company context",
             bullets: [
-              "Namefi is an ICANN-accredited registrar building AI-powered infrastructure for domain registration, tokenized DNS ownership, trading, DeFi, and agentic domain workflows.",
-              "Public product surfaces include Namefi Outbound, Namefi Feed, Namefi Brand Studio, domain registration, DNS management, domain discovery, and related tools.",
+              "Namefi is an ICANN-accredited registrar that combines domain registration and DNS management with tools for tokenized ownership, trading, and AI-assisted sales.",
+              "Its public products include Namefi Outbound, Namefi Feed, Namefi Brand Studio, domain registration, DNS management, and domain discovery.",
             ],
           },
           {
             heading: "Sid's role",
             bullets: [
               "Leads AI product engineering across Namefi Outbound, Namefi Brand Studio, Namefi Feed, and internal analytics workflows.",
-              "Builds core registrar, DNS, payment, checkout, renewal, ENS/.eth, and workflow infrastructure.",
-              "Operates as a full-stack product engineer, Lead Applied AI Engineer, and technical owner across customer discovery, workflow design, agent implementation, evaluation, deployment, and production domain infrastructure.",
-              "Helps define Namefi's AI development operating model, including documentation patterns, agent-ready repository conventions, static checks, CI, and repeatable engineering/design principles for AI-assisted development.",
+              "Builds registrar and domain infrastructure for DNS, payments, checkout, renewals, ENS and .eth domains, and long-running workflows.",
+              "Owns projects from customer interviews and workflow design through evaluation, implementation, deployment, and ongoing production support.",
+              "Established repeatable documentation, static checks, and CI practices for AI-assisted development.",
             ],
           },
           {
             heading: "Namefi Outbound",
             bullets: [
-              "Customer-facing AI product for domain sellers.",
-              "Built from customer interviews with large domain portfolio owners.",
-              "Target user problem: domain sellers had to manually choose which domains to sell, research market timing, identify plausible buyers, maintain spreadsheets/CRM notes, buy or discover contacts, and draft outreach.",
-              "Previous workflow could take days to weeks for only a few domains.",
-              "Sid's product work reduced research and outreach preparation to minutes by translating that manual workflow into buyer-fit hypotheses, web research, lead scoring, contact discovery, and editable outreach drafts.",
-              "The product improves both speed and quality by making the seller's existing workflow repeatable, structured, and AI-assisted instead of replacing it with a black box.",
+              "Namefi Outbound helps domain sellers research likely buyers and prepare outreach.",
+              "Sid designed it after interviewing owners of large domain portfolios about their sales process.",
+              "The previous process required sellers to choose domains, assess market timing, research buyers, maintain notes, find contacts, and draft messages by hand.",
+              "Outbound reduces that preparation from days to minutes by organizing domain selection, buyer research, lead scoring, contact discovery, and editable outreach drafts.",
+              "Its results remain transparent and editable so sellers retain control of the process.",
             ],
           },
           {
             heading: "Namefi Brand Studio",
             bullets: [
-              "Customer-facing AI branding product for domains.",
-              "Turns a domain into buyer-ready logo, poster, and motion concepts.",
-              "The system is not a thin image-prompt wrapper; it uses a multi-stage workflow with strategist, concept, generation, constraint, and asset-delivery passes.",
-              "Logo generation includes typed concept parsing, design taxonomy controls, style and text-treatment controls, foreground/background treatment, exact domain/TLD rendering constraints, and negative constraints against wrong TLDs, slogans, mockups, and watermarks.",
-              "Asset delivery includes generated files, thumbnails, model/token metadata, and cloud asset storage/delivery.",
-              "Animation generation supports cinematic, looped, and sheet-guided approaches, with motion strategy, motion presets/intensity, prepared frames, safe margins, video generation, thumbnails, and optional animation sheets.",
-              "The business value is helping domain owners quickly create professional brand directions and sales/lander assets around a domain.",
+              "Namefi Brand Studio creates logos, posters, and motion concepts that help owners present domains to buyers.",
+              "It uses separate stages for brand strategy, concept development, image generation, validation, animation, and asset delivery.",
+              "The system preserves the exact domain name, including its top-level domain, and rejects common generation errors such as incorrect suffixes, slogans, mockups, and watermarks.",
+              "It supports still and animated assets, prepared frames, thumbnails, generation metadata, and cloud delivery.",
             ],
           },
           {
             heading: "Namefi Feed",
             bullets: [
-              "Customer-facing discovery product for domain buyers.",
-              "MLS-style discovery layer for public secondary-market domain sale listings.",
-              "Aggregates fragmented sale activity from sources such as X, NamePros, DNForum, marketplaces, and other public listing channels.",
-              "Normalizes diverse, noisy listing formats into searchable/RSS-friendly surfaces.",
-              "Extracts and structures domains, sellers, sources, prices, currencies, and listing metadata.",
-              "Public/user-supplied scale as of the resume reconstruction: roughly 4,000-5,000 indexed listings.",
-              "Business value: buyers can discover secondary-market domain opportunities in one place instead of manually tracking many forums, marketplaces, and social feeds; sellers receive more distribution and credibility.",
+              "Namefi Feed collects roughly 4,000 to 5,000 public domain listings from X, NamePros, DNForum, marketplaces, and other public sources.",
+              "It extracts and standardizes domains, sellers, sources, prices, currencies, and other listing details.",
+              "Buyers can search the listings or follow them through RSS instead of monitoring many forums, marketplaces, and social feeds.",
             ],
           },
           {
             heading: "Core registrar and domain infrastructure",
             bullets: [
-              "Built or contributed to registrar integrations, including third-party registrar connectivity.",
-              "Built domain registration, renewal, checkout, payments, DNS records, DNSSEC, nameserver management, ENS/.eth support, and operational flows required for registrar-grade products.",
-              "Led or substantially drove the move from Airflow-style DAGs to Temporal for stateful long-running processing, then reused Temporal for AI workflows and operational systems.",
-              "This infrastructure work shows Sid can ship AI products inside real regulated/operational systems, not only demos.",
+              "Built third-party registrar integrations and systems for domain registration, renewal, checkout, payments, DNS records, DNSSEC, nameserver management, and ENS and .eth support.",
+              "Led the migration from Airflow-style DAGs to Temporal for stateful, long-running processes, then applied Temporal to AI and operational workflows.",
             ],
           },
         ],
@@ -489,23 +495,20 @@ export const resumeData = {
           {
             heading: "Context and role",
             bullets: [
-              "EdWrite is Memorang's AI-native, graph-based headless CMS for education, combining structured curricula, custom agents, human-in-the-loop workflows, bulk content generation, and API delivery.",
-              "Sid built EdWrite as Lead Product Engineer for Memorang's AI content platform.",
-              "Worked directly with the CTO and CEO.",
-              "Managed two CMS team members while coordinating with services, frontend, and app teams.",
+              "EdWrite is a graph-based headless CMS for structured educational content and AI-assisted content production.",
+              "Sid led product engineering for EdWrite, managed three developers, worked directly with the CTO and CEO, and coordinated with backend, frontend, and mobile teams.",
             ],
           },
           {
             heading: "Major work and impact",
             bullets: [
-              "Built EdWrite, Memorang's graph-based headless CMS, and translated Cambridge/TOEFL-style education requirements into schema-first platform work.",
-              "Modeled TOEFL-like exam structures into dynamic schemas for sections, question types, component types, content groups, practice scoring, and adaptive workflows.",
-              "Designed human-in-the-loop agent workflows for subject-matter experts to generate, review, and manage full question sets and companion audio/image media at scale.",
+              "Translated Cambridge and TOEFL curricula and assessment requirements into versioned schemas exposed through content APIs.",
+              "Modeled exam sections, question types, content groups, scoring, and adaptive practice as configurable structures.",
+              "Designed human-in-the-loop workflows for subject-matter experts to generate, review, and manage complete question sets with supporting audio and images.",
               "Built schema versioning so content and question formats could evolve without breaking existing client apps or backend services.",
-              "Built or led adaptive practice flows that could track scores, weak spots, and personalized practice material.",
-              "Built an AI media recommendation system using media metadata embeddings and cross-product vector similarity search.",
-              "Helped modernize a large JS/Flow monorepo toward TypeScript, Bun, and Biome using AI-agentic refactor workflows, codemods, and ecosystem upgrades.",
-              "The work positioned Memorang's CMS as AI-native rather than a conventional content-entry tool.",
+              "Built adaptive practice flows that track scores, identify weak areas, and recommend personalized material.",
+              "Built recommendations for supporting media using metadata embeddings and vector similarity search across products.",
+              "Led the gradual migration of a large Flow-typed JavaScript monorepo to TypeScript, introducing Bun, Biome, codemods, and AI-assisted refactoring.",
             ],
           },
         ],
@@ -526,18 +529,18 @@ export const resumeData = {
             heading: "Company context",
             bullets: [
               "Yuppies Tech is a product engineering consultancy founded by Sid.",
-              "Sid personally worked on client projects as the technical owner or technical lead.",
-              "The consultancy model often paired Yuppies Tech with design or product partners; Sid owned the technical execution, implementation architecture, delivery, and technical feasibility.",
+              "Sid grew and led a 15-engineer team while remaining directly involved in architecture and implementation.",
+              "As the client-facing technical partner, he led technical discovery, architecture, feasibility, and delivery in collaboration with design and product teams.",
             ],
           },
           {
             heading: "General value",
             bullets: [
-              "Served as client-facing technical partner for enterprise and startup clients across travel, automotive, crypto, messaging, and browsers.",
-              "Translated ambiguous business, design, and customer needs into scoped architectures, delivery plans, product systems, and production releases.",
-              "Led delivery under high ambiguity, including emergency COVID timelines, App Store/Play Store constraints, browser and device compatibility constraints, and legacy code modernization.",
-              "Frequently worked directly with CTOs, heads of engineering, heads of product, founders, QA leads, design teams, marketing teams, and enterprise stakeholders.",
-              "Strong theme: making design a first-class citizen of technical implementation through design systems, design QA, and cross-functional review loops.",
+              "Led enterprise and startup engagements across travel, automotive, crypto, messaging, and browsers.",
+              "Turned unclear business and product requirements into practical architectures, delivery plans, and production releases.",
+              "Led delivery on compressed COVID-era timelines while navigating App Store and Play Store requirements, browser and device compatibility issues, and legacy-code modernization.",
+              "Worked directly with founders, executives, product and engineering leaders, designers, marketers, and QA teams.",
+              "Used design systems and design reviews to keep implementation aligned with product design.",
             ],
           },
         ],
@@ -548,23 +551,21 @@ export const resumeData = {
           {
             heading: "Context and role",
             bullets: [
-              "Veera Browser is an Indian/global Chromium-based browser focused on speed, privacy, ad blocking, and rewards for browsing.",
-              "Sid led Android browser delivery from zero to Play Store.",
-              "Later helped with the iOS browser platform/release setup.",
-              "Worked directly with CTO/head of engineering, design, product, marketing, founders, and QA.",
-              "Yuppies team was Sid plus one additional engineer for Android app-level feature work.",
+              "Veera is a Chromium-based browser focused on speed, privacy, ad blocking, and browsing rewards.",
+              "Sid led the Android browser from initial development through its Play Store launch.",
+              "He later established the iOS platform and release setup.",
+              "He worked directly with engineering leadership, founders, product, design, marketing, and QA.",
             ],
           },
           {
             heading: "Major work and impact",
             bullets: [
-              "Built and maintained a Chromium-based Android browser with a patch stack over vanilla Chromium plus relevant Brave-derived security/privacy patches.",
-              "Owned Chromium/Brave patch management across C++, Java, build files, assets, app screens, onboarding, feed, rewards, search, tab systems, login/signup, and privacy/security changes.",
-              "Set up build and release processes, Play Store delivery, stability monitoring, QA coordination, and update cadence.",
-              "Built app-level product features including onboarding, login/signup, rewards, recurring and milestone rewards, usage-based rewards, search, tabs, and a syndicated news/feed experience.",
-              "Reduced build iteration from 4-6 hour full builds to near-instant app-layer UI iteration.",
-              "Reduced clean release builds to roughly 2 hours through ccache/sccache, aggressive caching, debug/release lanes, and architecture-specific build variants.",
-              "Created a maintainable patch/update/release process for a Chromium product rather than a one-off fork.",
+              "Built and maintained the Android browser as a managed patch stack over upstream Chromium, incorporating selected privacy and security changes from Brave.",
+              "Owned changes across the C++ and Java codebases, build configuration, and product assets.",
+              "Established build and release processes, Play Store delivery, stability monitoring, QA coordination, and a regular update cadence.",
+              "Built product features for onboarding, authentication, rewards, search, tab management, and a syndicated news feed.",
+              "Enabled near-instant app-layer UI iteration that otherwise required four-to-six-hour full builds.",
+              "Reduced clean release builds to roughly two hours with compiler caching, reusable build artifacts, separate build lanes, and architecture-specific variants.",
             ],
           },
         ],
@@ -577,20 +578,18 @@ export const resumeData = {
             bullets: [
               "Texts was an all-in-one messaging client later acquired by Automattic in 2023.",
               "Sid built the production Facebook Messenger channel integration.",
-              "Worked in a TypeScript/Electron product environment.",
-              "Worked directly with the founding/product team.",
+              "He worked in its TypeScript and Electron codebase and collaborated directly with the founding product team.",
             ],
           },
           {
             heading: "Major work and impact",
             bullets: [
-              "Built a Messenger-compatible channel over undocumented/private messaging infrastructure.",
-              "Implemented protocol-compatible MQTT/Facebook Thrift handling.",
-              "Built typed Thrift encode/decode tooling for JavaScript/TypeScript.",
-              "Implemented encrypted payload support and message sync/send/receive behavior.",
-              "Built feature-parity messaging behavior across threads, group messages, rich attachments, photos, videos, files, reactions, read receipts, typing indicators, and presence.",
-              "Reverse-engineering research used tools such as Ghidra, Burp Suite, Frida, certificate-unpinning techniques, runtime method inspection, and Facebook's white-hat program.",
-              "Messenger was a must-have messaging channel for an all-in-one inbox product and became a production channel in Texts.",
+              "Reverse-engineered undocumented service interfaces to build a Messenger-compatible channel.",
+              "Implemented MQTT transport, Facebook Thrift serialization, and typed encoding and decoding tools for TypeScript.",
+              "Implemented encrypted payload handling, message synchronization, sending, and receiving.",
+              "Implemented threads, groups, attachments, photos, videos, files, reactions, read receipts, typing indicators, and presence.",
+              "Used Ghidra, Burp Suite, Frida, certificate unpinning, runtime inspection, and Facebook's white-hat program during protocol research.",
+              "The integration shipped as a production channel in Texts.",
             ],
           },
         ],
@@ -603,20 +602,19 @@ export const resumeData = {
             bullets: [
               "ZebPay was one of India's largest crypto exchanges at the time of the engagement.",
               "Sid was the client-facing technical lead for iOS and Android modernization.",
-              "Led a roughly 10-person embedded Yuppies team, split across iOS and Android.",
-              "Worked with ZebPay's Head of Product, Head of QA, and Head of Engineering.",
+              "He worked with ZebPay's Head of Product, Head of QA, and Head of Engineering.",
             ],
           },
           {
             heading: "Major work and impact",
             bullets: [
               "Modernized legacy iOS and Android codebases to restore release velocity and reduce instability.",
-              "Cleared App Store and Play Store submission blockers tied to old target versions and platform requirements.",
-              "Built CI/CD and release pipelines so the client could ship with more confidence.",
-              "Shipped exchange features, payments, wallet SDK integrations, coin/token launch support, and product flows.",
-              "Built OTC/high-net-worth trader workflows, including internationalized KYC flows.",
-              "KYC work included country-specific document handling, document/audio/video ingestion, facial/video recognition, third-party KYC integrations such as IDfy, and secure document access workflows.",
-              "Improved release cadence from monthly or bi-monthly to weekly during stabilization, later settling around twice monthly depending on feature scope.",
+              "Removed App Store and Play Store submission blockers caused by outdated target versions and platform requirements.",
+              "Built CI/CD and release pipelines that made releases more reliable.",
+              "Shipped exchange and payment features, wallet SDK integrations, and support for new coin and token launches.",
+              "Built over-the-counter workflows for high-net-worth traders and localized KYC processes.",
+              "Implemented country-specific document handling, media capture, identity verification, integrations such as IDfy, and secure document access.",
+              "During stabilization, increased the release cadence from every two weeks to weekly.",
             ],
           },
         ],
@@ -627,25 +625,22 @@ export const resumeData = {
           {
             heading: "Context and role",
             bullets: [
-              "Client was Mitsubishi Motors Puerto Rico / MMSC.",
-              "Product/campaign was the MiAR virtual dealership and Outlander AR campaign.",
-              "Sid was client-facing technical lead.",
-              "Owned technical discovery, feasibility, AR architecture, implementation planning, deployment, and release execution.",
-              "Managed a 3-person technical team: Sid plus one backend engineer and one frontend engineer.",
-              "Coordinated with Puerto Rico stakeholders and Mitsubishi's Japanese-side stakeholders.",
+              "Mitsubishi Motors Puerto Rico commissioned MiAR, a virtual dealership and Outlander augmented-reality campaign.",
+              "Sid was the client-facing technical lead and owned discovery, feasibility, architecture, implementation planning, and release delivery.",
+              "He coordinated with stakeholders in Puerto Rico and Japan.",
             ],
           },
           {
             heading: "Major work and impact",
             bullets: [
-              "During COVID, dealership footfall fell sharply and Mitsubishi wanted customers to experience vehicles remotely from home.",
-              "Built native iOS/iPadOS AR experience and companion React/WebAR experience.",
-              "Implemented optimized 3D vehicle delivery suitable for web and mobile AR.",
-              "Supported AR interactions such as placing vehicles in a room, viewing interiors, opening doors/trunk/boot, inspecting dashboard and feature areas, and capturing AR experiences.",
-              "Built contest/admin workflows around the Outlander AR photo campaign.",
+              "During COVID, Mitsubishi wanted customers to explore vehicles remotely as dealership visits declined.",
+              "Built native iOS and iPadOS augmented-reality apps and a companion React-based WebAR experience.",
+              "Optimized 3D vehicle models for delivery on mobile devices and the web.",
+              "Implemented vehicle placement, interior views, interactive doors and trunks, feature inspection, and photo capture.",
+              "Built contest-administration tooling for the Outlander AR photo campaign.",
               "Supported bilingual content in English and Brazilian Portuguese.",
-              "Worked directly with a WebAR SDK vendor to resolve browser and device compatibility.",
-              "Optimized for lower-end Android devices and mobile browsers common in Puerto Rico.",
+              "Worked directly with a WebAR SDK vendor to resolve browser and device compatibility issues.",
+              "Optimized the web experience for lower-end Android devices and mobile-browser constraints in the Puerto Rico market.",
             ],
           },
         ],
@@ -656,22 +651,51 @@ export const resumeData = {
           {
             heading: "Context and role",
             bullets: [
-              "Client was Airbus.",
-              "Partner was Milkinside, which owned design direction and client communication.",
-              "Product was Airbus Tripset travel companion app.",
-              "Sid was the solo technical partner on the Yuppies side.",
-              "Owned technical implementation end to end: mobile app, backend aggregation layer, frontend/client work, integrations, and release.",
+              "Airbus Tripset was a public travel companion designed to help passengers navigate COVID-era travel restrictions and find airport guidance.",
+              "Sid owned end-to-end technical delivery for Yuppies Tech and worked with Milkinside, the project's design and client-communication lead.",
+              "He delivered the mobile app, backend services, integrations, and releases.",
             ],
           },
           {
             heading: "Major work and impact",
             bullets: [
-              "Airbus Tripset was a public iOS/Android companion app intended to help air travelers navigate COVID travel restrictions, airport guidance, flight information, and journey requirements.",
-              "Built a React Native iOS/Android app.",
-              "Built backend aggregation over Airbus APIs, Amadeus APIs, CMS-driven COVID/travel guidance, and other travel-data sources.",
-              "Supported itinerary-related information, booking/ticket input, flight and airport data, timing/delay information, travel restrictions, airport guidelines, and notifications.",
-              "Designed the backend layer so the client app did not directly depend on many third-party APIs.",
-              "Delivered a global public travel product during COVID under emergency timeline pressure.",
+              "Built the React Native app for iOS and Android.",
+              "Built backend services that combined Airbus and Amadeus APIs, CMS-managed travel guidance, and other travel data.",
+              "Included itinerary entry, flight and airport data, delay alerts, travel restrictions, airport guidance, and notifications.",
+              "Designed the backend so the app did not depend directly on multiple third-party services.",
+              "Delivered the public travel product globally on a compressed COVID-era timeline.",
+            ],
+          },
+        ],
+      },
+      {
+        title: "Kult",
+        sections: [
+          {
+            heading: "Role",
+            bullets: [
+              "Company: Kult.",
+              "Title: Vice President of Engineering.",
+              "Dates: January 2020 - January 2021.",
+              "Location: Mumbai.",
+            ],
+          },
+          {
+            heading: "VP Engineering scope",
+            bullets: [
+              "Kult is a consumer beauty and skincare commerce product.",
+              "As Vice President of Engineering, Sid owned the zero-to-one product and engineering strategy for its AWS-hosted Elixir backend and native iOS and Android apps.",
+              "He led a 10-engineer team across backend and mobile development.",
+              "He translated the product vision into a technical roadmap, system architecture, and platform investments, then coordinated delivery.",
+              "He set the technical direction for both mobile apps while contributing directly in Swift and Kotlin.",
+            ],
+          },
+          {
+            heading: "Architecture and hands-on delivery",
+            bullets: [
+              "Architected both native apps, defining their project structure, shared product patterns, and platform conventions.",
+              "Established CI/CD, release systems, environment configuration, analytics, deep linking, Bugsnag observability, and third-party SDK integrations for iOS and Android.",
+              "Implemented app features across catalog discovery and filtering, product details, accounts, theming, Kult Kafe, and stories.",
             ],
           },
         ],
@@ -679,38 +703,30 @@ export const resumeData = {
     ] satisfies DeepDive[],
     roleFit: {
       strongFit: [
-        "Applied AI Architect and Solutions Architect roles at model labs where customer discovery, technical advisory, eval design, hands-on prototypes, and deployment architecture matter together.",
-        "Technical Success or Solutions Engineering roles where the company needs a builder who can translate business requirements into working GenAI systems and reusable implementation patterns.",
-        "AI product engineer roles where the company needs production AI workflows, not only prompts.",
-        "Applied AI lead roles where engineering, product judgment, tooling, and operating model matter together.",
-        "Staff full-stack engineer roles requiring depth across frontend, backend, infrastructure, CI/CD, and product architecture.",
-        "Founding engineer roles requiring zero-to-one execution, design/product partnership, customer discovery, and hands-on implementation.",
-        "Technical lead roles for small teams in high-ambiguity environments.",
-        "Teams building AI products inside existing regulated, operational, or infrastructure-heavy systems.",
+        "Hands-on VP of Engineering or Head of Engineering roles that combine team leadership, technical strategy, and direct architectural involvement.",
+        "Applied AI leadership and solutions architecture roles that combine customer discovery, evaluation, prototyping, and production deployment.",
+        "AI product engineering roles focused on reliable production workflows.",
+        "Staff-level full-stack roles spanning frontend, backend, infrastructure, CI/CD, and product architecture.",
+        "Founding engineering roles that require product partnership, customer discovery, architecture, and hands-on implementation.",
+        "Teams integrating AI into regulated, operational, or infrastructure-heavy products.",
       ],
-      inaccurateAs: [
-        "A pure frontend-only engineer.",
-        "A pure ML researcher.",
-        "A non-technical manager.",
-        "A narrow mobile-only engineer, even though he has deep mobile experience.",
-        "A conventional agency operator who only delegates implementation.",
-      ],
+      inaccurateAs: [],
     },
     publicReferences: [
       {
         href: "https://namefi.io/",
         label: "Namefi",
-        note: "Current company and public product surface.",
+        note: "Current company and public product.",
       },
       {
         href: "https://namefi.io/feed",
         label: "Namefi Feed",
-        note: "Public Feed surface.",
+        note: "Public domain-listing discovery product.",
       },
       {
         href: "https://memorang.com/products/edwrite",
         label: "Memorang EdWrite",
-        note: "AI-native, graph-based headless CMS for education.",
+        note: "Graph-based headless CMS for educational content.",
       },
       {
         href: "https://www.airbus.com/en/newsroom/stories/2021-03-tripset-the-companion-app-that-helps-air-travellers-navigate-during-covid",
@@ -730,7 +746,7 @@ export const resumeData = {
       {
         href: "https://texts.com/",
         label: "Texts",
-        note: "Public Texts/Beeper transition page.",
+        note: "Public page describing the transition from Texts to Beeper.",
       },
       {
         href: "https://techcrunch.com/2023/10/24/wordpress-com-owner-buys-all-in-one-messaging-app-texts-com-for-50m/",
@@ -750,7 +766,7 @@ export const resumeData = {
       {
         href: "https://gildehealthcare.com/news/all/gilde-healthcare-portfolio-withings-acquires-leading-health-and-fitness-app-8fit/",
         label: "Withings acquisition of 8fit",
-        note: "Public 8fit/Withings acquisition context.",
+        note: "Public announcement of Withings acquiring 8fit.",
       },
       {
         href: "https://github.com/f0rr0",
@@ -763,12 +779,12 @@ export const resumeData = {
     {
       href: "https://github.com/f0rr0/oliphaunt",
       label: "oliphaunt",
-      note: "Rust project for embedded Postgres inside apps and tests; a strong public Rust/database tooling signal.",
+      note: "Rust library for running embedded PostgreSQL inside applications and tests.",
     },
     {
       href: "https://github.com/f0rr0/react-native-rating",
       label: "react-native-rating",
-      note: "Cross-platform React Native rating component built with Animated and the native driver; a strong public React Native component signal.",
+      note: "Cross-platform React Native rating component built with Animated and the native driver.",
     },
     {
       href: "https://medium.com/engineering-housing/how-we-built-our-react-native-app-3380a33811ac",

--- a/src/lib/resume.ts
+++ b/src/lib/resume.ts
@@ -1,4 +1,4 @@
-import { resumeData } from "@/content/resume";
+import { resumeData, resumeRoleMarkerLabels } from "@/content/resume";
 import type { PublicReference, ResumeRole } from "@/content/resume";
 import type { BlogPost } from "@/lib/blog-utils";
 import { publicUrl } from "@/lib/site";
@@ -18,13 +18,32 @@ const markdownLink = ({
 }: PublicReference | { href: string; label: string; note: string }) =>
   `- [${label}](${href}): ${note}`;
 
-const normalizeDate = (value: string) =>
-  value
-    .replace("Apr ", "April ")
-    .replace("Jan ", "January ")
-    .replace("Nov ", "November ")
-    .replace("Oct ", "October ")
-    .replace("Dec ", "December ");
+const monthNumbers = {
+  Apr: "04",
+  Aug: "08",
+  Dec: "12",
+  Feb: "02",
+  Jan: "01",
+  Jul: "07",
+  Jun: "06",
+  Mar: "03",
+  May: "05",
+  Nov: "11",
+  Oct: "10",
+  Sep: "09",
+} as const;
+
+const normalizeDate = (value: string) => {
+  const [monthOrYear, year] = value.trim().split(/\s+/);
+
+  if (monthOrYear === undefined || year === undefined) {
+    return value.trim();
+  }
+
+  const month = monthNumbers[monthOrYear as keyof typeof monthNumbers];
+
+  return month === undefined ? value.trim() : `${year}-${month}`;
+};
 
 const bulletText = (bullet: NonNullable<ResumeRole["bullets"]>[number]) =>
   typeof bullet === "string"
@@ -34,7 +53,60 @@ const bulletText = (bullet: NonNullable<ResumeRole["bullets"]>[number]) =>
 const roleBullets = (role: ResumeRole) =>
   role.bullets?.map((bullet) => bulletText(bullet)) ?? [];
 
+const roleMarkers = (role: ResumeRole) =>
+  role.markers?.map((marker) => resumeRoleMarkerLabels[marker]) ?? [];
+
+const roleLeadershipScope = (role: ResumeRole) => role.leadershipScope;
+
 const localProfileUrl = (path: string) => publicUrl(path);
+
+const [currentExperience] = resumeData.experience;
+const [currentRole] = currentExperience?.roles ?? [];
+
+const isGitHubProject = (reference: PublicReference) =>
+  reference.href.startsWith("https://github.com/");
+
+const openSourceProjects = resumeData.openSource.filter(isGitHubProject);
+const publications = resumeData.openSource.filter(
+  (reference) => !isGitHubProject(reference)
+);
+
+const formatNaturalList = (items: string[]) => {
+  if (items.length < 2) {
+    return items[0] ?? "";
+  }
+
+  if (items.length === 2) {
+    return `${items[0]} and ${items[1]}`;
+  }
+
+  return `${items.slice(0, -1).join(", ")}, and ${items.at(-1)}`;
+};
+
+const isClaimGuidance = (note: string) =>
+  /^(avoid|do not|only|treat|use|when|work summaries)\b/i.test(note);
+
+const educationStudyType = (tagline: string) => {
+  const degree = tagline.replace(/\.$/, "").split(",")[0]?.trim();
+
+  return degree === "BS" ? "Bachelor of Science" : degree;
+};
+
+const educationSummary = resumeData.education
+  .flatMap((item) =>
+    item.roles.map((role) => {
+      const studyType = educationStudyType(item.tagline);
+
+      return studyType === "High School"
+        ? `${role.title} at ${item.company} (${role.dates})`
+        : `${studyType} in ${role.title} from ${item.company} (${role.dates})`;
+    })
+  )
+  .join("; ");
+
+const foundedOrganizations = resumeData.experience
+  .filter((item) => item.roles.some((role) => /\bFounder\b/.test(role.title)))
+  .map((item) => item.company);
 
 const buildAskAboutMePrompt = () => {
   const contextUrl = publicUrl("/llms.txt");
@@ -42,7 +114,7 @@ const buildAskAboutMePrompt = () => {
   return [
     `Read ${contextUrl} for full context about ${resumeData.person.name}.`,
     "This is an informational research chat, not a code-editing task.",
-    `I want to ask questions about ${resumeData.person.name}'s work, technical depth, projects, and fit for Applied AI Solutions Architect, Applied AI Lead, staff full-stack engineer, or founding engineer roles.`,
+    `I want to ask questions about ${resumeData.person.name}'s work, technical depth, projects, and fit for roles such as ${resumeData.person.targetPositioning}.`,
     "Use the public source links in that file when verification is needed, and call out uncertainty when a claim is not supported.",
   ].join(" ");
 };
@@ -75,7 +147,7 @@ export const buildJsonResume = () => ({
   basics: {
     email: resumeData.person.email,
     image: publicUrl(resumeData.person.image),
-    label: resumeData.person.role,
+    label: currentRole?.title ?? resumeData.person.role,
     location: {
       city: "Mumbai",
       countryCode: "IN",
@@ -112,14 +184,19 @@ export const buildJsonResume = () => ({
         institution: item.company,
         location: role.location,
         startDate: normalizeDate(startDate),
-        studyType: item.tagline.replace(/\.$/, ""),
+        studyType: educationStudyType(item.tagline),
       };
     })
   ),
-  projects: resumeData.openSource.map((project) => ({
+  projects: openSourceProjects.map((project) => ({
     description: project.note,
     name: project.label,
     url: project.href,
+  })),
+  publications: publications.map((publication) => ({
+    name: publication.label,
+    summary: publication.note,
+    url: publication.href,
   })),
   skills: [
     {
@@ -127,8 +204,8 @@ export const buildJsonResume = () => ({
         "Applied AI solutions architecture",
         "AI product engineering",
         "technical advisory",
-        "AI evals",
-        "agentic workflows",
+        "AI evaluation",
+        "AI-assisted workflows",
         "TypeScript",
         "React",
         "Next.js",
@@ -150,17 +227,23 @@ export const buildJsonResume = () => ({
   },
   work: resumeData.experience.flatMap((item) =>
     item.roles.map((role) => {
-      const roleSummary = "summary" in role ? role.summary : undefined;
       const [startDate, endDate] = role.dates.split(" - ");
+      const roleSummary = "summary" in role ? role.summary : undefined;
 
       return {
         ...(endDate === undefined || endDate === "Present"
           ? {}
           : { endDate: normalizeDate(endDate) }),
         highlights: roleBullets(role),
+        ...(roleLeadershipScope(role) === undefined
+          ? {}
+          : { leadershipScope: roleLeadershipScope(role) }),
         location: role.location,
         name: item.company,
         position: role.title,
+        ...(role.markers === undefined
+          ? {}
+          : { roleMarkers: roleMarkers(role) }),
         startDate: normalizeDate(startDate),
         summary: roleSummary ?? item.tagline,
       };
@@ -169,15 +252,12 @@ export const buildJsonResume = () => ({
 });
 
 export const buildLlmsTxt = (blogPosts: BlogPost[] = []) => {
-  const currentRole =
-    resumeData.experience[0]?.roles[0]?.title ?? resumeData.person.role;
   const {
     accuracyNotes,
     deepDives,
     positioning,
     publicReferences,
     publicSignalGuidance,
-    publicWorkHighlights,
     roleFit,
     strengths,
   } = resumeData.machineReadable;
@@ -231,6 +311,23 @@ export const buildLlmsTxt = (blogPosts: BlogPost[] = []) => {
   ];
 
   const canonicalText = canonicalLinks.map(markdownLink).join("\n");
+  const factualContext = accuracyNotes.filter((note) => !isClaimGuidance(note));
+  const claimGuidance = [
+    ...accuracyNotes.filter(isClaimGuidance),
+    ...publicSignalGuidance,
+  ];
+  const roleMarkerAssignments = resumeData.experience
+    .flatMap((item) =>
+      item.roles.flatMap((role) => {
+        const markerList = formatNaturalList(roleMarkers(role));
+        if (markerList.length === 0) {
+          return [];
+        }
+
+        return [`- ${role.title} at ${item.company} — ${markerList}.`];
+      })
+    )
+    .join("\n");
   const deepDiveText = deepDives
     .map((deepDive) =>
       [
@@ -243,34 +340,61 @@ export const buildLlmsTxt = (blogPosts: BlogPost[] = []) => {
       ].join("\n")
     )
     .join("\n\n");
+  const compactHistory = resumeData.experience.filter((item) => {
+    const companyKey = item.company
+      .split(/[,/]/)[0]
+      ?.trim()
+      .toLocaleLowerCase();
+
+    return !deepDives.some((deepDive) =>
+      deepDive.title.toLocaleLowerCase().includes(companyKey ?? "")
+    );
+  });
   const writingText =
     blogPosts.length === 0
       ? "- No published blog posts were found in the current build."
       : blogPosts
-          .map((post) =>
-            [
-              `### ${post.metadata.title}`,
-              `- URL: ${localProfileUrl(`/blog/${post.slug}`)}.`,
-              `- Published: ${post.date.toISOString().slice(0, 10)}.`,
-              `- Updated: ${(post.updatedAt ?? post.date).toISOString().slice(0, 10)}.`,
-              `- Author: ${post.metadata.author}.`,
-              `- Summary: ${post.metadata.summary}`,
-              `- Tags: ${(post.metadata.tags ?? []).join(", ") || "None"}.`,
-              `- Reading time: ${post.readingTime}; word count: ${post.wordCount}.`,
-            ].join("\n")
+          .map(
+            (post) =>
+              `- [${post.metadata.title}](${localProfileUrl(`/blog/${post.slug}`)}) — ${post.date.toISOString().slice(0, 10)}. ${post.metadata.summary}`
           )
-          .join("\n\n");
+          .join("\n");
+  const claimGuidanceSection =
+    claimGuidance.length === 0
+      ? ""
+      : `## Claim and Citation Guidance
+
+${claimGuidance.map((guidance) => `- ${guidance}`).join("\n")}
+
+`;
+  const openSourceSection =
+    openSourceProjects.length === 0
+      ? ""
+      : `## Open Source
+
+${openSourceProjects.map(markdownLink).join("\n")}
+
+`;
+  const publicationsSection =
+    publications.length === 0
+      ? ""
+      : `## Publications
+
+${publications.map(markdownLink).join("\n")}
+
+`;
 
   return `# ${resumeData.person.name}
 
-> ${resumeData.person.name} is an Applied AI Lead, senior full-stack engineer, founder of Yuppies Tech, and solutions-architect-style builder who turns customer workflows into production AI systems.
+> ${resumeData.summary}
 
 Last updated: ${resumeData.lastUpdated}
 
-This file is the canonical machine-readable profile for Sid Jain on this website. It is written for recruiters, search systems, AI agents, and other software that need accurate public context about Sid's work, strengths, and career history.
+This is the canonical machine-readable profile for ${resumeData.person.name} on this website. It provides public career context for recruiters, search systems, and AI tools.
 
-Important accuracy notes:
-${accuracyNotes.map((note) => `- ${note}`).join("\n")}
+## Verified Context
+
+${factualContext.map((note) => `- ${note}`).join("\n")}
 
 ## Canonical Links
 
@@ -279,14 +403,12 @@ ${canonicalText}
 ## Identity
 
 - Name: ${resumeData.person.name}.
-- Public handle: f0rr0.
-- Alternate GitHub identity: yuppiestechdev.
+- Public aliases: ${formatNaturalList([...resumeData.person.alternateNames])}.
 - Location: ${resumeData.person.location}.
-- Current target positioning: ${resumeData.person.targetPositioning}.
-- Current title: ${currentRole} at Namefi.
-- Current company: Namefi / D3ServeLabs.
-- Consultancy founded: Yuppies Tech.
-- Education: BS, Computer Science and Engineering, University of California, Los Angeles, 2013-2016; Delhi Public School, R. K. Puram, Computer Science/Physics/Chemistry/Math, 2011-2013.
+- Professional focus: ${resumeData.person.role}.
+- Current role: ${currentRole?.title ?? resumeData.person.role} at ${currentExperience?.company ?? "the current company"}.
+- Roles of interest: ${resumeData.person.targetPositioning}.
+${foundedOrganizations.length === 0 ? "" : `- Founded: ${formatNaturalList(foundedOrganizations)}.\n`}- Education: ${educationSummary}.
 
 ## High-Level Positioning
 
@@ -295,21 +417,19 @@ ${positioning}
 Representative strengths:
 ${strengths.map((strength) => `- ${strength}`).join("\n")}
 
-## Public Work Highlights
+Role indicators used on the human-readable resume:
+- Hands-on: material, direct contribution to architecture or implementation.
+- Leadership: responsibility for other engineers, team direction, and delivery outcomes.
 
-These are stable public-work highlights. Avoid using stale repository, follower, contribution, or commit-count claims unless freshly verified from public sources:
+Role indicators by position:
+${roleMarkerAssignments}
 
-${publicWorkHighlights.map((highlight) => `- ${highlight}`).join("\n")}
-
-Guidance:
-${publicSignalGuidance.map((guidance) => `- ${guidance}`).join("\n")}
-
+${claimGuidanceSection}
 ${deepDiveText}
 
 ## Earlier Experience
 
-${resumeData.experience
-  .slice(2)
+${compactHistory
   .map((item) =>
     [
       `${item.company}:`,
@@ -323,21 +443,14 @@ ${resumeData.experience
   )
   .join("\n\n")}
 
-## Open Source and Public Work
-
-${resumeData.openSource.map(markdownLink).join("\n")}
-
-## Writing
+${openSourceSection}${publicationsSection}## Writing
 
 ${writingText}
 
-## Recruiter-Relevant Role Fit
+## Role Alignment
 
-Sid is a strong fit for:
+Best-aligned roles:
 ${roleFit.strongFit.map((item) => `- ${item}`).join("\n")}
-
-Sid is less accurately represented as:
-${roleFit.inaccurateAs.map((item) => `- ${item}`).join("\n")}
 
 ## Public References
 

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -2,6 +2,22 @@ import { resumeData } from "@/content/resume";
 import { env } from "@/env";
 
 const CANONICAL_SITE_URL = "https://f0rr0.dev";
+const [currentExperience] = resumeData.experience;
+const [currentRole] = currentExperience?.roles ?? [];
+const foundedExperience = resumeData.experience.find((experience) =>
+  experience.roles.some((role) => /\bFounder\b/.test(role.title))
+);
+const currentRoleTitle = currentRole?.title ?? resumeData.person.role;
+const currentCompany = currentExperience?.company;
+const founderClause =
+  foundedExperience === undefined
+    ? ""
+    : ` who founded ${foundedExperience.company}`;
+const currentRoleClause =
+  currentCompany === undefined
+    ? ""
+    : ` and now serves as ${currentRoleTitle} at ${currentCompany}`;
+const profileDescription = `${resumeData.person.name} is an ${resumeData.person.role}${founderClause}${currentRoleClause}.`;
 
 const withProtocol = (value: string) => {
   const normalized = value.trim().replace(/\/+$/, "");
@@ -52,13 +68,13 @@ const resolveSiteUrl = () => {
 
 export const siteConfig = {
   author: {
-    bio: `${resumeData.person.role} building AI-native products and hard production systems from zero to launch.`,
+    bio: `${resumeData.person.role} building AI products and complex production systems from customer discovery through launch.`,
     handle: "f0rr0",
     image: "/resume/sid-jain-profile.png",
-    name: "Sid Jain",
+    name: resumeData.person.name,
     role: resumeData.person.role,
   },
-  description: `${resumeData.person.name} is a ${resumeData.person.role} building AI-native products, mobile/browser platforms, and production infrastructure.`,
+  description: profileDescription,
   language: "en-US",
   locale: "en_US",
   name: "Sid Jain",

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -12,7 +12,7 @@ import type {
 
 import { resumeData } from "@/content/resume";
 import type { BlogPost } from "@/lib/blog-utils";
-import { publicUrl } from "@/lib/site";
+import { publicUrl, siteConfig } from "@/lib/site";
 
 const linkedInUrl = "https://linkedin.com/in/f0rr0";
 const githubUrl = "https://github.com/f0rr0";
@@ -22,6 +22,12 @@ const personId = () => publicUrl("/#sid-jain");
 const websiteId = () => publicUrl("/#website");
 
 const sameAs = [linkedInUrl, githubUrl, yuppiesGithubUrl];
+const [currentExperience] = resumeData.experience;
+const [currentRole] = currentExperience?.roles ?? [];
+const currentCompanyReference =
+  resumeData.machineReadable.publicReferences.find(
+    (reference) => reference.label === currentExperience?.company
+  );
 
 const buildPersonNode = (): Person => ({
   "@id": personId(),
@@ -39,17 +45,16 @@ const buildPersonNode = (): Person => ({
       sameAs: "https://dpsrkp.net/",
     },
   ],
-  description:
-    "Applied AI Lead and senior full-stack engineer building production AI systems from customer workflows.",
+  description: siteConfig.description,
   email: `mailto:${resumeData.person.email}`,
   image: publicUrl(resumeData.person.image),
-  jobTitle: resumeData.person.role,
+  jobTitle: currentRole?.title ?? resumeData.person.role,
   knowsAbout: [
     "Applied AI solutions architecture",
     "AI product engineering",
     "technical advisory",
     "AI evaluation",
-    "agentic workflows",
+    "AI-assisted workflows",
     "TypeScript",
     "React",
     "Next.js",
@@ -68,9 +73,13 @@ const buildPersonNode = (): Person => ({
   url: publicUrl("/resume"),
   worksFor: {
     "@type": "Organization",
-    name: "Namefi",
-    sameAs: "https://namefi.io/",
-    url: "https://namefi.io/",
+    name: currentExperience?.company ?? "Current employer",
+    ...(currentCompanyReference === undefined
+      ? {}
+      : {
+          sameAs: currentCompanyReference.href,
+          url: currentCompanyReference.href,
+        }),
   },
 });
 
@@ -83,7 +92,7 @@ const buildWebsiteNode = (): WebSite => ({
     "@type": "Person",
     name: resumeData.person.name,
   },
-  description: resumeData.summary,
+  description: siteConfig.description,
   inLanguage: "en-US",
   name: resumeData.person.name,
   publisher: {
@@ -104,7 +113,7 @@ export const buildProfilePageJsonLd = (): WithContext<ProfilePage> => ({
   "@id": publicUrl("/resume#profile"),
   "@type": "ProfilePage",
   dateModified: resumeData.lastUpdated,
-  description: resumeData.summary,
+  description: siteConfig.description,
   isPartOf: {
     "@id": websiteId(),
     "@type": "WebSite",


### PR DESCRIPTION
## Summary

- position the résumé for hands-on VP Engineering and Applied AI leadership roles
- add consistent Hands-on and Leadership role indicators across the website and PDF
- expand Kult architecture and leadership detail while clarifying team scope across Memorang and Yuppies Tech
- rewrite awkward résumé and llms.txt copy and align JSON Resume, metadata, and structured data
- regenerate the two-page PDF and correct extraction, canonical URL, and stale blog-copy issues

## Why

The human résumé, PDF, machine-readable profile, and site metadata had drifted in role wording and contained several ambiguous or unnatural descriptions. This change restores one canonical account across every surface while preserving hands-on technical depth and organization-level leadership.

## Validation

- bun run format:check
- bun run format:typ:check
- bun run typecheck
- bun run lint
- bun run build
- official JSON Resume schema validation
- desktop light/dark and mobile visual review
- two-page PDF visual and text-extraction review