### PR TITLE
feat: unify site shell and refresh resume

### DIFF
--- a/career/generated/sid-jain-resume-dark.typ
+++ b/career/generated/sid-jain-resume-dark.typ
@@ -75,7 +75,7 @@
     align: top,
     [#profile-photo("/public/resume/sid-jain-profile-avatar.png")],
     [#box(height: 36pt)[#align(left + horizon)[#t(
-      "Sid Jain",
+      "Sid Jain ",
       fill: strong,
       font: "Literata",
       size: 36pt,
@@ -88,7 +88,7 @@
       #set par(leading: 0.422em)
       #align(right)[
         #link("mailto:sid_26@outlook.com")[#t(
-          "sid_26@outlook.com",
+          " sid_26@outlook.com",
           fill: accent,
           font: "Source Sans 3",
           size: 7.5pt,
@@ -120,7 +120,19 @@
   #block[
     #set par(leading: 0.625em)
     #t(
-      "Applied AI Lead and hands-on engineering leader who turns loosely defined customer needs into production systems. Leads customer discovery, technical strategy, teams, architecture, and delivery while remaining directly involved in AI workflow design, evaluation, prototyping, and full-stack implementation across marketplaces, browsers, mobile apps, and infrastructure-heavy products.",
+      "Software engineer and technical leader with 10+ years building and operating production applications, platforms, and infrastructure. Leads Applied AI at Namefi, taking customer workflows from discovery and system design through evaluation, implementation, and support; previously built human-in-the-loop AI content systems at Memorang. Founded a 15-engineer consultancy and shipped browser, messaging, payments, travel, mobile, and cloud systems.",
+      fill: muted,
+      font: "Source Sans 3",
+      size: 10pt,
+      weight: "regular",
+      style: "normal",
+    )
+  ]
+  #v(3pt)
+  #block[
+    #set par(leading: 0.625em)
+    #t(
+      "Based in Mumbai • Available for India/APAC travel",
       fill: muted,
       font: "Source Sans 3",
       size: 10pt,
@@ -132,7 +144,7 @@
 
   #block(breakable: false)[
 
-    #v(12pt)
+    #v(6pt)
     #t(
       "Experience",
       fill: strong,
@@ -158,16 +170,34 @@
           dy: 0pt,
         )]],
         [
-          #t(
-            "Namefi",
-            fill: strong,
-            font: "Literata",
-            size: 12pt,
-            weight: "bold",
-            style: "normal",
-            kerning: false,
+          #grid(
+            columns: (auto, auto),
+            gutter: 5pt,
+            align: horizon,
+            [#t(
+              "Namefi",
+              fill: strong,
+              font: "Literata",
+              size: 12pt,
+              weight: "bold",
+              style: "normal",
+              kerning: false,
+            )],
+            [#box(
+              inset: (x: 4pt, y: 3pt),
+              radius: 8pt,
+              fill: rgb("#242220"),
+              stroke: 0.75pt + rgb("#57534e"),
+            )[#t(
+              "Early-stage",
+              fill: rgb("#c7c2bd"),
+              font: "Source Sans 3",
+              size: 7.5pt,
+              weight: "medium",
+              style: "normal",
+            )]],
           )
-          #v(-6pt)
+          #v(-3.75pt)
           #t(
             "ICANN-accredited registrar building AI products for domain ownership and sales.",
             fill: muted,
@@ -194,7 +224,7 @@
                 style: "normal",
               )],
               [#box(
-                inset: (x: 4pt, y: 1.5pt),
+                inset: (x: 4pt, y: 3pt),
                 radius: 8pt,
                 fill: rgb("#2d2418"),
                 stroke: 0.75pt + rgb("#9a6a2b"),
@@ -208,7 +238,7 @@
               )]],
             )],
             [#t(
-              "San Francisco Bay Area / Remote · Jan 2025 - Present",
+              "Mumbai / Remote · Jan 2025 - Present",
               fill: muted,
               font: "Source Sans 3",
               size: 8.25pt,
@@ -232,7 +262,7 @@
               style: "normal",
             )],
             [#t(
-              "Interviewed owners of large domain portfolios and built Namefi Outbound to streamline buyer research, lead scoring, contact discovery, and outreach drafting, reducing sales preparation from days to minutes.",
+              "Built Namefi Outbound from customer discovery through production, cutting buyer research from days to about five minutes per domain: 50-70 ranked leads with fit rationales, decision-maker contacts, and tailored drafts.",
               fill: muted,
               font: "Source Sans 3",
               size: 10pt,
@@ -255,7 +285,7 @@
               style: "normal",
             )],
             [#t(
-              "Designed Brand Studio, a multi-stage AI system that creates logos, posters, and motion concepts for domains. It separates strategy, concept generation, and animation while preserving the exact domain name, including its top-level domain.",
+              "Built model-judged evals for buyer fit, name and product similarity, and decision-maker contacts; validated outputs through seller reports covering hundreds of prospective buyers.",
               fill: muted,
               font: "Source Sans 3",
               size: 10pt,
@@ -278,7 +308,7 @@
               style: "normal",
             )],
             [#t(
-              "Built Namefi Feed, which aggregates and structures roughly 4,000 to 5,000 public domain listings from X, forums, and marketplaces, making them searchable on the web and through RSS feeds.",
+              "Built and operated Namefi Studio, a Temporal pipeline for logos, posters, website mockups, and motion; separated strategy from generation and used prompt constraints plus visual review for domain/TLD fidelity.",
               fill: muted,
               font: "Source Sans 3",
               size: 10pt,
@@ -301,7 +331,30 @@
               style: "normal",
             )],
             [#t(
-              "Built production registrar systems for third-party integrations, registration, renewals, payments, checkout, and analytics. Added DNS record and DNSSEC management, nameserver controls, ENS and .eth support, and long-running Temporal workflows.",
+              "Built and operated Namefi Feed, a Temporal ingestion and AI-classification system serving nearly 8,000 active listings, with reliable concurrent ingestion, retries, price verification, and auditable decisions.",
+              fill: muted,
+              font: "Source Sans 3",
+              size: 10pt,
+              weight: "regular",
+              style: "normal",
+            )],
+          )
+          #v(1.5pt)
+
+          #grid(
+            columns: (6pt, 1fr),
+            gutter: 6pt,
+            align: top,
+            [#t(
+              "·",
+              fill: accent,
+              font: "Source Sans 3",
+              size: 10pt,
+              weight: "bold",
+              style: "normal",
+            )],
+            [#t(
+              "Built registrar and commerce systems across integrations, registration, checkout, payments, and analytics; replaced Airflow with testable Temporal workflows, simplifying recovery and making orchestration failures rare.",
               fill: muted,
               font: "Source Sans 3",
               size: 10pt,
@@ -315,7 +368,7 @@
     ]
 
   ]
-  #v(12pt)
+  #v(9pt)
 
   #block(breakable: false)[
     #grid(
@@ -331,16 +384,34 @@
         dy: 0pt,
       )]],
       [
-        #t(
-          "Memorang",
-          fill: strong,
-          font: "Literata",
-          size: 12pt,
-          weight: "bold",
-          style: "normal",
-          kerning: false,
+        #grid(
+          columns: (auto, auto),
+          gutter: 5pt,
+          align: horizon,
+          [#t(
+            "Memorang",
+            fill: strong,
+            font: "Literata",
+            size: 12pt,
+            weight: "bold",
+            style: "normal",
+            kerning: false,
+          )],
+          [#box(
+            inset: (x: 4pt, y: 3pt),
+            radius: 8pt,
+            fill: rgb("#242220"),
+            stroke: 0.75pt + rgb("#57534e"),
+          )[#t(
+            "Growth-stage",
+            fill: rgb("#c7c2bd"),
+            font: "Source Sans 3",
+            size: 7.5pt,
+            weight: "medium",
+            style: "normal",
+          )]],
         )
-        #v(-6pt)
+        #v(-3.75pt)
         #t(
           "AI-assisted educational content platform for structured curricula and assessments.",
           fill: muted,
@@ -359,7 +430,7 @@
             gutter: 4pt,
             align: horizon,
             [#t(
-              "Lead Product Engineer, AI Content Platform",
+              "Lead Applied AI Engineer",
               fill: strong,
               font: "Source Sans 3",
               size: 10pt,
@@ -367,7 +438,7 @@
               style: "normal",
             )],
             [#box(
-              inset: (x: 4pt, y: 1.5pt),
+              inset: (x: 4pt, y: 3pt),
               radius: 8pt,
               fill: rgb("#2d2418"),
               stroke: 0.75pt + rgb("#9a6a2b"),
@@ -380,7 +451,7 @@
               style: "normal",
             )]],
             [#box(
-              inset: (x: 4pt, y: 1.5pt),
+              inset: (x: 4pt, y: 3pt),
               radius: 8pt,
               fill: rgb("#2a2429"),
               stroke: 0.75pt + rgb("#7a6171"),
@@ -394,7 +465,7 @@
             )]],
           )],
           [#t(
-            "San Francisco Bay Area / Remote · Apr 2024 - Jan 2025",
+            "Mumbai / Remote · Apr 2024 - Jan 2025",
             fill: muted,
             font: "Source Sans 3",
             size: 8.25pt,
@@ -418,7 +489,7 @@
             style: "normal",
           )],
           [#t(
-            "Built EdWrite, a graph-based headless CMS that represents Cambridge and TOEFL curricula and assessment requirements in versioned schemas exposed through content APIs.",
+            "Built and shipped EdWrite, a graph-based CMS and content API managing tens of thousands of Cambridge and TOEFL questions, with adaptive practice, scoring, and semantic media recommendations.",
             fill: muted,
             font: "Source Sans 3",
             size: 10pt,
@@ -441,7 +512,7 @@
             style: "normal",
           )],
           [#t(
-            "Designed human-in-the-loop workflows that let subject-matter experts generate, review, and manage complete question sets with supporting audio and images. Also built adaptive practice and scoring, plus semantic recommendations for related media.",
+            "Built human-in-the-loop generation for question sets, audio, and images, cutting content cycles from months to days; SME review calibrated model-based evals, while client SMEs controlled publishing.",
             fill: muted,
             font: "Source Sans 3",
             size: 10pt,
@@ -464,7 +535,7 @@
             style: "normal",
           )],
           [#t(
-            "Managed a three-developer CMS team and owned its roadmap, coordinating with backend, frontend, and mobile teams while working directly with the CTO and CEO.",
+            "Led a three-developer CMS team and roadmap across backend, frontend, and mobile, working directly with the CTO and CEO.",
             fill: muted,
             font: "Source Sans 3",
             size: 10pt,
@@ -487,7 +558,7 @@
             style: "normal",
           )],
           [#t(
-            "Led the gradual migration of a large Flow-typed JavaScript monorepo to TypeScript, introducing Bun, Biome, codemods, and AI-assisted refactoring.",
+            "Led an AI-assisted Flow-to-TypeScript migration across hundreds of thousands of lines; cut compilation to single-digit minutes, accelerated CI and merges, and enabled safer refactors with fewer runtime errors.",
             fill: muted,
             font: "Source Sans 3",
             size: 10pt,
@@ -500,7 +571,7 @@
     )
   ]
 
-  #v(12pt)
+  #v(9pt)
 
   #block(breakable: false)[
     #grid(
@@ -516,16 +587,34 @@
         dy: 0.75pt,
       )]],
       [
-        #t(
-          "Yuppies Tech",
-          fill: strong,
-          font: "Literata",
-          size: 12pt,
-          weight: "bold",
-          style: "normal",
-          kerning: false,
+        #grid(
+          columns: (auto, auto),
+          gutter: 5pt,
+          align: horizon,
+          [#t(
+            "Yuppies Tech",
+            fill: strong,
+            font: "Literata",
+            size: 12pt,
+            weight: "bold",
+            style: "normal",
+            kerning: false,
+          )],
+          [#box(
+            inset: (x: 4pt, y: 3pt),
+            radius: 8pt,
+            fill: rgb("#242220"),
+            stroke: 0.75pt + rgb("#57534e"),
+          )[#t(
+            "0 → 1",
+            fill: rgb("#c7c2bd"),
+            font: "Source Sans 3",
+            size: 7.5pt,
+            weight: "medium",
+            style: "normal",
+          )]],
         )
-        #v(-6pt)
+        #v(-3.75pt)
         #t(
           "Product engineering consultancy for complex client products.",
           fill: muted,
@@ -552,7 +641,7 @@
               style: "normal",
             )],
             [#box(
-              inset: (x: 4pt, y: 1.5pt),
+              inset: (x: 4pt, y: 3pt),
               radius: 8pt,
               fill: rgb("#2d2418"),
               stroke: 0.75pt + rgb("#9a6a2b"),
@@ -565,7 +654,7 @@
               style: "normal",
             )]],
             [#box(
-              inset: (x: 4pt, y: 1.5pt),
+              inset: (x: 4pt, y: 3pt),
               radius: 8pt,
               fill: rgb("#2a2429"),
               stroke: 0.75pt + rgb("#7a6171"),
@@ -589,7 +678,7 @@
         )
         #v(2.25pt)
         #t(
-          "Founded and grew Yuppies Tech to 15 engineers while remaining the client-facing technical lead. Turned unclear requirements into architecture, delivery plans, and production releases.",
+          "Founded and grew Yuppies Tech to 15 engineers while remaining the client-facing technical lead. Turned unclear requirements into architecture, delivery plans, and production releases. Selected engagements:",
           fill: muted,
           font: "Source Sans 3",
           size: 10pt,
@@ -678,7 +767,7 @@
               weight: "medium",
               style: "normal",
             )#t(
-              "led modernization of ZebPay's iOS and Android apps, release infrastructure, exchange and payment features, and international KYC. During stabilization, increased the release cadence from every two weeks to weekly.",
+              "led modernization of ZebPay's iOS and Android apps, release infrastructure, exchange and payment features, and international KYC. During stabilization, increased the release cadence from monthly to weekly.",
               fill: muted,
               font: "Source Sans 3",
               size: 10pt,
@@ -751,7 +840,7 @@
     )
   ]
 
-  #v(12pt)
+  #v(9pt)
 
   #block(breakable: false)[
     #grid(
@@ -767,16 +856,34 @@
         dy: 0pt,
       )]],
       [
-        #t(
-          "Kult",
-          fill: strong,
-          font: "Literata",
-          size: 12pt,
-          weight: "bold",
-          style: "normal",
-          kerning: false,
+        #grid(
+          columns: (auto, auto),
+          gutter: 5pt,
+          align: horizon,
+          [#t(
+            "Kult",
+            fill: strong,
+            font: "Literata",
+            size: 12pt,
+            weight: "bold",
+            style: "normal",
+            kerning: false,
+          )],
+          [#box(
+            inset: (x: 4pt, y: 3pt),
+            radius: 8pt,
+            fill: rgb("#242220"),
+            stroke: 0.75pt + rgb("#57534e"),
+          )[#t(
+            "0 → 1",
+            fill: rgb("#c7c2bd"),
+            font: "Source Sans 3",
+            size: 7.5pt,
+            weight: "medium",
+            style: "normal",
+          )]],
         )
-        #v(-6pt)
+        #v(-3.75pt)
         #t(
           "Consumer beauty and skincare commerce.",
           fill: muted,
@@ -803,7 +910,7 @@
               style: "normal",
             )],
             [#box(
-              inset: (x: 4pt, y: 1.5pt),
+              inset: (x: 4pt, y: 3pt),
               radius: 8pt,
               fill: rgb("#2d2418"),
               stroke: 0.75pt + rgb("#9a6a2b"),
@@ -816,7 +923,7 @@
               style: "normal",
             )]],
             [#box(
-              inset: (x: 4pt, y: 1.5pt),
+              inset: (x: 4pt, y: 3pt),
               radius: 8pt,
               fill: rgb("#2a2429"),
               stroke: 0.75pt + rgb("#7a6171"),
@@ -890,7 +997,7 @@
     )
   ]
 
-  #v(12pt)
+  #v(9pt)
 
   #block(breakable: false)[
     #grid(
@@ -906,16 +1013,34 @@
         dy: 0pt,
       )]],
       [
-        #t(
-          "Yilu",
-          fill: strong,
-          font: "Literata",
-          size: 12pt,
-          weight: "bold",
-          style: "normal",
-          kerning: false,
+        #grid(
+          columns: (auto, auto),
+          gutter: 5pt,
+          align: horizon,
+          [#t(
+            "Yilu",
+            fill: strong,
+            font: "Literata",
+            size: 12pt,
+            weight: "bold",
+            style: "normal",
+            kerning: false,
+          )],
+          [#box(
+            inset: (x: 4pt, y: 3pt),
+            radius: 8pt,
+            fill: rgb("#242220"),
+            stroke: 0.75pt + rgb("#57534e"),
+          )[#t(
+            "0 → 1",
+            fill: rgb("#c7c2bd"),
+            font: "Source Sans 3",
+            size: 7.5pt,
+            weight: "medium",
+            style: "normal",
+          )]],
         )
-        #v(-6pt)
+        #v(-3.75pt)
         #t(
           "Smart travel platform built for Lufthansa Group with BCG Digital Ventures.",
           fill: muted,
@@ -930,7 +1055,7 @@
           columns: (1fr, auto),
           gutter: 12pt,
           [#grid(
-            columns: (auto, auto),
+            columns: (auto, auto, auto),
             gutter: 4pt,
             align: horizon,
             [#t(
@@ -942,13 +1067,26 @@
               style: "normal",
             )],
             [#box(
-              inset: (x: 4pt, y: 1.5pt),
+              inset: (x: 4pt, y: 3pt),
               radius: 8pt,
               fill: rgb("#2d2418"),
               stroke: 0.75pt + rgb("#9a6a2b"),
             )[#t(
               "Hands-on",
               fill: rgb("#f0b85f"),
+              font: "Source Sans 3",
+              size: 7.5pt,
+              weight: "medium",
+              style: "normal",
+            )]],
+            [#box(
+              inset: (x: 4pt, y: 3pt),
+              radius: 8pt,
+              fill: rgb("#2a2429"),
+              stroke: 0.75pt + rgb("#7a6171"),
+            )[#t(
+              "Leadership",
+              fill: rgb("#e3bfd7"),
               font: "Source Sans 3",
               size: 7.5pt,
               weight: "medium",
@@ -1003,7 +1141,7 @@
             style: "normal",
           )],
           [#t(
-            "Helped establish the engineering team by writing job descriptions, creating technical exercises, and interviewing candidates. Also served as Scrum Master.",
+            "As the first engineering hire, led a five-developer full-stack pod with a product manager and designer; partnered with the CTO on key hires and served as Scrum Master for early sprints, establishing the team's delivery cadence.",
             fill: muted,
             font: "Source Sans 3",
             size: 10pt,
@@ -1016,7 +1154,7 @@
     )
   ]
 
-  #v(12pt)
+  #v(9pt)
 
   #block(breakable: false)[
     #grid(
@@ -1032,16 +1170,34 @@
         dy: 0pt,
       )]],
       [
-        #t(
-          "8fit",
-          fill: strong,
-          font: "Literata",
-          size: 12pt,
-          weight: "bold",
-          style: "normal",
-          kerning: false,
+        #grid(
+          columns: (auto, auto),
+          gutter: 5pt,
+          align: horizon,
+          [#t(
+            "8fit",
+            fill: strong,
+            font: "Literata",
+            size: 12pt,
+            weight: "bold",
+            style: "normal",
+            kerning: false,
+          )],
+          [#box(
+            inset: (x: 4pt, y: 3pt),
+            radius: 8pt,
+            fill: rgb("#242220"),
+            stroke: 0.75pt + rgb("#57534e"),
+          )[#t(
+            "Growth-stage",
+            fill: rgb("#c7c2bd"),
+            font: "Source Sans 3",
+            size: 7.5pt,
+            weight: "medium",
+            style: "normal",
+          )]],
         )
-        #v(-6pt)
+        #v(-3.75pt)
         #t(
           "Fitness and nutrition platform later acquired by Withings.",
           fill: muted,
@@ -1068,7 +1224,7 @@
               style: "normal",
             )],
             [#box(
-              inset: (x: 4pt, y: 1.5pt),
+              inset: (x: 4pt, y: 3pt),
               radius: 8pt,
               fill: rgb("#2d2418"),
               stroke: 0.75pt + rgb("#9a6a2b"),
@@ -1142,7 +1298,7 @@
     )
   ]
 
-  #v(12pt)
+  #v(9pt)
 
   #block(breakable: false)[
     #grid(
@@ -1158,16 +1314,34 @@
         dy: 0pt,
       )]],
       [
-        #t(
-          "Housing",
-          fill: strong,
-          font: "Literata",
-          size: 12pt,
-          weight: "bold",
-          style: "normal",
-          kerning: false,
+        #grid(
+          columns: (auto, auto),
+          gutter: 5pt,
+          align: horizon,
+          [#t(
+            "Housing",
+            fill: strong,
+            font: "Literata",
+            size: 12pt,
+            weight: "bold",
+            style: "normal",
+            kerning: false,
+          )],
+          [#box(
+            inset: (x: 4pt, y: 3pt),
+            radius: 8pt,
+            fill: rgb("#242220"),
+            stroke: 0.75pt + rgb("#57534e"),
+          )[#t(
+            "Late-stage",
+            fill: rgb("#c7c2bd"),
+            font: "Source Sans 3",
+            size: 7.5pt,
+            weight: "medium",
+            style: "normal",
+          )]],
         )
-        #v(-6pt)
+        #v(-3.75pt)
         #t(
           "Indian real estate search and transaction platform.",
           fill: muted,
@@ -1194,7 +1368,7 @@
               style: "normal",
             )],
             [#box(
-              inset: (x: 4pt, y: 1.5pt),
+              inset: (x: 4pt, y: 3pt),
               radius: 8pt,
               fill: rgb("#2d2418"),
               stroke: 0.75pt + rgb("#9a6a2b"),
@@ -1291,7 +1465,7 @@
     )
   ]
 
-  #v(12pt)
+  #v(9pt)
 
   #block(breakable: false)[
     #grid(
@@ -1307,16 +1481,21 @@
         dy: 0.75pt,
       )]],
       [
-        #t(
-          "Earlier Consulting and Startup Work",
-          fill: strong,
-          font: "Literata",
-          size: 12pt,
-          weight: "bold",
-          style: "normal",
-          kerning: false,
+        #grid(
+          columns: auto,
+          gutter: 5pt,
+          align: horizon,
+          [#t(
+            "Earlier Consulting and Startup Work",
+            fill: strong,
+            font: "Literata",
+            size: 12pt,
+            weight: "bold",
+            style: "normal",
+            kerning: false,
+          )],
         )
-        #v(-6pt)
+        #v(-3.75pt)
         #t(
           "Bridg, 1mg, HornOk, Volkno, Meriad, and self-employed work.",
           fill: muted,
@@ -1343,7 +1522,7 @@
               style: "normal",
             )],
             [#box(
-              inset: (x: 4pt, y: 1.5pt),
+              inset: (x: 4pt, y: 3pt),
               radius: 8pt,
               fill: rgb("#2d2418"),
               stroke: 0.75pt + rgb("#9a6a2b"),
@@ -1448,16 +1627,21 @@
           dy: 0pt,
         )]],
         [
-          #t(
-            "University of California, Los Angeles",
-            fill: strong,
-            font: "Literata",
-            size: 12pt,
-            weight: "bold",
-            style: "normal",
-            kerning: false,
+          #grid(
+            columns: auto,
+            gutter: 5pt,
+            align: horizon,
+            [#t(
+              "University of California, Los Angeles",
+              fill: strong,
+              font: "Literata",
+              size: 12pt,
+              weight: "bold",
+              style: "normal",
+              kerning: false,
+            )],
           )
-          #v(-6pt)
+          #v(-3.75pt)
           #t(
             "Bachelor of Science.",
             fill: muted,
@@ -1501,7 +1685,7 @@
     ]
 
   ]
-  #v(12pt)
+  #v(9pt)
 
   #block(breakable: false)[
     #grid(
@@ -1517,16 +1701,21 @@
         dy: 0pt,
       )]],
       [
-        #t(
-          "Delhi Public School, R. K. Puram",
-          fill: strong,
-          font: "Literata",
-          size: 12pt,
-          weight: "bold",
-          style: "normal",
-          kerning: false,
+        #grid(
+          columns: auto,
+          gutter: 5pt,
+          align: horizon,
+          [#t(
+            "Delhi Public School, R. K. Puram",
+            fill: strong,
+            font: "Literata",
+            size: 12pt,
+            weight: "bold",
+            style: "normal",
+            kerning: false,
+          )],
         )
-        #v(-6pt)
+        #v(-3.75pt)
         #t(
           "High School.",
           fill: muted,

--- a/public/resume/sid-jain-resume.pdf
+++ b/public/resume/sid-jain-resume.pdf
@@ -2,43 +2,43 @@
 %€€€€
 
 1 0 obj
-<</Type/Pages/Count 2/Kids[321 0 R 322 0 R]>>
+<</Type/Pages/Count 2/Kids[362 0 R 363 0 R]>>
 endobj
 2 0 obj
-<</Type/OutputIntent/DestOutputProfile 346 0 R/S/GTS_PDFA1/OutputConditionIdentifier(Custom)/OutputCondition(sRGB)/RegistryName()/Info(sRGB v4.2)>>
+<</Type/OutputIntent/DestOutputProfile 387 0 R/S/GTS_PDFA1/OutputConditionIdentifier(Custom)/OutputCondition(sRGB)/RegistryName()/Info(sRGB v4.2)>>
 endobj
 3 0 obj
 [2 0 R]
 endobj
 4 0 obj
-<</Type/StructTreeRoot/RoleMap<</Datetime/Span/Terms/Part/Title/P/Strong/Span/Em/Span>>/K[293 0 R]/ParentTree<</Nums[0 11 0 R 1 12 0 R 2 13 0 R 3 5 0 R 4 6 0 R]>>/ParentTreeNextKey 5>>
+<</Type/StructTreeRoot/RoleMap<</Datetime/Span/Terms/Part/Title/P/Strong/Span/Em/Span>>/K[334 0 R]/ParentTree<</Nums[0 11 0 R 1 12 0 R 2 13 0 R 3 5 0 R 4 6 0 R]>>/ParentTreeNextKey 5>>
 endobj
 5 0 obj
-[7 0 R 9 0 R 11 0 R 12 0 R 13 0 R 17 0 R 17 0 R 17 0 R 17 0 R 18 0 R 19 0 R 21 0 R 22 0 R 23 0 R 25 0 R 29 0 R 32 0 R 34 0 R 34 0 R 37 0 R 39 0 R 39 0 R 39 0 R 42 0 R 44 0 R 44 0 R 47 0 R 49 0 R 49 0 R 49 0 R 54 0 R 56 0 R 57 0 R 58 0 R 60 0 R 62 0 R 66 0 R 69 0 R 71 0 R 71 0 R 74 0 R 76 0 R 76 0 R 76 0 R 79 0 R 81 0 R 81 0 R 84 0 R 86 0 R 86 0 R 91 0 R 93 0 R 94 0 R 95 0 R 97 0 R 99 0 R 103 0 R 106 0 R 106 0 R 107 0 R 109 0 R 109 0 R 109 0 R 109 0 R 112 0 R 114 0 R 114 0 R 114 0 R 114 0 R 117 0 R 119 0 R 119 0 R 119 0 R 119 0 R 122 0 R 124 0 R 124 0 R 124 0 R 124 0 R 127 0 R 129 0 R 129 0 R 129 0 R 129 0 R]
+[7 0 R 9 0 R 11 0 R 12 0 R 13 0 R 17 0 R 17 0 R 17 0 R 17 0 R 17 0 R 18 0 R 19 0 R 21 0 R 23 0 R 26 0 R 27 0 R 29 0 R 33 0 R 36 0 R 38 0 R 38 0 R 41 0 R 43 0 R 43 0 R 46 0 R 48 0 R 48 0 R 51 0 R 53 0 R 53 0 R 56 0 R 58 0 R 58 0 R 63 0 R 65 0 R 67 0 R 70 0 R 71 0 R 73 0 R 75 0 R 79 0 R 82 0 R 84 0 R 84 0 R 87 0 R 89 0 R 89 0 R 92 0 R 94 0 R 94 0 R 97 0 R 99 0 R 99 0 R 104 0 R 106 0 R 108 0 R 111 0 R 112 0 R 114 0 R 116 0 R 120 0 R 123 0 R 123 0 R 124 0 R 126 0 R 126 0 R 126 0 R 126 0 R 129 0 R 131 0 R 131 0 R 131 0 R 131 0 R 134 0 R 136 0 R 136 0 R 136 0 R 139 0 R 141 0 R 141 0 R 141 0 R 141 0 R 144 0 R 146 0 R 146 0 R 146 0 R 146 0 R]
 endobj
 6 0 obj
-[134 0 R 136 0 R 137 0 R 138 0 R 140 0 R 142 0 R 146 0 R 149 0 R 151 0 R 151 0 R 154 0 R 156 0 R 156 0 R 161 0 R 163 0 R 164 0 R 165 0 R 167 0 R 171 0 R 174 0 R 176 0 R 176 0 R 179 0 R 181 0 R 181 0 R 186 0 R 188 0 R 189 0 R 190 0 R 192 0 R 196 0 R 199 0 R 201 0 R 201 0 R 204 0 R 206 0 R 211 0 R 213 0 R 214 0 R 215 0 R 217 0 R 221 0 R 224 0 R 226 0 R 226 0 R 229 0 R 231 0 R 231 0 R 231 0 R 234 0 R 236 0 R 241 0 R 243 0 R 244 0 R 245 0 R 247 0 R 251 0 R 254 0 R 256 0 R 256 0 R 259 0 R 261 0 R 266 0 R 267 0 R 269 0 R 270 0 R 271 0 R 275 0 R 280 0 R 282 0 R 283 0 R 284 0 R 288 0 R]
+[151 0 R 153 0 R 155 0 R 158 0 R 159 0 R 161 0 R 163 0 R 167 0 R 170 0 R 172 0 R 172 0 R 175 0 R 177 0 R 177 0 R 182 0 R 184 0 R 186 0 R 189 0 R 190 0 R 192 0 R 194 0 R 198 0 R 201 0 R 203 0 R 203 0 R 206 0 R 208 0 R 208 0 R 213 0 R 215 0 R 217 0 R 220 0 R 221 0 R 223 0 R 227 0 R 230 0 R 232 0 R 232 0 R 235 0 R 237 0 R 242 0 R 244 0 R 246 0 R 249 0 R 250 0 R 252 0 R 256 0 R 259 0 R 261 0 R 261 0 R 264 0 R 266 0 R 266 0 R 266 0 R 269 0 R 271 0 R 276 0 R 278 0 R 281 0 R 282 0 R 284 0 R 288 0 R 291 0 R 293 0 R 293 0 R 296 0 R 298 0 R 303 0 R 304 0 R 306 0 R 309 0 R 310 0 R 314 0 R 319 0 R 321 0 R 324 0 R 325 0 R 329 0 R]
 endobj
 7 0 obj
-<</Type/StructElem/S/Figure/P 8 0 R/A[<</O/Layout/Placement/Block>>]/K[0]/Pg 321 0 R>>
+<</Type/StructElem/S/Figure/P 8 0 R/A[<</O/Layout/Placement/Block>>]/K[0]/Pg 362 0 R>>
 endobj
 8 0 obj
 <</Type/StructElem/S/Div/P 16 0 R/K[7 0 R]>>
 endobj
 9 0 obj
-<</Type/StructElem/S/Span/P 10 0 R/A[<</O/Layout/Placement/Block>>]/K[1]/Pg 321 0 R>>
+<</Type/StructElem/S/Span/P 10 0 R/A[<</O/Layout/Placement/Block>>]/K[1]/Pg 362 0 R>>
 endobj
 10 0 obj
 <</Type/StructElem/S/Div/P 16 0 R/K[9 0 R]>>
 endobj
 11 0 obj
-<</Type/StructElem/S/Link/P 14 0 R/K[2<</Type/OBJR/Pg 321 0 R/Obj 294 0 R>>]/Pg 321 0 R>>
+<</Type/StructElem/S/Link/P 14 0 R/K[2<</Type/OBJR/Pg 362 0 R/Obj 335 0 R>>]/Pg 362 0 R>>
 endobj
 12 0 obj
-<</Type/StructElem/S/Link/P 14 0 R/K[3<</Type/OBJR/Pg 321 0 R/Obj 295 0 R>>]/Pg 321 0 R>>
+<</Type/StructElem/S/Link/P 14 0 R/K[3<</Type/OBJR/Pg 362 0 R/Obj 336 0 R>>]/Pg 362 0 R>>
 endobj
 13 0 obj
-<</Type/StructElem/S/Link/P 14 0 R/K[4<</Type/OBJR/Pg 321 0 R/Obj 296 0 R>>]/Pg 321 0 R>>
+<</Type/StructElem/S/Link/P 14 0 R/K[4<</Type/OBJR/Pg 362 0 R/Obj 337 0 R>>]/Pg 362 0 R>>
 endobj
 14 0 obj
 <</Type/StructElem/S/P/P 15 0 R/K[11 0 R 12 0 R 13 0 R]>>
@@ -47,933 +47,1056 @@ endobj
 <</Type/StructElem/S/Div/P 16 0 R/K[14 0 R]>>
 endobj
 16 0 obj
-<</Type/StructElem/S/Div/P 293 0 R/K[8 0 R 10 0 R 15 0 R]>>
+<</Type/StructElem/S/Div/P 334 0 R/K[8 0 R 10 0 R 15 0 R]>>
 endobj
 17 0 obj
-<</Type/StructElem/S/Span/P 293 0 R/A[<</O/Layout/Placement/Block>>]/K[5 6 7 8]/Pg 321 0 R>>
+<</Type/StructElem/S/Span/P 334 0 R/A[<</O/Layout/Placement/Block>>]/K[5 6 7 8 9]/Pg 362 0 R>>
 endobj
 18 0 obj
-<</Type/StructElem/S/P/P 293 0 R/K[9]/Pg 321 0 R>>
+<</Type/StructElem/S/P/P 334 0 R/K[10]/Pg 362 0 R>>
 endobj
 19 0 obj
-<</Type/StructElem/S/Figure/P 20 0 R/A[<</O/Layout/Placement/Block>>]/K[10]/Pg 321 0 R>>
+<</Type/StructElem/S/Figure/P 20 0 R/A[<</O/Layout/Placement/Block>>]/K[11]/Pg 362 0 R>>
 endobj
 20 0 obj
-<</Type/StructElem/S/Div/P 53 0 R/K[19 0 R]>>
+<</Type/StructElem/S/Div/P 62 0 R/K[19 0 R]>>
 endobj
 21 0 obj
-<</Type/StructElem/S/P/P 52 0 R/K[11]/Pg 321 0 R>>
+<</Type/StructElem/S/Span/P 22 0 R/A[<</O/Layout/Placement/Block>>]/K[12]/Pg 362 0 R>>
 endobj
 22 0 obj
-<</Type/StructElem/S/P/P 52 0 R/K[12]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 25 0 R/K[21 0 R]>>
 endobj
 23 0 obj
-<</Type/StructElem/S/Span/P 24 0 R/A[<</O/Layout/Placement/Block>>]/K[13]/Pg 321 0 R>>
+<</Type/StructElem/S/Span/P 24 0 R/A[<</O/Layout/Placement/Block>>]/K[13]/Pg 362 0 R>>
 endobj
 24 0 obj
-<</Type/StructElem/S/Div/P 27 0 R/K[23 0 R]>>
+<</Type/StructElem/S/Div/P 25 0 R/K[23 0 R]>>
 endobj
 25 0 obj
-<</Type/StructElem/S/Span/P 26 0 R/A[<</O/Layout/Placement/Block>>]/K[14]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 61 0 R/K[22 0 R 24 0 R]>>
 endobj
 26 0 obj
-<</Type/StructElem/S/Div/P 27 0 R/K[25 0 R]>>
+<</Type/StructElem/S/P/P 61 0 R/K[14]/Pg 362 0 R>>
 endobj
 27 0 obj
-<</Type/StructElem/S/Div/P 28 0 R/K[24 0 R 26 0 R]>>
+<</Type/StructElem/S/Span/P 28 0 R/A[<</O/Layout/Placement/Block>>]/K[15]/Pg 362 0 R>>
 endobj
 28 0 obj
 <</Type/StructElem/S/Div/P 31 0 R/K[27 0 R]>>
 endobj
 29 0 obj
-<</Type/StructElem/S/Span/P 30 0 R/A[<</O/Layout/Placement/Block>>]/K[15]/Pg 321 0 R>>
+<</Type/StructElem/S/Span/P 30 0 R/A[<</O/Layout/Placement/Block>>]/K[16]/Pg 362 0 R>>
 endobj
 30 0 obj
 <</Type/StructElem/S/Div/P 31 0 R/K[29 0 R]>>
 endobj
 31 0 obj
-<</Type/StructElem/S/Div/P 52 0 R/K[28 0 R 30 0 R]>>
+<</Type/StructElem/S/Div/P 32 0 R/K[28 0 R 30 0 R]>>
 endobj
 32 0 obj
-<</Type/StructElem/S/Span/P 33 0 R/A[<</O/Layout/Placement/Block>>]/K[16]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 35 0 R/K[31 0 R]>>
 endobj
 33 0 obj
-<</Type/StructElem/S/Div/P 36 0 R/K[32 0 R]>>
+<</Type/StructElem/S/Span/P 34 0 R/A[<</O/Layout/Placement/Block>>]/K[17]/Pg 362 0 R>>
 endobj
 34 0 obj
-<</Type/StructElem/S/Span/P 35 0 R/A[<</O/Layout/Placement/Block>>]/K[17 18]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 35 0 R/K[33 0 R]>>
 endobj
 35 0 obj
-<</Type/StructElem/S/Div/P 36 0 R/K[34 0 R]>>
+<</Type/StructElem/S/Div/P 61 0 R/K[32 0 R 34 0 R]>>
 endobj
 36 0 obj
-<</Type/StructElem/S/Div/P 52 0 R/K[33 0 R 35 0 R]>>
+<</Type/StructElem/S/Span/P 37 0 R/A[<</O/Layout/Placement/Block>>]/K[18]/Pg 362 0 R>>
 endobj
 37 0 obj
-<</Type/StructElem/S/Span/P 38 0 R/A[<</O/Layout/Placement/Block>>]/K[19]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 40 0 R/K[36 0 R]>>
 endobj
 38 0 obj
-<</Type/StructElem/S/Div/P 41 0 R/K[37 0 R]>>
+<</Type/StructElem/S/Span/P 39 0 R/A[<</O/Layout/Placement/Block>>]/K[19 20]/Pg 362 0 R>>
 endobj
 39 0 obj
-<</Type/StructElem/S/Span/P 40 0 R/A[<</O/Layout/Placement/Block>>]/K[20 21 22]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 40 0 R/K[38 0 R]>>
 endobj
 40 0 obj
-<</Type/StructElem/S/Div/P 41 0 R/K[39 0 R]>>
+<</Type/StructElem/S/Div/P 61 0 R/K[37 0 R 39 0 R]>>
 endobj
 41 0 obj
-<</Type/StructElem/S/Div/P 52 0 R/K[38 0 R 40 0 R]>>
+<</Type/StructElem/S/Span/P 42 0 R/A[<</O/Layout/Placement/Block>>]/K[21]/Pg 362 0 R>>
 endobj
 42 0 obj
-<</Type/StructElem/S/Span/P 43 0 R/A[<</O/Layout/Placement/Block>>]/K[23]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 45 0 R/K[41 0 R]>>
 endobj
 43 0 obj
-<</Type/StructElem/S/Div/P 46 0 R/K[42 0 R]>>
+<</Type/StructElem/S/Span/P 44 0 R/A[<</O/Layout/Placement/Block>>]/K[22 23]/Pg 362 0 R>>
 endobj
 44 0 obj
-<</Type/StructElem/S/Span/P 45 0 R/A[<</O/Layout/Placement/Block>>]/K[24 25]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 45 0 R/K[43 0 R]>>
 endobj
 45 0 obj
-<</Type/StructElem/S/Div/P 46 0 R/K[44 0 R]>>
+<</Type/StructElem/S/Div/P 61 0 R/K[42 0 R 44 0 R]>>
 endobj
 46 0 obj
-<</Type/StructElem/S/Div/P 52 0 R/K[43 0 R 45 0 R]>>
+<</Type/StructElem/S/Span/P 47 0 R/A[<</O/Layout/Placement/Block>>]/K[24]/Pg 362 0 R>>
 endobj
 47 0 obj
-<</Type/StructElem/S/Span/P 48 0 R/A[<</O/Layout/Placement/Block>>]/K[26]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 50 0 R/K[46 0 R]>>
 endobj
 48 0 obj
-<</Type/StructElem/S/Div/P 51 0 R/K[47 0 R]>>
+<</Type/StructElem/S/Span/P 49 0 R/A[<</O/Layout/Placement/Block>>]/K[25 26]/Pg 362 0 R>>
 endobj
 49 0 obj
-<</Type/StructElem/S/Span/P 50 0 R/A[<</O/Layout/Placement/Block>>]/K[27 28 29]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 50 0 R/K[48 0 R]>>
 endobj
 50 0 obj
-<</Type/StructElem/S/Div/P 51 0 R/K[49 0 R]>>
+<</Type/StructElem/S/Div/P 61 0 R/K[47 0 R 49 0 R]>>
 endobj
 51 0 obj
-<</Type/StructElem/S/Div/P 52 0 R/K[48 0 R 50 0 R]>>
+<</Type/StructElem/S/Span/P 52 0 R/A[<</O/Layout/Placement/Block>>]/K[27]/Pg 362 0 R>>
 endobj
 52 0 obj
-<</Type/StructElem/S/Div/P 53 0 R/K[21 0 R 22 0 R 31 0 R 36 0 R 41 0 R 46 0 R 51 0 R]>>
+<</Type/StructElem/S/Div/P 55 0 R/K[51 0 R]>>
 endobj
 53 0 obj
-<</Type/StructElem/S/Div/P 293 0 R/K[20 0 R 52 0 R]>>
+<</Type/StructElem/S/Span/P 54 0 R/A[<</O/Layout/Placement/Block>>]/K[28 29]/Pg 362 0 R>>
 endobj
 54 0 obj
-<</Type/StructElem/S/Figure/P 55 0 R/A[<</O/Layout/Placement/Block>>]/K[30]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 55 0 R/K[53 0 R]>>
 endobj
 55 0 obj
-<</Type/StructElem/S/Div/P 90 0 R/K[54 0 R]>>
+<</Type/StructElem/S/Div/P 61 0 R/K[52 0 R 54 0 R]>>
 endobj
 56 0 obj
-<</Type/StructElem/S/P/P 89 0 R/K[31]/Pg 321 0 R>>
+<</Type/StructElem/S/Span/P 57 0 R/A[<</O/Layout/Placement/Block>>]/K[30]/Pg 362 0 R>>
 endobj
 57 0 obj
-<</Type/StructElem/S/P/P 89 0 R/K[32]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 60 0 R/K[56 0 R]>>
 endobj
 58 0 obj
-<</Type/StructElem/S/Span/P 59 0 R/A[<</O/Layout/Placement/Block>>]/K[33]/Pg 321 0 R>>
+<</Type/StructElem/S/Span/P 59 0 R/A[<</O/Layout/Placement/Block>>]/K[31 32]/Pg 362 0 R>>
 endobj
 59 0 obj
-<</Type/StructElem/S/Div/P 64 0 R/K[58 0 R]>>
+<</Type/StructElem/S/Div/P 60 0 R/K[58 0 R]>>
 endobj
 60 0 obj
-<</Type/StructElem/S/Span/P 61 0 R/A[<</O/Layout/Placement/Block>>]/K[34]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 61 0 R/K[57 0 R 59 0 R]>>
 endobj
 61 0 obj
-<</Type/StructElem/S/Div/P 64 0 R/K[60 0 R]>>
+<</Type/StructElem/S/Div/P 62 0 R/K[25 0 R 26 0 R 35 0 R 40 0 R 45 0 R 50 0 R 55 0 R 60 0 R]>>
 endobj
 62 0 obj
-<</Type/StructElem/S/Span/P 63 0 R/A[<</O/Layout/Placement/Block>>]/K[35]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 334 0 R/K[20 0 R 61 0 R]>>
 endobj
 63 0 obj
-<</Type/StructElem/S/Div/P 64 0 R/K[62 0 R]>>
+<</Type/StructElem/S/Figure/P 64 0 R/A[<</O/Layout/Placement/Block>>]/K[33]/Pg 362 0 R>>
 endobj
 64 0 obj
-<</Type/StructElem/S/Div/P 65 0 R/K[59 0 R 61 0 R 63 0 R]>>
+<</Type/StructElem/S/Div/P 103 0 R/K[63 0 R]>>
 endobj
 65 0 obj
-<</Type/StructElem/S/Div/P 68 0 R/K[64 0 R]>>
+<</Type/StructElem/S/Span/P 66 0 R/A[<</O/Layout/Placement/Block>>]/K[34]/Pg 362 0 R>>
 endobj
 66 0 obj
-<</Type/StructElem/S/Span/P 67 0 R/A[<</O/Layout/Placement/Block>>]/K[36]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 69 0 R/K[65 0 R]>>
 endobj
 67 0 obj
-<</Type/StructElem/S/Div/P 68 0 R/K[66 0 R]>>
+<</Type/StructElem/S/Span/P 68 0 R/A[<</O/Layout/Placement/Block>>]/K[35]/Pg 362 0 R>>
 endobj
 68 0 obj
-<</Type/StructElem/S/Div/P 89 0 R/K[65 0 R 67 0 R]>>
+<</Type/StructElem/S/Div/P 69 0 R/K[67 0 R]>>
 endobj
 69 0 obj
-<</Type/StructElem/S/Span/P 70 0 R/A[<</O/Layout/Placement/Block>>]/K[37]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 102 0 R/K[66 0 R 68 0 R]>>
 endobj
 70 0 obj
-<</Type/StructElem/S/Div/P 73 0 R/K[69 0 R]>>
+<</Type/StructElem/S/P/P 102 0 R/K[36]/Pg 362 0 R>>
 endobj
 71 0 obj
-<</Type/StructElem/S/Span/P 72 0 R/A[<</O/Layout/Placement/Block>>]/K[38 39]/Pg 321 0 R>>
+<</Type/StructElem/S/Span/P 72 0 R/A[<</O/Layout/Placement/Block>>]/K[37]/Pg 362 0 R>>
 endobj
 72 0 obj
-<</Type/StructElem/S/Div/P 73 0 R/K[71 0 R]>>
+<</Type/StructElem/S/Div/P 77 0 R/K[71 0 R]>>
 endobj
 73 0 obj
-<</Type/StructElem/S/Div/P 89 0 R/K[70 0 R 72 0 R]>>
+<</Type/StructElem/S/Span/P 74 0 R/A[<</O/Layout/Placement/Block>>]/K[38]/Pg 362 0 R>>
 endobj
 74 0 obj
-<</Type/StructElem/S/Span/P 75 0 R/A[<</O/Layout/Placement/Block>>]/K[40]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 77 0 R/K[73 0 R]>>
 endobj
 75 0 obj
-<</Type/StructElem/S/Div/P 78 0 R/K[74 0 R]>>
+<</Type/StructElem/S/Span/P 76 0 R/A[<</O/Layout/Placement/Block>>]/K[39]/Pg 362 0 R>>
 endobj
 76 0 obj
-<</Type/StructElem/S/Span/P 77 0 R/A[<</O/Layout/Placement/Block>>]/K[41 42 43]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 77 0 R/K[75 0 R]>>
 endobj
 77 0 obj
-<</Type/StructElem/S/Div/P 78 0 R/K[76 0 R]>>
+<</Type/StructElem/S/Div/P 78 0 R/K[72 0 R 74 0 R 76 0 R]>>
 endobj
 78 0 obj
-<</Type/StructElem/S/Div/P 89 0 R/K[75 0 R 77 0 R]>>
+<</Type/StructElem/S/Div/P 81 0 R/K[77 0 R]>>
 endobj
 79 0 obj
-<</Type/StructElem/S/Span/P 80 0 R/A[<</O/Layout/Placement/Block>>]/K[44]/Pg 321 0 R>>
+<</Type/StructElem/S/Span/P 80 0 R/A[<</O/Layout/Placement/Block>>]/K[40]/Pg 362 0 R>>
 endobj
 80 0 obj
-<</Type/StructElem/S/Div/P 83 0 R/K[79 0 R]>>
+<</Type/StructElem/S/Div/P 81 0 R/K[79 0 R]>>
 endobj
 81 0 obj
-<</Type/StructElem/S/Span/P 82 0 R/A[<</O/Layout/Placement/Block>>]/K[45 46]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 102 0 R/K[78 0 R 80 0 R]>>
 endobj
 82 0 obj
-<</Type/StructElem/S/Div/P 83 0 R/K[81 0 R]>>
+<</Type/StructElem/S/Span/P 83 0 R/A[<</O/Layout/Placement/Block>>]/K[41]/Pg 362 0 R>>
 endobj
 83 0 obj
-<</Type/StructElem/S/Div/P 89 0 R/K[80 0 R 82 0 R]>>
+<</Type/StructElem/S/Div/P 86 0 R/K[82 0 R]>>
 endobj
 84 0 obj
-<</Type/StructElem/S/Span/P 85 0 R/A[<</O/Layout/Placement/Block>>]/K[47]/Pg 321 0 R>>
+<</Type/StructElem/S/Span/P 85 0 R/A[<</O/Layout/Placement/Block>>]/K[42 43]/Pg 362 0 R>>
 endobj
 85 0 obj
-<</Type/StructElem/S/Div/P 88 0 R/K[84 0 R]>>
+<</Type/StructElem/S/Div/P 86 0 R/K[84 0 R]>>
 endobj
 86 0 obj
-<</Type/StructElem/S/Span/P 87 0 R/A[<</O/Layout/Placement/Block>>]/K[48 49]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 102 0 R/K[83 0 R 85 0 R]>>
 endobj
 87 0 obj
-<</Type/StructElem/S/Div/P 88 0 R/K[86 0 R]>>
+<</Type/StructElem/S/Span/P 88 0 R/A[<</O/Layout/Placement/Block>>]/K[44]/Pg 362 0 R>>
 endobj
 88 0 obj
-<</Type/StructElem/S/Div/P 89 0 R/K[85 0 R 87 0 R]>>
+<</Type/StructElem/S/Div/P 91 0 R/K[87 0 R]>>
 endobj
 89 0 obj
-<</Type/StructElem/S/Div/P 90 0 R/K[56 0 R 57 0 R 68 0 R 73 0 R 78 0 R 83 0 R 88 0 R]>>
+<</Type/StructElem/S/Span/P 90 0 R/A[<</O/Layout/Placement/Block>>]/K[45 46]/Pg 362 0 R>>
 endobj
 90 0 obj
-<</Type/StructElem/S/Div/P 293 0 R/K[55 0 R 89 0 R]>>
+<</Type/StructElem/S/Div/P 91 0 R/K[89 0 R]>>
 endobj
 91 0 obj
-<</Type/StructElem/S/Figure/P 92 0 R/A[<</O/Layout/Placement/Block>>]/K[50]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 102 0 R/K[88 0 R 90 0 R]>>
 endobj
 92 0 obj
-<</Type/StructElem/S/Div/P 133 0 R/K[91 0 R]>>
+<</Type/StructElem/S/Span/P 93 0 R/A[<</O/Layout/Placement/Block>>]/K[47]/Pg 362 0 R>>
 endobj
 93 0 obj
-<</Type/StructElem/S/P/P 132 0 R/K[51]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 96 0 R/K[92 0 R]>>
 endobj
 94 0 obj
-<</Type/StructElem/S/P/P 132 0 R/K[52]/Pg 321 0 R>>
+<</Type/StructElem/S/Span/P 95 0 R/A[<</O/Layout/Placement/Block>>]/K[48 49]/Pg 362 0 R>>
 endobj
 95 0 obj
-<</Type/StructElem/S/Span/P 96 0 R/A[<</O/Layout/Placement/Block>>]/K[53]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 96 0 R/K[94 0 R]>>
 endobj
 96 0 obj
-<</Type/StructElem/S/Div/P 101 0 R/K[95 0 R]>>
+<</Type/StructElem/S/Div/P 102 0 R/K[93 0 R 95 0 R]>>
 endobj
 97 0 obj
-<</Type/StructElem/S/Span/P 98 0 R/A[<</O/Layout/Placement/Block>>]/K[54]/Pg 321 0 R>>
+<</Type/StructElem/S/Span/P 98 0 R/A[<</O/Layout/Placement/Block>>]/K[50]/Pg 362 0 R>>
 endobj
 98 0 obj
 <</Type/StructElem/S/Div/P 101 0 R/K[97 0 R]>>
 endobj
 99 0 obj
-<</Type/StructElem/S/Span/P 100 0 R/A[<</O/Layout/Placement/Block>>]/K[55]/Pg 321 0 R>>
+<</Type/StructElem/S/Span/P 100 0 R/A[<</O/Layout/Placement/Block>>]/K[51 52]/Pg 362 0 R>>
 endobj
 100 0 obj
 <</Type/StructElem/S/Div/P 101 0 R/K[99 0 R]>>
 endobj
 101 0 obj
-<</Type/StructElem/S/Div/P 102 0 R/K[96 0 R 98 0 R 100 0 R]>>
+<</Type/StructElem/S/Div/P 102 0 R/K[98 0 R 100 0 R]>>
 endobj
 102 0 obj
-<</Type/StructElem/S/Div/P 105 0 R/K[101 0 R]>>
+<</Type/StructElem/S/Div/P 103 0 R/K[69 0 R 70 0 R 81 0 R 86 0 R 91 0 R 96 0 R 101 0 R]>>
 endobj
 103 0 obj
-<</Type/StructElem/S/Span/P 104 0 R/A[<</O/Layout/Placement/Block>>]/K[56]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 334 0 R/K[64 0 R 102 0 R]>>
 endobj
 104 0 obj
-<</Type/StructElem/S/Div/P 105 0 R/K[103 0 R]>>
+<</Type/StructElem/S/Figure/P 105 0 R/A[<</O/Layout/Placement/Block>>]/K[53]/Pg 362 0 R>>
 endobj
 105 0 obj
-<</Type/StructElem/S/Div/P 132 0 R/K[102 0 R 104 0 R]>>
+<</Type/StructElem/S/Div/P 150 0 R/K[104 0 R]>>
 endobj
 106 0 obj
-<</Type/StructElem/S/P/P 132 0 R/K[57 58]/Pg 321 0 R>>
+<</Type/StructElem/S/Span/P 107 0 R/A[<</O/Layout/Placement/Block>>]/K[54]/Pg 362 0 R>>
 endobj
 107 0 obj
-<</Type/StructElem/S/Figure/P 108 0 R/A[<</O/Layout/Placement/Block>>]/K[59]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 110 0 R/K[106 0 R]>>
 endobj
 108 0 obj
-<</Type/StructElem/S/Div/P 111 0 R/K[107 0 R]>>
+<</Type/StructElem/S/Span/P 109 0 R/A[<</O/Layout/Placement/Block>>]/K[55]/Pg 362 0 R>>
 endobj
 109 0 obj
-<</Type/StructElem/S/Span/P 110 0 R/A[<</O/Layout/Placement/Block>>]/K[60 61 62 63]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 110 0 R/K[108 0 R]>>
 endobj
 110 0 obj
-<</Type/StructElem/S/Div/P 111 0 R/K[109 0 R]>>
+<</Type/StructElem/S/Div/P 149 0 R/K[107 0 R 109 0 R]>>
 endobj
 111 0 obj
-<</Type/StructElem/S/Div/P 132 0 R/K[108 0 R 110 0 R]>>
+<</Type/StructElem/S/P/P 149 0 R/K[56]/Pg 362 0 R>>
 endobj
 112 0 obj
-<</Type/StructElem/S/Figure/P 113 0 R/A[<</O/Layout/Placement/Block>>]/K[64]/Pg 321 0 R>>
+<</Type/StructElem/S/Span/P 113 0 R/A[<</O/Layout/Placement/Block>>]/K[57]/Pg 362 0 R>>
 endobj
 113 0 obj
-<</Type/StructElem/S/Div/P 116 0 R/K[112 0 R]>>
+<</Type/StructElem/S/Div/P 118 0 R/K[112 0 R]>>
 endobj
 114 0 obj
-<</Type/StructElem/S/Span/P 115 0 R/A[<</O/Layout/Placement/Block>>]/K[65 66 67 68]/Pg 321 0 R>>
+<</Type/StructElem/S/Span/P 115 0 R/A[<</O/Layout/Placement/Block>>]/K[58]/Pg 362 0 R>>
 endobj
 115 0 obj
-<</Type/StructElem/S/Div/P 116 0 R/K[114 0 R]>>
+<</Type/StructElem/S/Div/P 118 0 R/K[114 0 R]>>
 endobj
 116 0 obj
-<</Type/StructElem/S/Div/P 132 0 R/K[113 0 R 115 0 R]>>
+<</Type/StructElem/S/Span/P 117 0 R/A[<</O/Layout/Placement/Block>>]/K[59]/Pg 362 0 R>>
 endobj
 117 0 obj
-<</Type/StructElem/S/Figure/P 118 0 R/A[<</O/Layout/Placement/Block>>]/K[69]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 118 0 R/K[116 0 R]>>
 endobj
 118 0 obj
-<</Type/StructElem/S/Div/P 121 0 R/K[117 0 R]>>
+<</Type/StructElem/S/Div/P 119 0 R/K[113 0 R 115 0 R 117 0 R]>>
 endobj
 119 0 obj
-<</Type/StructElem/S/Span/P 120 0 R/A[<</O/Layout/Placement/Block>>]/K[70 71 72 73]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 122 0 R/K[118 0 R]>>
 endobj
 120 0 obj
-<</Type/StructElem/S/Div/P 121 0 R/K[119 0 R]>>
+<</Type/StructElem/S/Span/P 121 0 R/A[<</O/Layout/Placement/Block>>]/K[60]/Pg 362 0 R>>
 endobj
 121 0 obj
-<</Type/StructElem/S/Div/P 132 0 R/K[118 0 R 120 0 R]>>
+<</Type/StructElem/S/Div/P 122 0 R/K[120 0 R]>>
 endobj
 122 0 obj
-<</Type/StructElem/S/Figure/P 123 0 R/A[<</O/Layout/Placement/Block>>]/K[74]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 149 0 R/K[119 0 R 121 0 R]>>
 endobj
 123 0 obj
-<</Type/StructElem/S/Div/P 126 0 R/K[122 0 R]>>
+<</Type/StructElem/S/P/P 149 0 R/K[61 62]/Pg 362 0 R>>
 endobj
 124 0 obj
-<</Type/StructElem/S/Span/P 125 0 R/A[<</O/Layout/Placement/Block>>]/K[75 76 77 78]/Pg 321 0 R>>
+<</Type/StructElem/S/Figure/P 125 0 R/A[<</O/Layout/Placement/Block>>]/K[63]/Pg 362 0 R>>
 endobj
 125 0 obj
-<</Type/StructElem/S/Div/P 126 0 R/K[124 0 R]>>
+<</Type/StructElem/S/Div/P 128 0 R/K[124 0 R]>>
 endobj
 126 0 obj
-<</Type/StructElem/S/Div/P 132 0 R/K[123 0 R 125 0 R]>>
+<</Type/StructElem/S/Span/P 127 0 R/A[<</O/Layout/Placement/Block>>]/K[64 65 66 67]/Pg 362 0 R>>
 endobj
 127 0 obj
-<</Type/StructElem/S/Figure/P 128 0 R/A[<</O/Layout/Placement/Block>>]/K[79]/Pg 321 0 R>>
+<</Type/StructElem/S/Div/P 128 0 R/K[126 0 R]>>
 endobj
 128 0 obj
-<</Type/StructElem/S/Div/P 131 0 R/K[127 0 R]>>
+<</Type/StructElem/S/Div/P 149 0 R/K[125 0 R 127 0 R]>>
 endobj
 129 0 obj
-<</Type/StructElem/S/Span/P 130 0 R/A[<</O/Layout/Placement/Block>>]/K[80 81 82 83]/Pg 321 0 R>>
+<</Type/StructElem/S/Figure/P 130 0 R/A[<</O/Layout/Placement/Block>>]/K[68]/Pg 362 0 R>>
 endobj
 130 0 obj
-<</Type/StructElem/S/Div/P 131 0 R/K[129 0 R]>>
+<</Type/StructElem/S/Div/P 133 0 R/K[129 0 R]>>
 endobj
 131 0 obj
-<</Type/StructElem/S/Div/P 132 0 R/K[128 0 R 130 0 R]>>
+<</Type/StructElem/S/Span/P 132 0 R/A[<</O/Layout/Placement/Block>>]/K[69 70 71 72]/Pg 362 0 R>>
 endobj
 132 0 obj
-<</Type/StructElem/S/Div/P 133 0 R/K[93 0 R 94 0 R 105 0 R 106 0 R 111 0 R 116 0 R 121 0 R 126 0 R 131 0 R]>>
+<</Type/StructElem/S/Div/P 133 0 R/K[131 0 R]>>
 endobj
 133 0 obj
-<</Type/StructElem/S/Div/P 293 0 R/K[92 0 R 132 0 R]>>
+<</Type/StructElem/S/Div/P 149 0 R/K[130 0 R 132 0 R]>>
 endobj
 134 0 obj
-<</Type/StructElem/S/Figure/P 135 0 R/A[<</O/Layout/Placement/Block>>]/K[0]/Pg 322 0 R>>
+<</Type/StructElem/S/Figure/P 135 0 R/A[<</O/Layout/Placement/Block>>]/K[73]/Pg 362 0 R>>
 endobj
 135 0 obj
-<</Type/StructElem/S/Div/P 160 0 R/K[134 0 R]>>
+<</Type/StructElem/S/Div/P 138 0 R/K[134 0 R]>>
 endobj
 136 0 obj
-<</Type/StructElem/S/P/P 159 0 R/K[1]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 137 0 R/A[<</O/Layout/Placement/Block>>]/K[74 75 76]/Pg 362 0 R>>
 endobj
 137 0 obj
-<</Type/StructElem/S/P/P 159 0 R/K[2]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 138 0 R/K[136 0 R]>>
 endobj
 138 0 obj
-<</Type/StructElem/S/Span/P 139 0 R/A[<</O/Layout/Placement/Block>>]/K[3]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 149 0 R/K[135 0 R 137 0 R]>>
 endobj
 139 0 obj
-<</Type/StructElem/S/Div/P 144 0 R/K[138 0 R]>>
+<</Type/StructElem/S/Figure/P 140 0 R/A[<</O/Layout/Placement/Block>>]/K[77]/Pg 362 0 R>>
 endobj
 140 0 obj
-<</Type/StructElem/S/Span/P 141 0 R/A[<</O/Layout/Placement/Block>>]/K[4]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 143 0 R/K[139 0 R]>>
 endobj
 141 0 obj
-<</Type/StructElem/S/Div/P 144 0 R/K[140 0 R]>>
+<</Type/StructElem/S/Span/P 142 0 R/A[<</O/Layout/Placement/Block>>]/K[78 79 80 81]/Pg 362 0 R>>
 endobj
 142 0 obj
-<</Type/StructElem/S/Span/P 143 0 R/A[<</O/Layout/Placement/Block>>]/K[5]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 143 0 R/K[141 0 R]>>
 endobj
 143 0 obj
-<</Type/StructElem/S/Div/P 144 0 R/K[142 0 R]>>
+<</Type/StructElem/S/Div/P 149 0 R/K[140 0 R 142 0 R]>>
 endobj
 144 0 obj
-<</Type/StructElem/S/Div/P 145 0 R/K[139 0 R 141 0 R 143 0 R]>>
+<</Type/StructElem/S/Figure/P 145 0 R/A[<</O/Layout/Placement/Block>>]/K[82]/Pg 362 0 R>>
 endobj
 145 0 obj
 <</Type/StructElem/S/Div/P 148 0 R/K[144 0 R]>>
 endobj
 146 0 obj
-<</Type/StructElem/S/Span/P 147 0 R/A[<</O/Layout/Placement/Block>>]/K[6]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 147 0 R/A[<</O/Layout/Placement/Block>>]/K[83 84 85 86]/Pg 362 0 R>>
 endobj
 147 0 obj
 <</Type/StructElem/S/Div/P 148 0 R/K[146 0 R]>>
 endobj
 148 0 obj
-<</Type/StructElem/S/Div/P 159 0 R/K[145 0 R 147 0 R]>>
+<</Type/StructElem/S/Div/P 149 0 R/K[145 0 R 147 0 R]>>
 endobj
 149 0 obj
-<</Type/StructElem/S/Span/P 150 0 R/A[<</O/Layout/Placement/Block>>]/K[7]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 150 0 R/K[110 0 R 111 0 R 122 0 R 123 0 R 128 0 R 133 0 R 138 0 R 143 0 R 148 0 R]>>
 endobj
 150 0 obj
-<</Type/StructElem/S/Div/P 153 0 R/K[149 0 R]>>
+<</Type/StructElem/S/Div/P 334 0 R/K[105 0 R 149 0 R]>>
 endobj
 151 0 obj
-<</Type/StructElem/S/Span/P 152 0 R/A[<</O/Layout/Placement/Block>>]/K[8 9]/Pg 322 0 R>>
+<</Type/StructElem/S/Figure/P 152 0 R/A[<</O/Layout/Placement/Block>>]/K[0]/Pg 363 0 R>>
 endobj
 152 0 obj
-<</Type/StructElem/S/Div/P 153 0 R/K[151 0 R]>>
+<</Type/StructElem/S/Div/P 181 0 R/K[151 0 R]>>
 endobj
 153 0 obj
-<</Type/StructElem/S/Div/P 159 0 R/K[150 0 R 152 0 R]>>
+<</Type/StructElem/S/Span/P 154 0 R/A[<</O/Layout/Placement/Block>>]/K[1]/Pg 363 0 R>>
 endobj
 154 0 obj
-<</Type/StructElem/S/Span/P 155 0 R/A[<</O/Layout/Placement/Block>>]/K[10]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 157 0 R/K[153 0 R]>>
 endobj
 155 0 obj
-<</Type/StructElem/S/Div/P 158 0 R/K[154 0 R]>>
+<</Type/StructElem/S/Span/P 156 0 R/A[<</O/Layout/Placement/Block>>]/K[2]/Pg 363 0 R>>
 endobj
 156 0 obj
-<</Type/StructElem/S/Span/P 157 0 R/A[<</O/Layout/Placement/Block>>]/K[11 12]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 157 0 R/K[155 0 R]>>
 endobj
 157 0 obj
-<</Type/StructElem/S/Div/P 158 0 R/K[156 0 R]>>
+<</Type/StructElem/S/Div/P 180 0 R/K[154 0 R 156 0 R]>>
 endobj
 158 0 obj
-<</Type/StructElem/S/Div/P 159 0 R/K[155 0 R 157 0 R]>>
+<</Type/StructElem/S/P/P 180 0 R/K[3]/Pg 363 0 R>>
 endobj
 159 0 obj
-<</Type/StructElem/S/Div/P 160 0 R/K[136 0 R 137 0 R 148 0 R 153 0 R 158 0 R]>>
+<</Type/StructElem/S/Span/P 160 0 R/A[<</O/Layout/Placement/Block>>]/K[4]/Pg 363 0 R>>
 endobj
 160 0 obj
-<</Type/StructElem/S/Div/P 293 0 R/K[135 0 R 159 0 R]>>
+<</Type/StructElem/S/Div/P 165 0 R/K[159 0 R]>>
 endobj
 161 0 obj
-<</Type/StructElem/S/Figure/P 162 0 R/A[<</O/Layout/Placement/Block>>]/K[13]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 162 0 R/A[<</O/Layout/Placement/Block>>]/K[5]/Pg 363 0 R>>
 endobj
 162 0 obj
-<</Type/StructElem/S/Div/P 185 0 R/K[161 0 R]>>
+<</Type/StructElem/S/Div/P 165 0 R/K[161 0 R]>>
 endobj
 163 0 obj
-<</Type/StructElem/S/P/P 184 0 R/K[14]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 164 0 R/A[<</O/Layout/Placement/Block>>]/K[6]/Pg 363 0 R>>
 endobj
 164 0 obj
-<</Type/StructElem/S/P/P 184 0 R/K[15]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 165 0 R/K[163 0 R]>>
 endobj
 165 0 obj
-<</Type/StructElem/S/Span/P 166 0 R/A[<</O/Layout/Placement/Block>>]/K[16]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 166 0 R/K[160 0 R 162 0 R 164 0 R]>>
 endobj
 166 0 obj
 <</Type/StructElem/S/Div/P 169 0 R/K[165 0 R]>>
 endobj
 167 0 obj
-<</Type/StructElem/S/Span/P 168 0 R/A[<</O/Layout/Placement/Block>>]/K[17]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 168 0 R/A[<</O/Layout/Placement/Block>>]/K[7]/Pg 363 0 R>>
 endobj
 168 0 obj
 <</Type/StructElem/S/Div/P 169 0 R/K[167 0 R]>>
 endobj
 169 0 obj
-<</Type/StructElem/S/Div/P 170 0 R/K[166 0 R 168 0 R]>>
+<</Type/StructElem/S/Div/P 180 0 R/K[166 0 R 168 0 R]>>
 endobj
 170 0 obj
-<</Type/StructElem/S/Div/P 173 0 R/K[169 0 R]>>
+<</Type/StructElem/S/Span/P 171 0 R/A[<</O/Layout/Placement/Block>>]/K[8]/Pg 363 0 R>>
 endobj
 171 0 obj
-<</Type/StructElem/S/Span/P 172 0 R/A[<</O/Layout/Placement/Block>>]/K[18]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 174 0 R/K[170 0 R]>>
 endobj
 172 0 obj
-<</Type/StructElem/S/Div/P 173 0 R/K[171 0 R]>>
+<</Type/StructElem/S/Span/P 173 0 R/A[<</O/Layout/Placement/Block>>]/K[9 10]/Pg 363 0 R>>
 endobj
 173 0 obj
-<</Type/StructElem/S/Div/P 184 0 R/K[170 0 R 172 0 R]>>
+<</Type/StructElem/S/Div/P 174 0 R/K[172 0 R]>>
 endobj
 174 0 obj
-<</Type/StructElem/S/Span/P 175 0 R/A[<</O/Layout/Placement/Block>>]/K[19]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 180 0 R/K[171 0 R 173 0 R]>>
 endobj
 175 0 obj
-<</Type/StructElem/S/Div/P 178 0 R/K[174 0 R]>>
+<</Type/StructElem/S/Span/P 176 0 R/A[<</O/Layout/Placement/Block>>]/K[11]/Pg 363 0 R>>
 endobj
 176 0 obj
-<</Type/StructElem/S/Span/P 177 0 R/A[<</O/Layout/Placement/Block>>]/K[20 21]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 179 0 R/K[175 0 R]>>
 endobj
 177 0 obj
-<</Type/StructElem/S/Div/P 178 0 R/K[176 0 R]>>
+<</Type/StructElem/S/Span/P 178 0 R/A[<</O/Layout/Placement/Block>>]/K[12 13]/Pg 363 0 R>>
 endobj
 178 0 obj
-<</Type/StructElem/S/Div/P 184 0 R/K[175 0 R 177 0 R]>>
+<</Type/StructElem/S/Div/P 179 0 R/K[177 0 R]>>
 endobj
 179 0 obj
-<</Type/StructElem/S/Span/P 180 0 R/A[<</O/Layout/Placement/Block>>]/K[22]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 180 0 R/K[176 0 R 178 0 R]>>
 endobj
 180 0 obj
-<</Type/StructElem/S/Div/P 183 0 R/K[179 0 R]>>
+<</Type/StructElem/S/Div/P 181 0 R/K[157 0 R 158 0 R 169 0 R 174 0 R 179 0 R]>>
 endobj
 181 0 obj
-<</Type/StructElem/S/Span/P 182 0 R/A[<</O/Layout/Placement/Block>>]/K[23 24]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 334 0 R/K[152 0 R 180 0 R]>>
 endobj
 182 0 obj
-<</Type/StructElem/S/Div/P 183 0 R/K[181 0 R]>>
+<</Type/StructElem/S/Figure/P 183 0 R/A[<</O/Layout/Placement/Block>>]/K[14]/Pg 363 0 R>>
 endobj
 183 0 obj
-<</Type/StructElem/S/Div/P 184 0 R/K[180 0 R 182 0 R]>>
+<</Type/StructElem/S/Div/P 212 0 R/K[182 0 R]>>
 endobj
 184 0 obj
-<</Type/StructElem/S/Div/P 185 0 R/K[163 0 R 164 0 R 173 0 R 178 0 R 183 0 R]>>
+<</Type/StructElem/S/Span/P 185 0 R/A[<</O/Layout/Placement/Block>>]/K[15]/Pg 363 0 R>>
 endobj
 185 0 obj
-<</Type/StructElem/S/Div/P 293 0 R/K[162 0 R 184 0 R]>>
+<</Type/StructElem/S/Div/P 188 0 R/K[184 0 R]>>
 endobj
 186 0 obj
-<</Type/StructElem/S/Figure/P 187 0 R/A[<</O/Layout/Placement/Block>>]/K[25]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 187 0 R/A[<</O/Layout/Placement/Block>>]/K[16]/Pg 363 0 R>>
 endobj
 187 0 obj
-<</Type/StructElem/S/Div/P 210 0 R/K[186 0 R]>>
+<</Type/StructElem/S/Div/P 188 0 R/K[186 0 R]>>
 endobj
 188 0 obj
-<</Type/StructElem/S/P/P 209 0 R/K[26]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 211 0 R/K[185 0 R 187 0 R]>>
 endobj
 189 0 obj
-<</Type/StructElem/S/P/P 209 0 R/K[27]/Pg 322 0 R>>
+<</Type/StructElem/S/P/P 211 0 R/K[17]/Pg 363 0 R>>
 endobj
 190 0 obj
-<</Type/StructElem/S/Span/P 191 0 R/A[<</O/Layout/Placement/Block>>]/K[28]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 191 0 R/A[<</O/Layout/Placement/Block>>]/K[18]/Pg 363 0 R>>
 endobj
 191 0 obj
-<</Type/StructElem/S/Div/P 194 0 R/K[190 0 R]>>
+<</Type/StructElem/S/Div/P 196 0 R/K[190 0 R]>>
 endobj
 192 0 obj
-<</Type/StructElem/S/Span/P 193 0 R/A[<</O/Layout/Placement/Block>>]/K[29]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 193 0 R/A[<</O/Layout/Placement/Block>>]/K[19]/Pg 363 0 R>>
 endobj
 193 0 obj
-<</Type/StructElem/S/Div/P 194 0 R/K[192 0 R]>>
+<</Type/StructElem/S/Div/P 196 0 R/K[192 0 R]>>
 endobj
 194 0 obj
-<</Type/StructElem/S/Div/P 195 0 R/K[191 0 R 193 0 R]>>
+<</Type/StructElem/S/Span/P 195 0 R/A[<</O/Layout/Placement/Block>>]/K[20]/Pg 363 0 R>>
 endobj
 195 0 obj
-<</Type/StructElem/S/Div/P 198 0 R/K[194 0 R]>>
+<</Type/StructElem/S/Div/P 196 0 R/K[194 0 R]>>
 endobj
 196 0 obj
-<</Type/StructElem/S/Span/P 197 0 R/A[<</O/Layout/Placement/Block>>]/K[30]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 197 0 R/K[191 0 R 193 0 R 195 0 R]>>
 endobj
 197 0 obj
-<</Type/StructElem/S/Div/P 198 0 R/K[196 0 R]>>
+<</Type/StructElem/S/Div/P 200 0 R/K[196 0 R]>>
 endobj
 198 0 obj
-<</Type/StructElem/S/Div/P 209 0 R/K[195 0 R 197 0 R]>>
+<</Type/StructElem/S/Span/P 199 0 R/A[<</O/Layout/Placement/Block>>]/K[21]/Pg 363 0 R>>
 endobj
 199 0 obj
-<</Type/StructElem/S/Span/P 200 0 R/A[<</O/Layout/Placement/Block>>]/K[31]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 200 0 R/K[198 0 R]>>
 endobj
 200 0 obj
-<</Type/StructElem/S/Div/P 203 0 R/K[199 0 R]>>
+<</Type/StructElem/S/Div/P 211 0 R/K[197 0 R 199 0 R]>>
 endobj
 201 0 obj
-<</Type/StructElem/S/Span/P 202 0 R/A[<</O/Layout/Placement/Block>>]/K[32 33]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 202 0 R/A[<</O/Layout/Placement/Block>>]/K[22]/Pg 363 0 R>>
 endobj
 202 0 obj
-<</Type/StructElem/S/Div/P 203 0 R/K[201 0 R]>>
+<</Type/StructElem/S/Div/P 205 0 R/K[201 0 R]>>
 endobj
 203 0 obj
-<</Type/StructElem/S/Div/P 209 0 R/K[200 0 R 202 0 R]>>
+<</Type/StructElem/S/Span/P 204 0 R/A[<</O/Layout/Placement/Block>>]/K[23 24]/Pg 363 0 R>>
 endobj
 204 0 obj
-<</Type/StructElem/S/Span/P 205 0 R/A[<</O/Layout/Placement/Block>>]/K[34]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 205 0 R/K[203 0 R]>>
 endobj
 205 0 obj
-<</Type/StructElem/S/Div/P 208 0 R/K[204 0 R]>>
+<</Type/StructElem/S/Div/P 211 0 R/K[202 0 R 204 0 R]>>
 endobj
 206 0 obj
-<</Type/StructElem/S/Span/P 207 0 R/A[<</O/Layout/Placement/Block>>]/K[35]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 207 0 R/A[<</O/Layout/Placement/Block>>]/K[25]/Pg 363 0 R>>
 endobj
 207 0 obj
-<</Type/StructElem/S/Div/P 208 0 R/K[206 0 R]>>
+<</Type/StructElem/S/Div/P 210 0 R/K[206 0 R]>>
 endobj
 208 0 obj
-<</Type/StructElem/S/Div/P 209 0 R/K[205 0 R 207 0 R]>>
+<</Type/StructElem/S/Span/P 209 0 R/A[<</O/Layout/Placement/Block>>]/K[26 27]/Pg 363 0 R>>
 endobj
 209 0 obj
-<</Type/StructElem/S/Div/P 210 0 R/K[188 0 R 189 0 R 198 0 R 203 0 R 208 0 R]>>
+<</Type/StructElem/S/Div/P 210 0 R/K[208 0 R]>>
 endobj
 210 0 obj
-<</Type/StructElem/S/Div/P 293 0 R/K[187 0 R 209 0 R]>>
+<</Type/StructElem/S/Div/P 211 0 R/K[207 0 R 209 0 R]>>
 endobj
 211 0 obj
-<</Type/StructElem/S/Figure/P 212 0 R/A[<</O/Layout/Placement/Block>>]/K[36]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 212 0 R/K[188 0 R 189 0 R 200 0 R 205 0 R 210 0 R]>>
 endobj
 212 0 obj
-<</Type/StructElem/S/Div/P 240 0 R/K[211 0 R]>>
+<</Type/StructElem/S/Div/P 334 0 R/K[183 0 R 211 0 R]>>
 endobj
 213 0 obj
-<</Type/StructElem/S/P/P 239 0 R/K[37]/Pg 322 0 R>>
+<</Type/StructElem/S/Figure/P 214 0 R/A[<</O/Layout/Placement/Block>>]/K[28]/Pg 363 0 R>>
 endobj
 214 0 obj
-<</Type/StructElem/S/P/P 239 0 R/K[38]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 241 0 R/K[213 0 R]>>
 endobj
 215 0 obj
-<</Type/StructElem/S/Span/P 216 0 R/A[<</O/Layout/Placement/Block>>]/K[39]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 216 0 R/A[<</O/Layout/Placement/Block>>]/K[29]/Pg 363 0 R>>
 endobj
 216 0 obj
 <</Type/StructElem/S/Div/P 219 0 R/K[215 0 R]>>
 endobj
 217 0 obj
-<</Type/StructElem/S/Span/P 218 0 R/A[<</O/Layout/Placement/Block>>]/K[40]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 218 0 R/A[<</O/Layout/Placement/Block>>]/K[30]/Pg 363 0 R>>
 endobj
 218 0 obj
 <</Type/StructElem/S/Div/P 219 0 R/K[217 0 R]>>
 endobj
 219 0 obj
-<</Type/StructElem/S/Div/P 220 0 R/K[216 0 R 218 0 R]>>
+<</Type/StructElem/S/Div/P 240 0 R/K[216 0 R 218 0 R]>>
 endobj
 220 0 obj
-<</Type/StructElem/S/Div/P 223 0 R/K[219 0 R]>>
+<</Type/StructElem/S/P/P 240 0 R/K[31]/Pg 363 0 R>>
 endobj
 221 0 obj
-<</Type/StructElem/S/Span/P 222 0 R/A[<</O/Layout/Placement/Block>>]/K[41]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 222 0 R/A[<</O/Layout/Placement/Block>>]/K[32]/Pg 363 0 R>>
 endobj
 222 0 obj
-<</Type/StructElem/S/Div/P 223 0 R/K[221 0 R]>>
+<</Type/StructElem/S/Div/P 225 0 R/K[221 0 R]>>
 endobj
 223 0 obj
-<</Type/StructElem/S/Div/P 239 0 R/K[220 0 R 222 0 R]>>
+<</Type/StructElem/S/Span/P 224 0 R/A[<</O/Layout/Placement/Block>>]/K[33]/Pg 363 0 R>>
 endobj
 224 0 obj
-<</Type/StructElem/S/Span/P 225 0 R/A[<</O/Layout/Placement/Block>>]/K[42]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 225 0 R/K[223 0 R]>>
 endobj
 225 0 obj
-<</Type/StructElem/S/Div/P 228 0 R/K[224 0 R]>>
+<</Type/StructElem/S/Div/P 226 0 R/K[222 0 R 224 0 R]>>
 endobj
 226 0 obj
-<</Type/StructElem/S/Span/P 227 0 R/A[<</O/Layout/Placement/Block>>]/K[43 44]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 229 0 R/K[225 0 R]>>
 endobj
 227 0 obj
-<</Type/StructElem/S/Div/P 228 0 R/K[226 0 R]>>
+<</Type/StructElem/S/Span/P 228 0 R/A[<</O/Layout/Placement/Block>>]/K[34]/Pg 363 0 R>>
 endobj
 228 0 obj
-<</Type/StructElem/S/Div/P 239 0 R/K[225 0 R 227 0 R]>>
+<</Type/StructElem/S/Div/P 229 0 R/K[227 0 R]>>
 endobj
 229 0 obj
-<</Type/StructElem/S/Span/P 230 0 R/A[<</O/Layout/Placement/Block>>]/K[45]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 240 0 R/K[226 0 R 228 0 R]>>
 endobj
 230 0 obj
-<</Type/StructElem/S/Div/P 233 0 R/K[229 0 R]>>
+<</Type/StructElem/S/Span/P 231 0 R/A[<</O/Layout/Placement/Block>>]/K[35]/Pg 363 0 R>>
 endobj
 231 0 obj
-<</Type/StructElem/S/Span/P 232 0 R/A[<</O/Layout/Placement/Block>>]/K[46 47 48]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 234 0 R/K[230 0 R]>>
 endobj
 232 0 obj
-<</Type/StructElem/S/Div/P 233 0 R/K[231 0 R]>>
+<</Type/StructElem/S/Span/P 233 0 R/A[<</O/Layout/Placement/Block>>]/K[36 37]/Pg 363 0 R>>
 endobj
 233 0 obj
-<</Type/StructElem/S/Div/P 239 0 R/K[230 0 R 232 0 R]>>
+<</Type/StructElem/S/Div/P 234 0 R/K[232 0 R]>>
 endobj
 234 0 obj
-<</Type/StructElem/S/Span/P 235 0 R/A[<</O/Layout/Placement/Block>>]/K[49]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 240 0 R/K[231 0 R 233 0 R]>>
 endobj
 235 0 obj
-<</Type/StructElem/S/Div/P 238 0 R/K[234 0 R]>>
+<</Type/StructElem/S/Span/P 236 0 R/A[<</O/Layout/Placement/Block>>]/K[38]/Pg 363 0 R>>
 endobj
 236 0 obj
-<</Type/StructElem/S/Span/P 237 0 R/A[<</O/Layout/Placement/Block>>]/K[50]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 239 0 R/K[235 0 R]>>
 endobj
 237 0 obj
-<</Type/StructElem/S/Div/P 238 0 R/K[236 0 R]>>
+<</Type/StructElem/S/Span/P 238 0 R/A[<</O/Layout/Placement/Block>>]/K[39]/Pg 363 0 R>>
 endobj
 238 0 obj
-<</Type/StructElem/S/Div/P 239 0 R/K[235 0 R 237 0 R]>>
+<</Type/StructElem/S/Div/P 239 0 R/K[237 0 R]>>
 endobj
 239 0 obj
-<</Type/StructElem/S/Div/P 240 0 R/K[213 0 R 214 0 R 223 0 R 228 0 R 233 0 R 238 0 R]>>
+<</Type/StructElem/S/Div/P 240 0 R/K[236 0 R 238 0 R]>>
 endobj
 240 0 obj
-<</Type/StructElem/S/Div/P 293 0 R/K[212 0 R 239 0 R]>>
+<</Type/StructElem/S/Div/P 241 0 R/K[219 0 R 220 0 R 229 0 R 234 0 R 239 0 R]>>
 endobj
 241 0 obj
-<</Type/StructElem/S/Figure/P 242 0 R/A[<</O/Layout/Placement/Block>>]/K[51]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 334 0 R/K[214 0 R 240 0 R]>>
 endobj
 242 0 obj
-<</Type/StructElem/S/Div/P 265 0 R/K[241 0 R]>>
+<</Type/StructElem/S/Figure/P 243 0 R/A[<</O/Layout/Placement/Block>>]/K[40]/Pg 363 0 R>>
 endobj
 243 0 obj
-<</Type/StructElem/S/P/P 264 0 R/K[52]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 275 0 R/K[242 0 R]>>
 endobj
 244 0 obj
-<</Type/StructElem/S/P/P 264 0 R/K[53]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 245 0 R/A[<</O/Layout/Placement/Block>>]/K[41]/Pg 363 0 R>>
 endobj
 245 0 obj
-<</Type/StructElem/S/Span/P 246 0 R/A[<</O/Layout/Placement/Block>>]/K[54]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 248 0 R/K[244 0 R]>>
 endobj
 246 0 obj
-<</Type/StructElem/S/Div/P 249 0 R/K[245 0 R]>>
+<</Type/StructElem/S/Span/P 247 0 R/A[<</O/Layout/Placement/Block>>]/K[42]/Pg 363 0 R>>
 endobj
 247 0 obj
-<</Type/StructElem/S/Span/P 248 0 R/A[<</O/Layout/Placement/Block>>]/K[55]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 248 0 R/K[246 0 R]>>
 endobj
 248 0 obj
-<</Type/StructElem/S/Div/P 249 0 R/K[247 0 R]>>
+<</Type/StructElem/S/Div/P 274 0 R/K[245 0 R 247 0 R]>>
 endobj
 249 0 obj
-<</Type/StructElem/S/Div/P 250 0 R/K[246 0 R 248 0 R]>>
+<</Type/StructElem/S/P/P 274 0 R/K[43]/Pg 363 0 R>>
 endobj
 250 0 obj
-<</Type/StructElem/S/Div/P 253 0 R/K[249 0 R]>>
+<</Type/StructElem/S/Span/P 251 0 R/A[<</O/Layout/Placement/Block>>]/K[44]/Pg 363 0 R>>
 endobj
 251 0 obj
-<</Type/StructElem/S/Span/P 252 0 R/A[<</O/Layout/Placement/Block>>]/K[56]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 254 0 R/K[250 0 R]>>
 endobj
 252 0 obj
-<</Type/StructElem/S/Div/P 253 0 R/K[251 0 R]>>
+<</Type/StructElem/S/Span/P 253 0 R/A[<</O/Layout/Placement/Block>>]/K[45]/Pg 363 0 R>>
 endobj
 253 0 obj
-<</Type/StructElem/S/Div/P 264 0 R/K[250 0 R 252 0 R]>>
+<</Type/StructElem/S/Div/P 254 0 R/K[252 0 R]>>
 endobj
 254 0 obj
-<</Type/StructElem/S/Span/P 255 0 R/A[<</O/Layout/Placement/Block>>]/K[57]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 255 0 R/K[251 0 R 253 0 R]>>
 endobj
 255 0 obj
 <</Type/StructElem/S/Div/P 258 0 R/K[254 0 R]>>
 endobj
 256 0 obj
-<</Type/StructElem/S/Span/P 257 0 R/A[<</O/Layout/Placement/Block>>]/K[58 59]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 257 0 R/A[<</O/Layout/Placement/Block>>]/K[46]/Pg 363 0 R>>
 endobj
 257 0 obj
 <</Type/StructElem/S/Div/P 258 0 R/K[256 0 R]>>
 endobj
 258 0 obj
-<</Type/StructElem/S/Div/P 264 0 R/K[255 0 R 257 0 R]>>
+<</Type/StructElem/S/Div/P 274 0 R/K[255 0 R 257 0 R]>>
 endobj
 259 0 obj
-<</Type/StructElem/S/Span/P 260 0 R/A[<</O/Layout/Placement/Block>>]/K[60]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 260 0 R/A[<</O/Layout/Placement/Block>>]/K[47]/Pg 363 0 R>>
 endobj
 260 0 obj
 <</Type/StructElem/S/Div/P 263 0 R/K[259 0 R]>>
 endobj
 261 0 obj
-<</Type/StructElem/S/Span/P 262 0 R/A[<</O/Layout/Placement/Block>>]/K[61]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 262 0 R/A[<</O/Layout/Placement/Block>>]/K[48 49]/Pg 363 0 R>>
 endobj
 262 0 obj
 <</Type/StructElem/S/Div/P 263 0 R/K[261 0 R]>>
 endobj
 263 0 obj
-<</Type/StructElem/S/Div/P 264 0 R/K[260 0 R 262 0 R]>>
+<</Type/StructElem/S/Div/P 274 0 R/K[260 0 R 262 0 R]>>
 endobj
 264 0 obj
-<</Type/StructElem/S/Div/P 265 0 R/K[243 0 R 244 0 R 253 0 R 258 0 R 263 0 R]>>
+<</Type/StructElem/S/Span/P 265 0 R/A[<</O/Layout/Placement/Block>>]/K[50]/Pg 363 0 R>>
 endobj
 265 0 obj
-<</Type/StructElem/S/Div/P 293 0 R/K[242 0 R 264 0 R]>>
+<</Type/StructElem/S/Div/P 268 0 R/K[264 0 R]>>
 endobj
 266 0 obj
-<</Type/StructElem/S/P/P 293 0 R/K[62]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 267 0 R/A[<</O/Layout/Placement/Block>>]/K[51 52 53]/Pg 363 0 R>>
 endobj
 267 0 obj
-<</Type/StructElem/S/Figure/P 268 0 R/A[<</O/Layout/Placement/Block>>]/K[63]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 268 0 R/K[266 0 R]>>
 endobj
 268 0 obj
-<</Type/StructElem/S/Div/P 279 0 R/K[267 0 R]>>
+<</Type/StructElem/S/Div/P 274 0 R/K[265 0 R 267 0 R]>>
 endobj
 269 0 obj
-<</Type/StructElem/S/P/P 278 0 R/K[64]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 270 0 R/A[<</O/Layout/Placement/Block>>]/K[54]/Pg 363 0 R>>
 endobj
 270 0 obj
-<</Type/StructElem/S/P/P 278 0 R/K[65]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 273 0 R/K[269 0 R]>>
 endobj
 271 0 obj
-<</Type/StructElem/S/Span/P 272 0 R/A[<</O/Layout/Placement/Block>>]/K[66]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 272 0 R/A[<</O/Layout/Placement/Block>>]/K[55]/Pg 363 0 R>>
 endobj
 272 0 obj
 <</Type/StructElem/S/Div/P 273 0 R/K[271 0 R]>>
 endobj
 273 0 obj
-<</Type/StructElem/S/Div/P 274 0 R/K[272 0 R]>>
+<</Type/StructElem/S/Div/P 274 0 R/K[270 0 R 272 0 R]>>
 endobj
 274 0 obj
-<</Type/StructElem/S/Div/P 277 0 R/K[273 0 R]>>
+<</Type/StructElem/S/Div/P 275 0 R/K[248 0 R 249 0 R 258 0 R 263 0 R 268 0 R 273 0 R]>>
 endobj
 275 0 obj
-<</Type/StructElem/S/Span/P 276 0 R/A[<</O/Layout/Placement/Block>>]/K[67]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 334 0 R/K[243 0 R 274 0 R]>>
 endobj
 276 0 obj
-<</Type/StructElem/S/Div/P 277 0 R/K[275 0 R]>>
+<</Type/StructElem/S/Figure/P 277 0 R/A[<</O/Layout/Placement/Block>>]/K[56]/Pg 363 0 R>>
 endobj
 277 0 obj
-<</Type/StructElem/S/Div/P 278 0 R/K[274 0 R 276 0 R]>>
+<</Type/StructElem/S/Div/P 302 0 R/K[276 0 R]>>
 endobj
 278 0 obj
-<</Type/StructElem/S/Div/P 279 0 R/K[269 0 R 270 0 R 277 0 R]>>
+<</Type/StructElem/S/Span/P 279 0 R/A[<</O/Layout/Placement/Block>>]/K[57]/Pg 363 0 R>>
 endobj
 279 0 obj
-<</Type/StructElem/S/Div/P 293 0 R/K[268 0 R 278 0 R]>>
+<</Type/StructElem/S/Div/P 280 0 R/K[278 0 R]>>
 endobj
 280 0 obj
-<</Type/StructElem/S/Figure/P 281 0 R/A[<</O/Layout/Placement/Block>>]/K[68]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 301 0 R/K[279 0 R]>>
 endobj
 281 0 obj
-<</Type/StructElem/S/Div/P 292 0 R/K[280 0 R]>>
+<</Type/StructElem/S/P/P 301 0 R/K[58]/Pg 363 0 R>>
 endobj
 282 0 obj
-<</Type/StructElem/S/P/P 291 0 R/K[69]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 283 0 R/A[<</O/Layout/Placement/Block>>]/K[59]/Pg 363 0 R>>
 endobj
 283 0 obj
-<</Type/StructElem/S/P/P 291 0 R/K[70]/Pg 322 0 R>>
+<</Type/StructElem/S/Div/P 286 0 R/K[282 0 R]>>
 endobj
 284 0 obj
-<</Type/StructElem/S/Span/P 285 0 R/A[<</O/Layout/Placement/Block>>]/K[71]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 285 0 R/A[<</O/Layout/Placement/Block>>]/K[60]/Pg 363 0 R>>
 endobj
 285 0 obj
 <</Type/StructElem/S/Div/P 286 0 R/K[284 0 R]>>
 endobj
 286 0 obj
-<</Type/StructElem/S/Div/P 287 0 R/K[285 0 R]>>
+<</Type/StructElem/S/Div/P 287 0 R/K[283 0 R 285 0 R]>>
 endobj
 287 0 obj
 <</Type/StructElem/S/Div/P 290 0 R/K[286 0 R]>>
 endobj
 288 0 obj
-<</Type/StructElem/S/Span/P 289 0 R/A[<</O/Layout/Placement/Block>>]/K[72]/Pg 322 0 R>>
+<</Type/StructElem/S/Span/P 289 0 R/A[<</O/Layout/Placement/Block>>]/K[61]/Pg 363 0 R>>
 endobj
 289 0 obj
 <</Type/StructElem/S/Div/P 290 0 R/K[288 0 R]>>
 endobj
 290 0 obj
-<</Type/StructElem/S/Div/P 291 0 R/K[287 0 R 289 0 R]>>
+<</Type/StructElem/S/Div/P 301 0 R/K[287 0 R 289 0 R]>>
 endobj
 291 0 obj
-<</Type/StructElem/S/Div/P 292 0 R/K[282 0 R 283 0 R 290 0 R]>>
+<</Type/StructElem/S/Span/P 292 0 R/A[<</O/Layout/Placement/Block>>]/K[62]/Pg 363 0 R>>
 endobj
 292 0 obj
-<</Type/StructElem/S/Div/P 293 0 R/K[281 0 R 291 0 R]>>
+<</Type/StructElem/S/Div/P 295 0 R/K[291 0 R]>>
 endobj
 293 0 obj
-<</Type/StructElem/S/Document/P 4 0 R/K[16 0 R 17 0 R 18 0 R 53 0 R 90 0 R 133 0 R 160 0 R 185 0 R 210 0 R 240 0 R 265 0 R 266 0 R 279 0 R 292 0 R]>>
+<</Type/StructElem/S/Span/P 294 0 R/A[<</O/Layout/Placement/Block>>]/K[63 64]/Pg 363 0 R>>
 endobj
 294 0 obj
-<</Type/Annot/Subtype/Link/Rect[501.8625 953.3525 570.24 961.4675]/Border[0 0 0]/A<</Type/Action/S/URI/URI(mailto:sid_26@outlook.com)>>/F 4/StructParent 0/Contents(Email sid_26@outlook.com)>>
+<</Type/StructElem/S/Div/P 295 0 R/K[293 0 R]>>
 endobj
 295 0 obj
-<</Type/Annot/Subtype/Link/Rect[501.285 944.1825 570.24 952.2975]/Border[0 0 0]/A<</Type/Action/S/URI/URI(https://linkedin.com/in/f0rr0)>>/F 4/StructParent 1/Contents(https://linkedin.com/in/f0rr0)>>
+<</Type/StructElem/S/Div/P 301 0 R/K[292 0 R 294 0 R]>>
 endobj
 296 0 obj
-<</Type/Annot/Subtype/Link/Rect[515.2125 935.0125 570.24 943.1275]/Border[0 0 0]/A<</Type/Action/S/URI/URI(https://github.com/f0rr0)>>/F 4/StructParent 2/Contents(https://github.com/f0rr0)>>
+<</Type/StructElem/S/Span/P 297 0 R/A[<</O/Layout/Placement/Block>>]/K[65]/Pg 363 0 R>>
 endobj
 297 0 obj
-[/ICCBased 346 0 R]
+<</Type/StructElem/S/Div/P 300 0 R/K[296 0 R]>>
 endobj
 298 0 obj
-<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 297 0 R>>/XObject<</x0 348 0 R/x1 350 0 R/x2 352 0 R/x3 354 0 R/x4 356 0 R/x5 358 0 R/x6 360 0 R/x7 362 0 R/x8 364 0 R>>/Font<</f0 300 0 R/f1 303 0 R/f2 306 0 R/f3 309 0 R/f4 312 0 R/f5 315 0 R/f6 318 0 R>>>>
+<</Type/StructElem/S/Span/P 299 0 R/A[<</O/Layout/Placement/Block>>]/K[66]/Pg 363 0 R>>
 endobj
 299 0 obj
-<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 297 0 R>>/XObject<</x0 366 0 R/x1 368 0 R/x2 370 0 R/x3 371 0 R/x4 373 0 R/x5 375 0 R/x6 377 0 R>>/Font<</f0 312 0 R/f1 315 0 R/f2 303 0 R/f3 306 0 R/f4 318 0 R/f5 309 0 R>>>>
+<</Type/StructElem/S/Div/P 300 0 R/K[298 0 R]>>
 endobj
 300 0 obj
-<</Type/Font/Subtype/Type0/BaseFont/QUGPQN+Literata-Regular/Encoding/Identity-H/DescendantFonts[301 0 R]/ToUnicode 324 0 R>>
+<</Type/StructElem/S/Div/P 301 0 R/K[297 0 R 299 0 R]>>
 endobj
 301 0 obj
-<</Type/Font/Subtype/CIDFontType2/BaseFont/QUGPQN+Literata-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 302 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 500 1 1 608 2 2 360 3 3 659 4 4 204 5 5 578 6 6 575 7 7 686]>>
+<</Type/StructElem/S/Div/P 302 0 R/K[280 0 R 281 0 R 290 0 R 295 0 R 300 0 R]>>
 endobj
 302 0 obj
-<</Type/FontDescriptor/FontName/QUGPQN+Literata-Regular/Flags 131076/FontBBox[22 -14 664 773]/ItalicAngle 0/Ascent 1177/Descent -308/CapHeight 710/StemV 95.4/CIDSet 323 0 R/FontFile2 325 0 R>>
+<</Type/StructElem/S/Div/P 334 0 R/K[277 0 R 301 0 R]>>
 endobj
 303 0 obj
-<</Type/Font/Subtype/Type0/BaseFont/TAVORV+SourceSans3-Semibold/Encoding/Identity-H/DescendantFonts[304 0 R]/ToUnicode 327 0 R>>
+<</Type/StructElem/S/P/P 334 0 R/K[67]/Pg 363 0 R>>
 endobj
 304 0 obj
-<</Type/Font/Subtype/CIDFontType2/BaseFont/TAVORV+SourceSans3-Semibold/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 305 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 672 1 1 431 2 2 262 3 3 564 4 4 500 5 6 513 7 7 875 8 8 549 9 9 556 10 10 361 11 11 271 12 12 522 13 13 275 14 14 462 15 15 843 16 16 560 17 17 507.00003 18 18 344 19 19 317 20 20 513 21 21 373 22 22 520 23 23 558 24 24 563 25 25 501.99997 26 26 516 27 27 200 28 28 558 29 29 564 30 30 282 31 31 538 32 32 663 33 33 322 34 34 582 35 35 275 36 36 576 37 37 510 38 38 639 39 39 546 40 40 625 41 41 536 42 42 597 43 43 748 44 44 275 45 45 481 46 46 540 47 47 495 48 48 745 49 49 545 50 50 642]>>
+<</Type/StructElem/S/Figure/P 305 0 R/A[<</O/Layout/Placement/Block>>]/K[68]/Pg 363 0 R>>
 endobj
 305 0 obj
-<</Type/FontDescriptor/FontName/TAVORV+SourceSans3-Semibold/Flags 131076/FontBBox[-69 -217 826 718]/ItalicAngle 0/Ascent 1000/Descent -326/CapHeight 660/StemV 144.2/CIDSet 326 0 R/FontFile2 328 0 R>>
+<</Type/StructElem/S/Div/P 318 0 R/K[304 0 R]>>
 endobj
 306 0 obj
-<</Type/Font/Subtype/Type0/BaseFont/SJODJH+SourceSans3-Regular/Encoding/Identity-H/DescendantFonts[307 0 R]/ToUnicode 330 0 R>>
+<</Type/StructElem/S/Span/P 307 0 R/A[<</O/Layout/Placement/Block>>]/K[69]/Pg 363 0 R>>
 endobj
 307 0 obj
-<</Type/Font/Subtype/CIDFontType2/BaseFont/SJODJH+SourceSans3-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 308 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 653 1 1 544 2 2 555 3 3 255 4 4 246 5 5 496 6 6 555 7 7 200 8 8 263 9 9 486 10 10 504 11 11 547 12 12 544 13 13 419 14 14 311 15 15 542 16 16 504 17 17 347 18 18 719 19 19 338 20 20 544 21 21 467 22 22 292 23 23 456 24 24 829 25 25 249 26 26 467 27 27 249 28 28 495 29 29 553 30 30 534 31 31 494 32 32 588 33 33 350 34 34 569 35 35 249 36 36 480 37 39 497 40 40 566 41 41 647 42 42 664 43 43 594 44 44 615 45 45 446 46 46 497 47 47 513 48 48 527 49 49 571 50 50 536 51 51 786 52 52 727 53 53 555 54 54 247 55 55 497 56 56 476 57 57 425 58 58 539 59 59 249 60 60 579 61 61 497 62 62 515 63 64 497 65 65 652 66 66 497 67 67 609 68 68 617 69 69 645 70 70 497 71 71 824 72 72 577]>>
+<</Type/StructElem/S/Div/P 308 0 R/K[306 0 R]>>
 endobj
 308 0 obj
-<</Type/FontDescriptor/FontName/SJODJH+SourceSans3-Regular/Flags 131076/FontBBox[-167 -224 790 724]/ItalicAngle 0/Ascent 1000/Descent -326/CapHeight 660/StemV 95.4/CIDSet 329 0 R/FontFile2 331 0 R>>
+<</Type/StructElem/S/Div/P 317 0 R/K[307 0 R]>>
 endobj
 309 0 obj
-<</Type/Font/Subtype/Type0/BaseFont/NOTHBP+Literata-Regular/Encoding/Identity-H/DescendantFonts[310 0 R]/ToUnicode 333 0 R>>
+<</Type/StructElem/S/P/P 317 0 R/K[70]/Pg 363 0 R>>
 endobj
 310 0 obj
-<</Type/Font/Subtype/CIDFontType2/BaseFont/NOTHBP+Literata-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 311 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 500 1 1 662 2 2 603 3 3 660 4 4 565 5 5 541 6 6 364 7 7 693 8 8 543 9 9 658 10 10 676 11 11 578 12 12 437 13 13 624]>>
+<</Type/StructElem/S/Span/P 311 0 R/A[<</O/Layout/Placement/Block>>]/K[71]/Pg 363 0 R>>
 endobj
 311 0 obj
-<</Type/FontDescriptor/FontName/NOTHBP+Literata-Regular/Flags 131076/FontBBox[5 -216 669 772]/ItalicAngle 0/Ascent 1177/Descent -308/CapHeight 701/StemV 95.4/CIDSet 332 0 R/FontFile2 334 0 R>>
+<</Type/StructElem/S/Div/P 312 0 R/K[310 0 R]>>
 endobj
 312 0 obj
-<</Type/Font/Subtype/Type0/BaseFont/FFRKZO+Literata-Regular/Encoding/Identity-H/DescendantFonts[313 0 R]/ToUnicode 336 0 R>>
+<</Type/StructElem/S/Div/P 313 0 R/K[311 0 R]>>
 endobj
 313 0 obj
-<</Type/Font/Subtype/CIDFontType2/BaseFont/FFRKZO+Literata-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 314 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 500 1 1 839 2 2 578 3 3 997 4 4 566 5 5 723 6 6 987 7 7 624 8 8 542 9 9 695 10 10 605 11 11 746 12 12 677 13 13 660 14 14 365 15 15 499 16 16 200 17 17 747 18 18 544 19 19 690 20 20 784 21 21 362 22 22 439 23 23 589 24 24 841 25 25 665 26 26 710 27 27 658 28 28 614 29 29 1111 30 30 672 31 31 786 32 32 623 33 33 612 34 34 428 35 35 326 36 36 649 37 37 756 38 38 778 39 39 654 40 40 648 41 41 745 42 42 329]>>
+<</Type/StructElem/S/Div/P 316 0 R/K[312 0 R]>>
 endobj
 314 0 obj
-<</Type/FontDescriptor/FontName/FFRKZO+Literata-Regular/Flags 131076/FontBBox[7 -230 1100 782]/ItalicAngle 0/Ascent 1177/Descent -308/CapHeight 700/StemV 95.4/CIDSet 335 0 R/FontFile2 337 0 R>>
+<</Type/StructElem/S/Span/P 315 0 R/A[<</O/Layout/Placement/Block>>]/K[72]/Pg 363 0 R>>
 endobj
 315 0 obj
-<</Type/Font/Subtype/Type0/BaseFont/ZFSMHF+SourceSans3-It/Encoding/Identity-H/DescendantFonts[316 0 R]/ToUnicode 339 0 R>>
+<</Type/StructElem/S/Div/P 316 0 R/K[314 0 R]>>
 endobj
 316 0 obj
-<</Type/Font/Subtype/CIDFontType2/BaseFont/ZFSMHF+SourceSans3-It/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 317 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 628 1 1 249 2 2 550 3 3 510 4 4 619 5 5 299 6 6 537 7 7 435 8 8 342 9 9 480 10 10 535 11 11 237 12 12 325 13 13 200 14 14 531 15 15 402 16 16 536 17 17 522 18 18 248 19 19 525 20 20 535 21 21 514 22 22 282 23 23 799 24 24 707 25 25 523 26 26 242 27 27 550 28 28 448 29 29 429 30 30 476 31 31 505.99997 32 32 448 33 33 462 34 34 561 35 35 588 36 36 569 37 37 594 38 38 496 39 39 473 40 40 534 41 41 756 42 42 242 43 43 480 44 44 622 45 45 633 46 46 705]>>
+<</Type/StructElem/S/Div/P 317 0 R/K[313 0 R 315 0 R]>>
 endobj
 317 0 obj
-<</Type/FontDescriptor/FontName/ZFSMHF+SourceSans3-It/Flags 131140/FontBBox[-62 -220 812 724]/ItalicAngle -11/Ascent 1000/Descent -326/CapHeight 660/StemV 95.4/CIDSet 338 0 R/FontFile2 340 0 R>>
+<</Type/StructElem/S/Div/P 318 0 R/K[308 0 R 309 0 R 316 0 R]>>
 endobj
 318 0 obj
-<</Type/Font/Subtype/Type0/BaseFont/FWNBCE+SourceSans3-Bold/Encoding/Identity-H/DescendantFonts[319 0 R]/ToUnicode 342 0 R>>
+<</Type/StructElem/S/Div/P 334 0 R/K[305 0 R 317 0 R]>>
 endobj
 319 0 obj
-<</Type/Font/Subtype/CIDFontType2/BaseFont/FWNBCE+SourceSans3-Bold/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 320 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 690 1 1 300]>>
+<</Type/StructElem/S/Figure/P 320 0 R/A[<</O/Layout/Placement/Block>>]/K[73]/Pg 363 0 R>>
 endobj
 320 0 obj
-<</Type/FontDescriptor/FontName/FWNBCE+SourceSans3-Bold/Flags 131076/FontBBox[61 -12 610 660]/ItalicAngle 0/Ascent 1000/Descent -326/CapHeight 660/StemV 168.6/CIDSet 341 0 R/FontFile2 343 0 R>>
+<</Type/StructElem/S/Div/P 333 0 R/K[319 0 R]>>
 endobj
 321 0 obj
-<</Type/Page/Resources 298 0 R/MediaBox[0 0 612 1008]/StructParents 3/Tabs/S/Parent 1 0 R/Contents 344 0 R/Annots[294 0 R 295 0 R 296 0 R]>>
+<</Type/StructElem/S/Span/P 322 0 R/A[<</O/Layout/Placement/Block>>]/K[74]/Pg 363 0 R>>
 endobj
 322 0 obj
-<</Type/Page/Resources 299 0 R/MediaBox[0 0 612 1008]/StructParents 4/Parent 1 0 R/Contents 345 0 R>>
+<</Type/StructElem/S/Div/P 323 0 R/K[321 0 R]>>
 endobj
 323 0 obj
+<</Type/StructElem/S/Div/P 332 0 R/K[322 0 R]>>
+endobj
+324 0 obj
+<</Type/StructElem/S/P/P 332 0 R/K[75]/Pg 363 0 R>>
+endobj
+325 0 obj
+<</Type/StructElem/S/Span/P 326 0 R/A[<</O/Layout/Placement/Block>>]/K[76]/Pg 363 0 R>>
+endobj
+326 0 obj
+<</Type/StructElem/S/Div/P 327 0 R/K[325 0 R]>>
+endobj
+327 0 obj
+<</Type/StructElem/S/Div/P 328 0 R/K[326 0 R]>>
+endobj
+328 0 obj
+<</Type/StructElem/S/Div/P 331 0 R/K[327 0 R]>>
+endobj
+329 0 obj
+<</Type/StructElem/S/Span/P 330 0 R/A[<</O/Layout/Placement/Block>>]/K[77]/Pg 363 0 R>>
+endobj
+330 0 obj
+<</Type/StructElem/S/Div/P 331 0 R/K[329 0 R]>>
+endobj
+331 0 obj
+<</Type/StructElem/S/Div/P 332 0 R/K[328 0 R 330 0 R]>>
+endobj
+332 0 obj
+<</Type/StructElem/S/Div/P 333 0 R/K[323 0 R 324 0 R 331 0 R]>>
+endobj
+333 0 obj
+<</Type/StructElem/S/Div/P 334 0 R/K[320 0 R 332 0 R]>>
+endobj
+334 0 obj
+<</Type/StructElem/S/Document/P 4 0 R/K[16 0 R 17 0 R 18 0 R 62 0 R 103 0 R 150 0 R 181 0 R 212 0 R 241 0 R 275 0 R 302 0 R 303 0 R 318 0 R 333 0 R]>>
+endobj
+335 0 obj
+<</Type/Annot/Subtype/Link/Rect[500.3625 953.3525 570.24 961.4675]/Border[0 0 0]/A<</Type/Action/S/URI/URI(mailto:sid_26@outlook.com)>>/F 4/StructParent 0/Contents(Email sid_26@outlook.com)>>
+endobj
+336 0 obj
+<</Type/Annot/Subtype/Link/Rect[501.285 944.1825 570.24 952.2975]/Border[0 0 0]/A<</Type/Action/S/URI/URI(https://linkedin.com/in/f0rr0)>>/F 4/StructParent 1/Contents(https://linkedin.com/in/f0rr0)>>
+endobj
+337 0 obj
+<</Type/Annot/Subtype/Link/Rect[515.2125 935.0125 570.24 943.1275]/Border[0 0 0]/A<</Type/Action/S/URI/URI(https://github.com/f0rr0)>>/F 4/StructParent 2/Contents(https://github.com/f0rr0)>>
+endobj
+338 0 obj
+[/ICCBased 387 0 R]
+endobj
+339 0 obj
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 338 0 R>>/XObject<</x0 389 0 R/x1 391 0 R/x2 393 0 R/x3 395 0 R/x4 397 0 R/x5 399 0 R/x6 401 0 R/x7 403 0 R/x8 405 0 R>>/Font<</f0 341 0 R/f1 344 0 R/f2 347 0 R/f3 350 0 R/f4 353 0 R/f5 356 0 R/f6 359 0 R>>>>
+endobj
+340 0 obj
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 338 0 R>>/XObject<</x0 407 0 R/x1 409 0 R/x2 411 0 R/x3 412 0 R/x4 414 0 R/x5 416 0 R/x6 418 0 R>>/Font<</f0 353 0 R/f1 344 0 R/f2 356 0 R/f3 347 0 R/f4 359 0 R/f5 350 0 R>>>>
+endobj
+341 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/QUGPQN+Literata-Regular/Encoding/Identity-H/DescendantFonts[342 0 R]/ToUnicode 365 0 R>>
+endobj
+342 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/QUGPQN+Literata-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 343 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 500 1 1 608 2 2 360 3 3 659 4 4 204 5 5 578 6 6 575 7 7 686]>>
+endobj
+343 0 obj
+<</Type/FontDescriptor/FontName/QUGPQN+Literata-Regular/Flags 131076/FontBBox[22 -14 664 773]/ItalicAngle 0/Ascent 1177/Descent -308/CapHeight 710/StemV 95.4/CIDSet 364 0 R/FontFile2 366 0 R>>
+endobj
+344 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/MJAJCJ+SourceSans3-Semibold/Encoding/Identity-H/DescendantFonts[345 0 R]/ToUnicode 368 0 R>>
+endobj
+345 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/MJAJCJ+SourceSans3-Semibold/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 346 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 672 1 1 200 2 2 431 3 3 262 4 4 564 5 5 500 6 7 513 8 8 875 9 9 549 10 10 556 11 11 361 12 12 271 13 13 522 14 14 275 15 15 462 16 16 843 17 17 560 18 18 507.00003 19 19 344 20 20 317 21 21 513 22 22 373 23 23 520 24 24 558 25 25 563 26 26 538 27 27 516 28 28 495 29 29 322 30 30 501.99997 31 31 558 32 32 564 33 33 282 34 34 663 35 35 628 36 36 748 37 37 618 38 38 513 39 39 510 40 40 639 41 41 546 42 42 625 43 43 536 44 44 597 45 45 275 46 46 481 47 47 540 48 48 582 49 49 745 50 50 545 51 51 642 52 52 576 53 53 275]>>
+endobj
+346 0 obj
+<</Type/FontDescriptor/FontName/MJAJCJ+SourceSans3-Semibold/Flags 131076/FontBBox[-69 -217 826 718]/ItalicAngle 0/Ascent 1000/Descent -326/CapHeight 660/StemV 144.2/CIDSet 367 0 R/FontFile2 369 0 R>>
+endobj
+347 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/ZSOBIM+SourceSans3-Regular/Encoding/Identity-H/DescendantFonts[348 0 R]/ToUnicode 371 0 R>>
+endobj
+348 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/ZSOBIM+SourceSans3-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 349 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 653 1 1 534 2 2 542 3 3 594 4 4 719 5 5 504 6 6 347 7 7 496 8 8 200 9 9 547 10 10 504 11 11 246 12 12 555 13 13 338 14 14 456 15 15 544 16 16 255 17 19 497 20 20 467 21 21 419 22 22 553 23 23 544 24 24 555 25 25 249 26 26 292 27 27 829 28 28 249 29 29 486 30 30 544 31 31 263 32 32 647 33 33 495 34 34 467 35 35 249 36 36 311 37 37 727 38 38 494 39 39 497 40 40 588 41 41 304 42 42 350 43 43 566 44 44 571 45 45 569 46 46 249 47 47 480 48 48 497 49 49 664 50 50 249 51 51 497 52 52 247 53 53 536 54 54 615 55 56 497 57 57 527 58 58 786 59 59 555 60 60 476 61 61 425 62 62 539 63 63 249 64 64 446 65 65 579 66 66 497 67 67 515 68 68 497 69 69 652 70 70 609 71 71 617 72 72 645 73 73 497 74 74 824 75 75 577]>>
+endobj
+349 0 obj
+<</Type/FontDescriptor/FontName/ZSOBIM+SourceSans3-Regular/Flags 131076/FontBBox[-167 -224 790 724]/ItalicAngle 0/Ascent 1000/Descent -326/CapHeight 660/StemV 95.4/CIDSet 370 0 R/FontFile2 372 0 R>>
+endobj
+350 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/NOTHBP+Literata-Regular/Encoding/Identity-H/DescendantFonts[351 0 R]/ToUnicode 374 0 R>>
+endobj
+351 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/NOTHBP+Literata-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 352 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 500 1 1 662 2 2 603 3 3 660 4 4 565 5 5 541 6 6 364 7 7 693 8 8 543 9 9 658 10 10 676 11 11 578 12 12 437 13 13 624]>>
+endobj
+352 0 obj
+<</Type/FontDescriptor/FontName/NOTHBP+Literata-Regular/Flags 131076/FontBBox[5 -216 669 772]/ItalicAngle 0/Ascent 1177/Descent -308/CapHeight 701/StemV 95.4/CIDSet 373 0 R/FontFile2 375 0 R>>
+endobj
+353 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/FFRKZO+Literata-Regular/Encoding/Identity-H/DescendantFonts[354 0 R]/ToUnicode 377 0 R>>
+endobj
+354 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/FFRKZO+Literata-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 355 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 500 1 1 839 2 2 578 3 3 997 4 4 566 5 5 723 6 6 987 7 7 624 8 8 542 9 9 695 10 10 605 11 11 746 12 12 677 13 13 660 14 14 365 15 15 499 16 16 200 17 17 747 18 18 544 19 19 690 20 20 784 21 21 362 22 22 439 23 23 589 24 24 841 25 25 665 26 26 710 27 27 658 28 28 614 29 29 1111 30 30 672 31 31 786 32 32 623 33 33 612 34 34 428 35 35 326 36 36 649 37 37 756 38 38 778 39 39 654 40 40 648 41 41 745 42 42 329]>>
+endobj
+355 0 obj
+<</Type/FontDescriptor/FontName/FFRKZO+Literata-Regular/Flags 131076/FontBBox[7 -230 1100 782]/ItalicAngle 0/Ascent 1177/Descent -308/CapHeight 700/StemV 95.4/CIDSet 376 0 R/FontFile2 378 0 R>>
+endobj
+356 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/ZFSMHF+SourceSans3-It/Encoding/Identity-H/DescendantFonts[357 0 R]/ToUnicode 380 0 R>>
+endobj
+357 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/ZFSMHF+SourceSans3-It/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 358 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 628 1 1 249 2 2 550 3 3 510 4 4 619 5 5 299 6 6 537 7 7 435 8 8 342 9 9 480 10 10 535 11 11 237 12 12 325 13 13 200 14 14 531 15 15 402 16 16 536 17 17 522 18 18 248 19 19 525 20 20 535 21 21 514 22 22 282 23 23 799 24 24 707 25 25 523 26 26 242 27 27 550 28 28 448 29 29 429 30 30 476 31 31 505.99997 32 32 448 33 33 462 34 34 561 35 35 588 36 36 569 37 37 594 38 38 496 39 39 473 40 40 534 41 41 756 42 42 242 43 43 480 44 44 622 45 45 633 46 46 705]>>
+endobj
+358 0 obj
+<</Type/FontDescriptor/FontName/ZFSMHF+SourceSans3-It/Flags 131140/FontBBox[-62 -220 812 724]/ItalicAngle -11/Ascent 1000/Descent -326/CapHeight 660/StemV 95.4/CIDSet 379 0 R/FontFile2 381 0 R>>
+endobj
+359 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/FWNBCE+SourceSans3-Bold/Encoding/Identity-H/DescendantFonts[360 0 R]/ToUnicode 383 0 R>>
+endobj
+360 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/FWNBCE+SourceSans3-Bold/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 361 0 R/DW 0/CIDToGIDMap/Identity/W[0 0 690 1 1 300]>>
+endobj
+361 0 obj
+<</Type/FontDescriptor/FontName/FWNBCE+SourceSans3-Bold/Flags 131076/FontBBox[61 -12 610 660]/ItalicAngle 0/Ascent 1000/Descent -326/CapHeight 660/StemV 168.6/CIDSet 382 0 R/FontFile2 384 0 R>>
+endobj
+362 0 obj
+<</Type/Page/Resources 339 0 R/MediaBox[0 0 612 1008]/StructParents 3/Tabs/S/Parent 1 0 R/Contents 385 0 R/Annots[335 0 R 336 0 R 337 0 R]>>
+endobj
+363 0 obj
+<</Type/Page/Resources 340 0 R/MediaBox[0 0 612 1008]/StructParents 4/Parent 1 0 R/Contents 386 0 R>>
+endobj
+364 0 obj
 <</Length 9/Filter/FlateDecode>>
 stream
 xœû   
 endstream
 endobj
-324 0 obj
+365 0 obj
 <</Length 377/Type/CMap/Filter/FlateDecode/WMode 0>>
 stream
 xœm’ËnÂ0E÷ùŠéÂ,hž*BHˆ”5¨]{ –ˆmÙÎ‚¿¯l'PU]$Ñ™¹ö½c‡¼ËÁŠ«3F¯>ÐªÆ0¬w•NÙ(ÖÔ(Ý‘#ïºvÚ(fÑÁºØR¸„B²[Ã±Óü'yÇ«O÷€ucªBNÂÝp½X€	
@@ -981,138 +1104,129 @@ xœm’ËnÂ0E÷ùŠéÂ,hž*BHˆ”5¨]{ –ˆmÙÎ‚¿¯l'PU]$Ñ™¹ö½c‡¼ËÁŠ«3F¯>ÐªÆ0¬w•NÙ(Ö
 O¸óî÷ñtÈ ýÚx
 endstream
 endobj
-325 0 obj
+366 0 obj
 <</Length 1547/Filter/FlateDecode>>
 stream
 xœ–]l[gÆç$MâØ>ÇqRçÄNŽ,¶ãcÇnâ~%ÍÒf„~,AÑJÝÔ‰³%u”8í
 Hë®¶&@¢C„zƒ&4qÃ*ª âb\ !Qí¢CÄ*CDô¾>]›tW;–ìÇïÇÿyþÏû¼ÒAÚ¸…+k7—xýÁKÀ7A{¥^«^íûö?&Aû7Pª×kÕ¶ûÊ?Á5Ö×›¯^\‹€¹ÖXªººÕÿ€«	t¯W_Û ƒ“àzKÌ_«®×¾öÑ€ë'àV7[M~Ìo ý§€ŠÊ=õ.^BÁ ­¼½»qT‰ªwwfÔ[;wÕF÷©GÔ?0	î„•ò&Så¸V°K¥ñ¢e¥²Úxñ¸V°u£\0¼Y5™ðDÂºnÄµHØ§*GKKCþ¢¢3eOZ…^sf|ôsGúÃ©É³cöY³3×3*M[¹Jb*›¿P1GÎ\ô%Oþ¹=u2ŽÆ“¹Á€oÐ>“8^‰öE‹tTÎ˜öh2cú–}z¬¼X‰ƒŠ	ÊyÍMˆÃP/—JãÁ¢•J•ËF0¬FDµŠ¥‚­GÂžD&x¨Ë°Üìj=÷û¢Ë‹-Sb=š»ÜÑ¶»j„]Þ‚úrælf4Ê bí=R¿¡îÑOŒ„eK¢ž1¾Å›JúÔ²0gÜ²’	4cçùËöÑÍs‰Šá¥Ü;;Â©ßu¹ü™cþøhO$ÊéFÎWÙ\øÒ­Ù@×wãÍ]òvîlA—§è]ˆ¥…ÞrêïàÈ—g§R(è{Ôaõ>ƒû´DÂ¯®Ë£‘½D¼O$ö|4qiÂéMGÃ]i£ßêîŠU^Ìvw½áš~®?ëïÑóý¾ø‰œòN,¢zJEîÛ½ýúNï'Ô yŽI>AW§ŸLx¼qUXúX‚‰„…‚²áñ$Vê±-'~yú|åõ•€eö|þ€ÇšM¹:=w9ß>î8¤OÊm¾áÉ˜>Ð­ôÆ}s'&N™î—†Ætg¨/äÕã‰¾¡“éôfFu—kXåÒ±täóáÁèÅÐpb(ŠH‚z[ª=£ðD¢aDä¤Ó†ÇL§ízÊ}¿Ë¥E/›˜êìÚýKðÏì=œµû^5SâfTs—:Û.'FÎ•öô æ.Øn-hüud,Ü[N} ‡T¯Bh±K?{˜ÿÞWýGÿ…¦ýM?¸·í¿úVßÛ»oî~ì¾ãÚ <¨b´µÏõÎîûà¾³ûæÎ×Ýwd¥§Ÿ6åclõ2£JSýïƒ:®žÀRßN¡Îm>äCEWÖ•Ÿ;zÚ8îð¬)þûxÅÕ¼+ÔK¬à]«øø…ƒ5l~ë`&ÿu°›I%æ`¦²è`/óJÓÁmD•_9¸{Êw0¢~ßÁQíà.%¡þÏÁ>J®8§h°ÁM6Ye…:MLlÆÈSÆd‘:5LæY¥IMª4©bržM¼B%¹gŠmšÔi°É&iY«É[L’#ÇŠ¬Qg›+dY¢ÁºmÐ`…5j,ÓàM¶È±v€qø/Rc…mÖ¨²I,yÆ(Pa‘E*Ï¬ÏØñlOûç¿(ç¶X•ªÌ}+,Ó”Ê×Øâ+Œ‘e‚,6¼ü˜W¥g5åèUj¬Ëµ¯bÒ`“ÓO9e2Ç5–È²ÈM6¨±(çjÒaQy^Ö^•Ê¯pÓéGô²Ê«’kšmyîU¹J|_ÅälIŽ–¨JÆ–5²RÇ&5jRY«òœó‚Eô¸$“°-×ŸrÒµ&ë,Ð#t<Ïu¶¤Ë¬Rã:U²Ÿä§•žò“Ý——Ç)úô•MÇ™Œ<©§½y¼O¤»åü¬“<Ñ³p»Éé¾è¨µ¢¥]t)¼>mK¿D=qj­{²Àó˜œ“Ì×öUžßWaôž$,/&<{¢l?ï“¤„§U®8‰¸áÜ¯VŽf™â‚ÄM&1Ÿ¹[,ÉSÙ÷-+U¬‘•÷w…ç˜eþ3îïòÙûxOú”§M¼¥1Ïi42Ìpþ›q¦`
 endstream
 endobj
-326 0 obj
-<</Length 13/Filter/FlateDecode>>
+367 0 obj
+<</Length 11/Filter/FlateDecode>>
 stream
-xœûÿ~  äó
+xœûÿ ëú
 endstream
 endobj
-327 0 obj
-<</Length 570/Type/CMap/Filter/FlateDecode/WMode 0>>
+368 0 obj
+<</Length 586/Type/CMap/Filter/FlateDecode/WMode 0>>
 stream
-xœm”Iâ0Fïù5‡Hô‰ílÝ!±EâÐ‹šÖÌâ‚‰N”åÀ¿Å_ÑÝÍ ç*»ê%¶ÃoûéÒÖGžÆ?½sWmÉÓõó¡	ÂpS—Ã•]ÿÂlÙÞ£ÝŒš¶.;îi½Ûì\Õa¸såe°|Ïù_ÊŠÏ•ûJkÐzèúú„áGÕ_xFï‰v–]_õ7RAþâ¶«j7#„áÖÙu}›ë‚HjPôÖÖåž{:UÎ¶R‰ŽcÝ@²UÙùgy=4~òþÖõ|Ý¹SM1²ìÐH&QôÎçªëÛM|cdù„Èkk¹­Ü™&÷f¿÷CÓ\xl’”egý4Ê¿®L‘ŽŠ%é¯¡[Ã²@ôû¹¶wÐh±¬-wÍ¡äöàÎÌ•RjAó¢(ŠÅXñŸxª0íx*ÿZŸ®4W*žŒ§ì	ƒPâ)-@©§Ø€2PÊ=%
-ôˆUdÞê¥ %H*¬¹­A+ÐÆ“Ù‚¶ˆI×hãI/@©™~êiøô¢Å]køÅèZÃ/‡Ÿ†_–ƒà—=‚ÄO2á—ÀAÃ/Ó ø© ¿DbðË%¿ßAÃ/ƒ_‚ê~î~)V1ð3èÅÀ/Á;3ðKànàg„r¬‚¯bà—Á/•Lø%p7ðËñ–üâ%Hü¤kø¥ƒ_ÛXü`Ã/E×±ìÏ{†•<nõñDž­rh[v½?Ðþ §¦rüy34u3Îò?¥Üo§‘^‹¿&ePY
+xœm”ËnÛ0E÷úŠéB€³p-’z$A`À‘-À‹<íÚÇ®€˜ôXøïòŽ è"9ÔÜCŠŠ¼îæ+Û~ðÜüLè‡vêkž—Oû.Šãu[O'vã3³e{™î©ëÛzà‘Êízëš1Šã­«?'Ë—šÿ•<ò±q_¾•Ó0¶§(Žß›ñ“ïi†
+™hkÙÍx¦ä&Šã_ÜMëîIEq¼q¶lO>Ü-¤-^û¶ÞñH‡ÆÙ^:Ñ‡ï)M¶©G¡ð[Ÿö]X¼;#Ÿ¶îÐ’A•:©$"Z¼ñ±ÆþL³ì†,0óÒ[îw¤Ù%ì·ÉÝÔuŸìCRFÙÙðáåŸ÷'¦…_GÅ’Ô×Ðû¹cyÀâ÷Sk/ ±n-Ý¾æ~ïŽ=$I’,é¡ªªjé;þ3Ÿ,û8Ôö}(WKzH,é@…™@ù(¥ ,PVò@Fƒ
+Pº”J‡;<EÖ­Ð/=‚¤C‰Ê´=‚6H½U˜Cjå7 Iò5~9*ürôSðÓÈ¢Ä©üR+øðSðËüò[øI%üRé¿\àW`wü´¤†_
+w¿ë4ü
+$ÓðKñ¿Y4üRäÔð+„¼ŸVwÈ©åü¤üRì„†Ÿ‚_†3Òâ'¿L*á—Jø™~…ä„_†9¿~Fü°/~NÚÈû™_ßÇTæq†ºWAÞy)üÝ¿ÞÂzê{vc¸úáÊùûÕ8¾~Cº¶ó«Â_øø\¾cž^ª¿¨ýXh
 endstream
 endobj
-328 0 obj
-<</Length 8432/Filter/FlateDecode>>
+369 0 obj
+<</Length 8715/Filter/FlateDecode>>
 stream
-xœ­{p[Y™æwÎ½ºzÛ–%Y¶åÇ•¯%;Ö•ìX~Å±Yò#vlÇ±ó’t"ù‘Äé¼:vÝMÓ¡z²†q1ìlYvª¶fŠ£4ËvCÅ°»lój`f º x,M(f©v†Ø[ç\I±Óévjä’ÏÏùÏ9ÿëüÿþkƒ °ã$´Í_^Qg~-ð€´¸pòì\«ý òK ÄqòÌ“'¾Úø¡ Pú[ ¶æÔbv!˜ûöˆ@×©S‹YëM·È€ÆSgW®žØk}ˆ\ ðê™óóÙÿñÂ·+è€3g³W/_—^¢€z.{vñîk?D¿(.œ_^ü¦¼tÆ|èÂÅÅßûÈ37€Î¿ˆ	ÿŸ+¸‚2ÔPßÆ]\ÆeÃ1º;ÀÆ ½±q—ÜÛ¸»Ñõ`lã.}™ÜÙ¸»1ÅGé+b|
-p 	$¤úò.ü£”¢¯'ñ›{ð] jç;mÜ-âo'ï*ÎÙAž,ÎÛDß¯@ý²Ø¯³˜EI|cc?Ø(®×P\ï¾ÔP\ï>ƒ®2H§UuÏ-”ìÛÃ”ÙÃ)ÖágÍéÌ	uõ@ŠÑ`ösX0?¯Íù†4CRº	‚d&aDgjæD„Q]h“tuá%ÉãE"ÉÜI5“Iä¨'™È¥$£ÉýWUæÐM&³Lž¾z“RšÌ$X`±&À{o–xI¢Fe4©%nº‰;™IhÓ©ÅôÍ
-Â1#LÖ™fÞdŠïÇ*’É<‚_]PÙíi&‡ßl&Îäðü0S†S&Ó3GR-à_M©lz:`ñ´_e=êI§Õœ]`ÍÓ©@þIem|¼cÞžN©'ÔÕÕ¬ÊlÓ©Œ_e*³q¨‹C]&Nû2Grža&Å°‡#˜#éßÃê8T·'{«óã–	séôB6ÍH8ÎsVXERK¤#Ì¤«Ã*“ƒÙ•™“Ó)fÖÌ¢%ü@š‘L„)BÜL
-«9ó\Båƒœ]¿A>ÿÍ¬™áyfj	¨Ì’TWÕUFÂ¹6SÉ¡}©Ì´?;“Nié@ZeñÙ#a?—Kž”3ëÌšß5ÔlÑ™UKh*ƒ–È2:w‚‘yF2ÌÜaV]åÔ–$çoÉ˜Sù
-,žIs”Ì Ö¦ß´– 9œh	Ç®o5$‡±
-	kI&3êðª–åJÂ†Ÿ+„©~/
-ŒIA-;dlá|‹é¬q:Å'Ç5©„Û¿–xÉé€4<
-øµ@º%a¥zŽÒa¶Š°2‘Œª²Òä8_@e¥Z"ÍÊøÓLJeeB_.]eeB(ê-ó«Z–¹’u5£2—–Ð"¬\ß³?•“†ÒÌ¹¨]0·¾g_jÏ¬Ñé¤™[ô{ôÊ“R¹òò$#Ùs…ù‘c4˜È•ò_e4˜`¤BS™œNå¸ø˜L¬®ª|Û²–€ÆH¶ ûq>…EOš•&GYYr4ÃèVe½…
-s€[b$É0p“"´åÕ‘ÞŸbåZBf%Z‚95fÍ$ÔÌ_VV¸àF"‘àðh	F²9%ÌÞö7¤#¬BÏÁŽ0Ÿž#¼­Ôs”·UzNâmµž“yë×s&ÞÖè9…·µzÎÌÛ:=gám½ž³ò6¬kù3%³gJS£Œ<ÆOK„é›+ŠƒOƒ‘Mƒ¡âàEcPÕÁJÃoÉ'#Ùÿl°ÊùÜÌ_@ÏAGXƒž#¼Õôåm£ž“xÔs2oCzÎÄÛ&=§ð¶YÏ™y»MÏYxÛ¢ç¬¼êjŸ0ØV]Í°ÊŒšÔÉp›ÈòCå6Û¦³Ö0km‰°íºªŽªo¡M-Û£qÇþ¶~Î}{AÅ¹e˜[ÛÞ’3ïpª--¸ŒmÏ[átèj§ ¼SGgøÍ{2~$-¼Ÿqyh@ëÉu/çµKWûÔÑ· Ÿ!™í‰°n=êë‹°ž•‘ä|O„íÐsA5ªŽr—ÀhpluuTÕ²jjÎÏ½®–¸ÙCˆ×Óa½:Cói	&™h9Ìž/®F5Uí[í‰°[ÑÔ¨±S´D[eîSâûR/ÉªIõ¿$‡LÕé÷´¶¤ºª‰ÚH†)É‡k†{;#*ÉÉÌ‚ÆLÉìÂtŠÉÉ¬Ÿ™’îéž“ÕT•É!m$Ûã×˜-9Â#–-)vÉ¨ÚD3|ª’Ìpe˜‚YfzÓªLq"‚œ)˜YÈ{Ò{¥#¬¯ UU™)”—…Ö×aýÅ!fã#Ú(ß”kq (BÎŒ!i†ý©¨Ú§D¼Íwªœ®¼*˜d¦àØæÜÅPâ£¬=¯-›ü®M”$êÊðça–*ŽëšåRa¾djÚ?“N©}éh®xÂ6¸etÆ?½e4ñÈ¹o7#©³ÞðÛm8¤³áUUíã6¶ÚóÖ¨LIFY[8Â†ËÜ>C†ä³Ì¡%Ö¹jjŸÕzòëè9›L¦üšôè¿–sž¸ëÓzüMöHçéÕsè¤²[Ïag8ÀuÆ	ÍsSÁ˜Îà5ŽýMðîŽ²®–‹þ=zÄãfÝ-6¡³-6É¥8¬©QudUË¤5¥sƒf“áÛ«ßFÂ6­ßáÀ>ý&=3úM"zf9Îh8Âösà88Èq8pH	@2a)ý%ž:…#,­¿DŒ¾ÃúKÄè;Âñ‡Žr<=ÆñtŒã	è8ßs8a¾'²|OÌñ=90Ïqv‡#lãp`‘ãpàÇáÀIA×P8ÂN	º8´$èâÐiA‡tqèŒ ‹Cg]:'èâÐy=‡¾¢/ˆ'GØ8Ž°‹\èâ)Ž°e=Gò8+Èq.	’Ç¹¬çÐ_\õŠx3® Ÿñ¤rô§ôÉ#<m€áÈžÑs(®÷Nñ$ÐŸ5@Ž~Í 9ú»ôÉ#<g€á#¼[ÏaWq½÷ˆ'þ¼rô?4@Ž~]Ï‘<Â¿1@Ž°j€á½úM»Èl™â¿)Si8¥üt:f–E&5N_-ëLØÐ	ú'`E)ÊáEW<æõ¸Ë]ef3•¿ÃKÒIPBè!PJŽË„P²(qšdH\&ÅŽ¹®`¬©I3wÇº»5ŸÔÝD\æýä·ë7¾Õ•[[åhÛ—¶?uþ<™=Gÿäþ™=§^;–N¯¿ðõo®gÈG¿Éã=AåÆ]òÇäBèŽwøˆD+eJ$‰€H$š¥ÏL‚de<)•×mQ"!“³"ìk5uWTÄÚ»:;BMQÚÙÑk¯ð™CZƒâõTøê¨×£|+6ßS‡CÍ¡mÚ®¦ÌLûþºXGo°±#lžs„þÊ†ªzµÔìnœ	Të}þÚ2gpGxWÀÆúüý2¡€1<Ç/öoÜ%wèËp£ïÛÃ¼Ó©x©˜ˆ¯‚Ê¦2Yšðoé‘di"m Ö‚ÒË“0™H„<3i&²Œ¬¤PÁ«?xh’t)¤òHÇ}^Š§Þ[_ZâtX¸‰Ûbˆ¦³£Kˆ£©3æÒš4Eijïîåeó›£çvf:[vÖÈËÇ-²·£»­ª½ª5Ùë¸þäôÊ@mÕÞ›÷:ý¡ãÝ?õ•˜Ü»ßÐ™cãiòóÛÊ)Cq?¸~ñ±ã”p[v"9}áœ‚!_gÀë ?xÏð°˜¯äUz~lGvJQA¨D)·=ÁæÊ$(•ŽËD’.IS üð7›LÎªp¬s€vvpúÍM‚3¯GQÌ]]±˜7”z×hW,Ø_=>?zvð\²º×÷âèÌóÚÚûZjûÛ:O§v®\¢¦9Q¾q—|Ÿ^‡ÍØßí#²TILr=I"òL
-á%§%È²”…$­pK¤Y3¡ôi:åthšj¯ÛÑìl6›`'v.vÒ ˜)5„Š:0¹jº‰Ãßç·Æ£ÍÝÍ§w^ìÝ_3àê®mNl“j&fOv&]æ»z{v¬ÿ—Äêãïøðî–º¯_?™Òš³»ŽqSEûÆQ©—~ ƒ˜ÂÆæ›NÅ}±É#D±ÝE`‘'¼D!{übÄ4B¬¤‰M&"Ã¦È¶%‡•*¡…ž†ÅN`Á"ÌfCGæ)ÿV;ŠÇ`’m²Év2lV>‹XjMãí¦Æ;1µJKPðVÓÒéx ™ ML%§úzcÛÃÛBÁµºÒí²[1HÎŠ°©{k¯bÖBÜò5~x¯/Ö3+\A\C!­¡„z=BaÝ>E‘Ú»º»…¢¼ž
-òÑñwŸè¾úRKÞŸ…ûê
-ôŒ×uëÕÔ9Öb«l¨ílèY9²ëÊñž‰kS-{õÑc‰ò¦Šjwc ­ºþÑÇVœüäÕø¡âÈSýÍÍ¡éýÀhKGË«ÑÖ½»¯ŒÆ2ÏÏ{vÐS¶»²š„|þ¨ÛGšÝnÛ¸K~Gî¡~Dâ-¤¼30J‹~ÑUFàó–ù]~«¥¤T’(ZŸD“°Iãð“òþÓ‰Äéþþ{ k` ««¿ßÑ¿¼of¹¿yfßrÿ±Ãcã‡æ±~ã.ù1¹NŽËæ ”¸(ðdJ~Í-B®ðsŒ9ÙTðf¾|¯,_2†Læ"(+-qÚ,&âQòÞËsy„b\y÷õý½»—›Õí5ËÇ¬’:á8ñéXÿ~»ÚH¦×½»CQx6Þ Gè{àÅ®x_9Qˆ›@¡<œ¬Lš!ô¸L(½2	EÁœ¹U\¥N‡Ýfµ˜“/ñh§ÖÙÝóÆ¼š×kçòÆÑ‘‰’Ì3Ï×ø¼îÛÜÞ×šnÜ8òúAÛ>‹Ãð‘coàú2JÑorP2J@(®Ë“Ra[+ç¸””ÊsìS”ÏõÇ–Ël²Y)µÕÛÆã4qÿVE!eÅØ ”¾ßÃn3K2%"€_ænêÊ¤,QJ/Qî@p”»]Âºb.nÿn­Éì»(}æÙOÞzæôåõÝ?úoë¯}çÐ;ÅÚ»6îâU¼vTÇ}"üÒÅ†£“ŠñÅpf«õº^¯¶´8ô†9pÛý,¹?ïvBI¥ƒJ´Š@’&xrQŒj›â{…§¬Äj†ŸøM[m8ïA½E‘Ê¡3»†žl­î.ÛVÝ;1Þ[ó´ÖïËÛq]ÕhI9·`oùhMC^f’…ÜC Gã›De¨•T’é„a¶Š­”PàÊ¤Ål’DòÇ«ù[ƒI>J²”pš‹ƒéx€ Z¹ænltYµ\Ê¾˜A³áí]š‹<s±;n‘ëÇ¢]ƒ.m2:5¾Ew,›¢;Èd Úº-Ô~â±õ¯‘`{ÿú§òA?ù%¹öÅm‘àæ¡3O½[È‘NªI6”ïûé›¼F~$wðÀ£¹]Š³zÑrƒÎÀT;?vÛÔíõäNB(«¯[ÿ(š7î’ï’{PP‡d<î'&¹†P l"òIž©ˆøùÏdŠñÓb&¨®¬ð–•˜ë,u²…(…øÛ:+¼s€{h¡ô’ÆAû·Ú‡ÏÇ§z“‡#Êú×lûbýÍ‡ÈG¶vö¯§ú—g¦—ú–†þä®†ñÊ#oÉ$ý
-$TÅ+D¢ò<?,˜Ú”®øÜ1ÉñúÔë•Nüî÷% 9L_Ù¸ÍN$ê DÈ{»HÞòê;&¹#™2¹2i&ŠrI™òÇý •–1šŽ—ðÂë*oÔ\.‹³&siÝ›ÒW/w:®ÇÆÆ&U·•Uú«2òþƒ¦Øä¼Í<kí<²~yùÿ­Èc¶Ä‡•­ñg+^·Ãïô8Š¸©Eä« ˜¿tižëÛüþ¶úº¶šš6ÇŸìc/¾ø±ýùáÖÓ‡Ÿ
-‡O>|º5o—WÈ=¸ðx>–E™MäuV‚q¼ÔÊ³úBo1.ç o´ùŒÏ¯0l¶è òé8w¯.¸ÎÌ°Ø¼g0Ìµz¬Yóúž²Ú¸Ü9Ô³ÍIR¤gýUHhÞh"ÿHî!†]˜ÄãŽ“ÊÊ˜B­¦Â)ê²²I‘—Dæaœv!Ô<h2Y³°ZŸžt‹YžÏ†"Ó)îä6Ï.¸7z"ä¼ÅÜøöâ4±Ø¶ä=œoå¹6ïì Ø=ŸœÜ¹£cWç®h¸±Á_]UYáAŒÄx6äÇˆ'ý]ùF˜h$¡ôX>1•6å	nÖšøÓÝÞÇ:GÜUoUSW:æ	–²£%eíû;Ê\v§9”>¿<®µoollooÛ9iI6ûCCW³#Ü¯ËŽæºÚÖRÙ=Þ1µÍl: —6Uw‡³ÍãòVîˆ·í’/v´¶¶··¶v¬¯µÕ×zÌµ`ÁïÑ—ááw™HÄð{F°{“k{“_óšßä×–åú‰¢[£/öxmä!¿6¶q—ZéË(G]ñ^g%&©ÆOe-Üë6õGÜëò~Ï¸²‘7ßë
-~‘7ßë<nî Ýuž:§]¤%å¤œ;HSC“fÖpµ)³3{+*H÷H\²Y–êÇƒGOôß»=ÑÞÓÑSsÄ;èËŸñ7\bÿ•]ÇÎŽÏtÿ´ÂÍ}ã,@¾G×`B}¼€qÓÉH¤ OL.—ì¬	DÀ;»BÊèÚýWç@Ý¸KþšÜC4¼Û`ßå$„ÖÕ:Y&yImíÛt®—*qÑ7Â¯TLk‰›¯1^Ì½þj‚jÍ¯y=®R›U¤Ê\ÌKºC›¯‰…ÛoWw§0õÛñ™÷~4µ7Z¶ì=zä¸En·ÔÅüSÍŽéøì²PWµgª:xöÔúk]5¡cUU§ÑP½Ÿçäë m£k°Â…p¼™ß‹µ“S†óÍÛ¢ÍfsÙ\.W•°E·9Ö×ÉskMšùï|Ÿô•Õ–ÈÎÚ;ß¹þ§b?ˆ‘£ÓÓçººÏ®_ k÷/ærÂ¨•Ü5†'¸s5¡¶†Ê&¡²”w\µ0™
-ž”›’ÜÓ“
-‘¤'¹SNuK­a+N:îñz¯%Àw°ÑeqV…}2ƒ¼»ðyÝ›,N$3“ÍGûŽw«ñ:iÞ°8ûËô/:ªC×/î¿2P[5sƒx²9ü]3â±°9î`/‘Íñ˜[Ûì
-ƒ‘Or;ý_tv´Æu^e*äùéqÃheÙt\!&Ó%_Å»‹ÌN?/Xy"xgÉêú/îÜ!*]›ûäÜ—æŠkÓ!±vS¼‘ç.‘Oò´weR1ÑB-bëš¼si®€kv…XWVÖïÑµõÿKÌ÷/’†õ×Œu[ð-RIBP÷öµ’îÎ˜·åWßÚ/ê,TÐSG×à€‡Û$*‘“å<·¦Âéô”—:yŽ
-(Æ	-Ü|5¯+Ö.Ü÷ì+c‰£Ç¼ÏØ>ºJMì>ýßdòÊ ß­ãø	ÞrøâÂý-Ïù\ÂTãuV†}M]]Mâ·„ÝUÛ;y¢W‰Öo‹Ì|v—{0lP›zÆÎ‚`ûÆ]ÚHo ¦ûWñÜ¿zKîÿÔC¹¿Ï+rÿRóèÜsòxö÷î»>3©¨êuÌ¶-hIVïl^pL}ðÌãÞ×¦Tù{O]x6P3m+ÚÏkâÜn‹‡Þl?&"Ë—d®f+¬\ËFüÈ[Žk–¼wýõ_ýŠ®Í}nný¸âj6îÒsôl"£‹P"¡¿7ÒÒp›ei»ˆ	QBÆ A†$_ãšågî)n«$Ëï£O“)‡½§«¹É_e9bMŠÓv{|"Ów^ÝEYˆšW¿ZtÇ`ñ ÞdˆFÀß¨nî©¬­kÒâÙ.mGÀS±m¼=9¹m°±nj›?ì<­MvUÔ§·½˜Œú;«ÂÓjF~m¯î
-U7Fï7:Ûê¨ínˆŒë“ádwUó¤ªŠ=½ä®VŽYµj5ô_·wzËƒûõŠv.Ûj€ZèÌÄëø¹!Ç…'|PÇ3Ãìrå37­3àÕ\ßû"ùÕ©>7wÿÕ¢ÍÇé,p‰S(I…“¯DþÁUj·ÂsÀdø!­É¨¹iÚì§_ø³?0›?sf>F×>þñ?ýä±å'¯žçqãw ­¡kpr:BA&¸Ó\™|íœpVÑNŠ¹+*¸óëvÇ¤/õéT©¿L.«*;~åëtmý/{zzzÈ˜áŸ$A?.TCÃŽx—•˜ÄÝ&™šNnâG–Éq¥À¨õWWzÊáBYÀ\à‰3ÅÝ«8ÊR9W‘Ëo-õ·ê½ÉÁ‹»ÏÍÄãævOMŒÏÑµºÑ¾öÉRÙ16˜Lµkí-mÍë¡ÎîŽVQsè«ä\Â5eŠ$Lä¯¼&¹èè¸ªŒ¨“b¾¼º7A’–efóç.÷Z&Ùì4÷]°”˜e³ÝÜ{î™Ûnv*²â°´“;a]lÚuïOÉ¶¶dà'F}]ÔÈÏhœ 9HÞÂš¹E²Î0§½ ß&wP…P\ó”˜‰\Pß–zGªÊ«Ê…¡¹›6Qlö= ¹ä#xG·Ýg—­kë•?þÈ;úUNÙVaï ¸ó˜'ìñ„=ýöÿd+t¯7ìã¾Í yCøÖ¸.¢>)T®?ªrm…µÜeÒI/	x›IßúÈ§×ÿšì!?›Y¯æˆßO»D­mñˆË.ó«#/Mp»¼"^‚ÌqGù¬p”¢Ò_Mª·¾éîÞ¬+IQN{êJ*le–¦V‡õK—Ø½vÙê¶ŽŸ¿YŸúïŠrP¢­ÁzòÓ_«£ZÃhà×÷7f³…Xø]C=¢ñp•Û°HÜcÒkÆiÙ”l×£¾2ŸàÄ\›O·»ºº5³¤IMZõºfß{Á^n•­.Û…ÕÇMYî8=uº]–Í&º¶~»¾¿±±¿žÄï_$-õÓ{ë^\ÿi|±nïtýúwù‡6î’ûôZxL©$­’(‘è–÷EO=ô¾¨Ö_á1›ÐBZŒ˜²éu‘ñ¾hkm©Âç3Ž)_f—öXkOïý°ÚßÔ³ß¹ì¯EwÔ¶ùÓ;Çz–™‰†`4´­ÑÝTjí˜Ý®7NT×nk¬
-øìÁª}£©NN·gã.]¦¯ ‘¿öæ‹	¦:bA=±Zä	ÿÃv‹\È‘Ãü„d"×¸LTZ²™)·9…×üÚ&a±XçvjµvX§üñÖ·Çv»½Õ˜1#-ò¯f47…´@ƒËeÔ$œ–úGÕ$CEæ	Açƒ2E…ß?ð©’ãï|çˆ³ÆæñÄêŒüi±hqÐ1ÛùüóG~qÐ,0Ûç÷þbýÈÆ_ÑAÓ/ó¼K¼OªéBÕ‘`ßæ¢#¡äÚ”„Ô‡Bõõ¡l¬«ml¬­ãEsq_ÄÈbnyå-rË±ergÝkØ 9÷Æk÷üÓñÒ¾ßÀ,ýœwÿpÏŽ÷‰vßØêýÕõ¯[ÎI_kÐüßóÚÖÏ×?X>tu½ÇrN¬´ùÓI?ŠýäÓ¨$
-úiÂä.”@£ºô8ÚiÛ¨Ž!²)ÅµaŒ¸±‹¼‚mÒŒÑ6Œ‘B3IÁAúá¡ÍäÆ¨Í4Š1Ãy³TF_htcv`ŒTc–òï1Kh¡#˜%n´Ò8¶“uÌÒgQCPMŸÀ,­Üø=€YúKTŠ½„ZƒfòpÐ×1KÑçx=lã¯ˆ"ä»ÿÿ‰4yžü’þ½T#]”>#ýLöÈ=ò5ù‡¦Ó;M2ýBÑ•kæ£æ,K‹å–OX~`±f¬kÖÏ[¿ksØºl×lfÚ§íÏÙ™ƒ:¦ÇG¯8=ÎŒó%ã%+%kB¢à™ð"¬ Øwã üÏÏªDÀþ8Ïe+ ®/&Ðñ¾<LQ‚[yXÂ8¾’‡åM8&¤HYVÐLNåa3^ ïÏÃØh([QIÛò°ítwvJ*}*— ÃtŸ‚Šv´¡1¨ÄÎc‹PÑŒSXÁ
-. ­h7~Qd‹8QÌã<Î¢Û CÅ,a§ b‹XÆ".â2± #8sXŠ)dq–ï Vbçq	1EµjóTÌ"‹sX†*(›Å"Îb	s83X;œÄ%œACmèD;vbCH`/vnY¯°Z‘7­eÌÙ‹†qPP½Œ%A¯ºeåS8Áó9\†ŠíˆŠovâ,²x‹ãqUðÐŽ(ºÆïKËV,	þ³P±‚‹Bò›sü8TœÇ‰‡t¶$hæ:àOpNhÄÐÀ,VOÆšç°€VœÇE±’1‡Ãœ¿KBW±$°£›ö˜FVH]Å¢P±;ûûÛÊ
-žÄ,b?Nåù{`œûXÁÁã	œÁ’—šÁßu!OqßYŒa*öŠõÏmYybË
-ÜZÖtA›ê&Ê¶îû@—‘Å’°½9œ#lŸkkƒØ'àôB}H:Ë˜²½€!]NÃD….N¢{1‚‰‡(ùçe´ ZCks¸TÔ»Á×7?qƒ˜…Š1ÌªUP‘Ïc˜9„1ìÇnìÅìÏƒ˜ÁŒxw¿cs÷b*’Ø‹)‰c6ÆF„EN!{0&pøÚ‹yùãçã‚ ~YÐnXáÎâ‚9§œóÏOÇâ¿HÃ*NäW-Ì]sæ±„“k—K…{‘,Næ­‚ã\'r¹hÎ‹a|Ô8KÆOâ¼ðuÅ™ã«ªx2–¹µ4'vå÷Ðjô_d3ùØ¿ñ
-ÚùÿE b£HÀ+ê¢3HáÐŸ#˜Æ>ìF9ÆàÆŒc†ÑŠ!Hh6ÒŒ0ÊC)BØ+ºÑ„â0jqý8Š6t^jøžtâøŠùÒ¹¥¶X[7öÜÂWgR9BÖÒŒ{!s"nÿwxæìcû†;aE‹èñ¬Zž“/Zæ,•q¥×¢›e«-?ôåyú”rZ9*OË	%fj¦b¨,1ho¸­Þ®¹]yÛ{»üvÉm{Ü‡ö–ªƒvÄßôÃ?Ç#ôP®‘\ß—bñë)þ¼0”kæÏ·,0:0”öçšx×ç-×@äøõùý…þ‰{Þ§¼›®(JJžû”¨)D­%-·ÈÆ{˜üG9Š¡—L
-†ø?™ý?‘^ì¾
+xœ­{	t[Y™æwï{zÚmË’,Ûòòäg-±ždÇòÇ‹,yßâØY¤$K^’8•­bg©
+4U1EN5Ã°d˜i ûMŸ¦¹JÑt a&šžÃ[Ó§†e(Â¡é3¡Šfˆ=ç¾')v*UÍôi×‰ïÿÞýï½ÿþÿ÷. V\€–Å‹kòì£å >–cçŽŸ^h¶þ@~”ØŽŸzôØË'ÿù.Pú î'–³KþÜ·~ DŸÐqâÄrÖü#ÃèW 4ž8½vùtÔrˆþÀN]Ìþtéþ)ÐüU çOg/Ÿ#wJ¯-q ò™ìéå;¯üÃ8Ð’¤sçÎ®®}â©Ç¿t|ÀóçÎ/Ÿûî‡ž¼t^ˆÿ?—p	d¨ žÍ;¸ˆ‹8Š£ô@n›}ôúæòúæÍŽ{s›wè‹äöæÍi>K_Òæ§±û‘@B˜¥_&oÇo…}‰<Š_ß;ƒŸP+?ióN'y{qÍ.òhqÝZøyjè—´óZ1‡9$‘Ä×7ÇñýÍ¾â~Åýî
+Åýî2¨2ÃþÔPZ–'n¢dï“æ¥X›—…Ò™còúþ£þìgL0aqQYðú|i†¤2xÉL"ÂˆÊäÌ±£ªâS|&¨òÒ‚ËD’9“r&“ÈQW2‘óIF“û.ËÌ¦0šLf—˜8sù¥4™I0ßr¿½Qâ&‰™Ñ¤’¸á$Îd&¡0Ì¤–Ó7*ÇŒ0QeB˜¹“)~«H&ó^yIf·f˜8t#DìÉ¡Å!&¥|Lð§g§|ŠÏ»ž’ÙÌLÊÇâi¯Ìº8Ô•NË9;»ÄB3)_þIf-|¾…cÞšIÉÇäõõ¬Ì,3©ŒWf2Ÿ³p¨ƒCo&N{õ3[r‘a6Å0Á‘}Ì–ôN°:ÕMdo–a‘cÜ4`!^Ê¦	§ÓyÒò«H*‰t„TyHf¢?»$3cr&ÅŒJ‚™”„×çK3’‰0I7ÂòRÎ¸ù$g×«“Ï3sfh‘š|23%åuy‘p®Åàgb`o*3ãÍÎ¦SJÚ—–Y|.ÅHØËå’'%ÂŒ*3'Ã7@u5›TfVŠÌ $²Œ.cd‘‘36E˜Y•9µ%ÉÅ›"d¾‹gÒ%3¨QkQo˜KJ4ùŠ†cU·’Mß…„†$ýyh]Ér¥jÂ†—+„É^/
+Œ	~%;¨a“å¬q&ÅÇ´¨„Û¿’xÁnƒ04“òy_ºÉa¥jŽÒ!¶”Œ°2•‘Œ,³Òä8ß@f¥J"ÍÊøÓlJfeš¾ªÌÊ4¡È7E,®+YæHfäõŒÌJB‰°rub_*'.¦™}Y¹aNubojbNéõ¥™S{ïRs(OîOåÊË“ŒdÌæ.Ç¨?‘+å¿Ê¨?ÁH…"3Á?“Êqñ1ÑŸX_—ù±eM>…‘löêó|	õkoÒ¬49ÂÊ’#F·+ëMT˜œÊ #I†¾„M[n9Ð¡})V®$ä!V¢$˜]aæLBÎüue%N$	.—’`$›s™Âì]aoC:Â*ÔÜáó¨9ÂÇJ5GùX¥æ>V«9‘^5gàcš“øX«æŒ|¬Ss&>Ö«93ÃªR?“2ûRŠeä!î-¦n™¬(N>¢OF¶LŠ“çõIY+¿)ŸŒdÿJg•ó¹•?ŸšƒŽ°5Gø¨¨9ÊÇF5'ðÑ¯æD>ÔœA5'ñ1¤æŒ|Ü¡æL|lRsf>FU¹G3ØfUÎ°ÊŒœTÉp›Èr'Œr›mQYs˜57EØNU–Gä7Ñ¦’íRx`K/ç¾µ â\‰4Ä-ŽílÊˆ{(Õ’Ö¸ŒmÏ›á´©r»Fy»Š<ÎÐÏd$ü@Zø{T|JËËƒ}JW®¸9¯ªÜ#¼	ýÉlW„uªQOO„uýK¨Œ$»"l—š£¨ðËQy„‡Fýcëë#Êˆ’•S^u•Ä.BÜ®¦ëV*˜GI0ÑÏD¿†–³!Á¬ÉðòzT‘åžõ®Û½MŽêû1II°e–á1%¾7õ‚(dïbÀPNðHkIÊëŠ¶BÎ0)y¿»fx´Ó³’˜Ì,)ÌÌ.Í¤˜˜Ìz™!™á‘îþ5YE–™P†³]^…Y’Ã<cY’Ú)ùA‡(zL•’®ƒ?ËoØ•‰N„Ÿ!ø3KùHzï¬t„õd!Ë23ò²Pzº"¬·8Å,Úü°2ÂåZì+Š3£Kša_**÷(>-ßæ_Êœ®¼*˜ägÿØÖÚEWâƒ¬=¯-…›|ÿJ’uexs?ËÇUEŽr)3O25ãM§äžt4×B\áØ6;ëÙ6›xàÚ·Z‘TYwø­TÙîðº,÷p[ïzsT&%£¬%aCËÜ>ºä³Ì¦$tÖ¹*rUºòû«9‹èO–üšôÈ¿•sžxëQº¼¾-öâKçéQsè¤2ªæ°;ìã:ã„æ¹)Š`LepënÜÃQÖÑaãoò~BÍ¸œ¬³)Â&U¶«)Â¦¸‡9*¯+Ù‚´¦UnÐl*a{ÔÀp8ÂfÔ Ø«Þ Ú›YõÑÞÌqœ‘p„íã8ØÏq8p€ãpà ú€d8ÂRê¼t
+GXZ}èï©/ýÝaŽG8t„ãiÐCOƒŽr<šçg…#,ÃÏä@–ŸÉ~&9Îh8Â–8–9Žq×èGØ	.­htqè¤F‡ÖèâÐ).ÖèâÐ.Usè)*ðœöÄâá{DÂvž]{J„#lUÍ‘<ÎšrœÉã\Tsè-îzI{ÒV\ÖA¾âQäè©9’Gx\9Â:ÈžTsè+î÷6íICJ9úäèoWs$ðä ƒájýÅýžÖž4ôgt£ÿ¡rô«jŽäþr„uäïRoXµÊ–IÞ"†RŠÏëK§afZfBãÌåB²ŽÀ€} ¤ï… 3JQ7:â1·ËYî(3©@&ÂqPBèAPJæEB(Ù”Ø"ƒä	Ç>‡?*ÆÎXg§â:ƒÄaÜG~³qý›]Q±¹YŒ¶|açcgÏ’¹3ô½wOMœXZzåh:½ñ¾¯}c#C>üžï	*7ï?"¯#€Îx›‡´R¤Dˆ0	A YPúäAV$Àã˜&ðV¹&	0Ø+Âž†@°³¢"ÖÚÑÞFi{[G¬µÂc(’ÛUá©£n—ôÍØbcL
+„};”þ`f¶u_]¬­ÛßØ„l†„·²¡ª^.µû;ƒ³¾ê½Ç[[f÷ï
+÷§ln¢ÀßÒ/Ñ :Ñwð‹=Â›wÈmú"œ¨Ç³Ì=“Š—Zˆx*¨h(#…Iï¶7‚(L¦uÄZPzq
+É‚'§ŒD‘$ªñêûî›‡ \È#Iº<ÒqÛÅ…âªw×—–Øm&	Nâ4é¢ioëÐÄl9” "IÁÖÎö@^6¿>rfw¦½iw¸:o½£¶Î–ªÖªæd·íê£3k}µU{nÜík÷æ;â)ß?µgŸ®3Ûæãäg›·  “–ã^pýäsó”p[ÑìD°{Â9	ƒžvŸÛF¾ÿôÐ¶^ÈËô*¼ØÚ¬”¢‚PRn{›kS T˜‰ \¦xáùƒ{U8ÖÞGÛÛ8ýÆ Æ™Û%IÆŽŽXÌH½}¤#æï­î9=p&YÝíy~dö™s-­=Mµ½-í'S»×.RÃ‚Öºy‡|^…!LÄG=D*‰A¬'0„@œ„A"¼å´Q²„5n‰4k$”>N§í6ÅWSívÚBöÑ +±r±“ÉX0H¡!PÔQ“»F­N7±y{¼æx4ÔÙê;Ù?r~ {_MŸ£³6”Ø!ÔL6Ìï<D:|¡ý“ýÝ]»6þKbýá'>8ÚT7ìöªÇSJ(»Ô´Mç¥uóˆÐMßƒLcs‚yfRqB,â0‘,}ÄDû	Lâ¤›HdÂ«Í†‰ùþ™´¾0h ",’hY±™©$j’èI˜¬&,ÃhÔudœöN°Ú™T<ƒh–+a1óUÄ,Qsoµ4Þö€U¨YX„7[–NÇ}ÉÁØHb:9ÝÓÛÞð7ÈÕ•N‡ÕŒ2`·W„<
+ôÑXk…&f¥!À-_áÞÀßzb1£ÄÄ5PJ¨Û¥)¬Ó#IBkGg§¦(·«‚|xüÇº‡.ÿ§ÔÊ÷Åcá^‰º}]ãuãj[5µ5Y*jÛºÖ÷_šïš¼2Ý´ÇW=š(VT;}-Õõ}hýðñ]ŽüÇ?Ö
+5f†Õý#MmM/·E›÷w^‰ež™;úÔ€«l´²š<Þ÷È;‡‚ºnwlÞ!¿#¯£^DâM„|00J‹qÑQFàq—y^³¥¤TÒ$Q´>MAÍ&uç'å½'‰“½}üw_G__GGo¯­wuïìjoïêìÞÕÞ£‡ÆÆ;Äsýæò#r.œÐ—ÅF(qP:é-<ˆ”âšS „\â~ŒÑPˆfžü[Q¼ O
+1ÌAPVZb·˜"\Ä%å£—#æpiŠqäÃ×÷öŒ®6†ä5«GÍ‚<i;öiÛø^o«ÜHf6Ü£(\›¯‘Ãôi¸Ñï)'qH”§“µ)!„Î‹„ÒKS$,YÅQj·Y-f“Q2ˆpw!€¶+í1wÌ­¸]±Vn!¯íž,É<ùäPÇíl³,ìyõ€áúõÃ¯°ì5Ùô9¶ù^£/¢Mñ €’IPBq„\œ
+Çš9Ç¥¤T¼Ÿc$}¦7¶ZfR©¥Þ2§‰»7+Ê9 Jú ¥ôEØøV‹Q)ÑøE¦.M‰¥ôåÔ[¹Ó¡PGÌÁíß©î±óÂ§žúØÍ'ß6I_Üýáßm¼òíƒoÓöîß¼ƒ—ñ¬¨Ž{´ôKëN(æ=˜­×«j½ÜÔdSTþO—·ÝO“×áåùÝJ(©´QVÂ$/.ŠYmK~¯p••˜ð¯a»ç#¨»( R9xªð‘æ‘êÎ²ÕÝ“ãÝµ1WsýÞ¼×U””sv—Ô4äe&˜ÈëðáHÜf¨¹’
+"ÔÍ¶BÒR+%¸4e2-yãÕü«ÁŸ%YJ8ÍÅÉt¼€>¥\q66:ÌöZ.eOL§YöÅÁÏXÇæMbýX´cÀ¡LE§Ç×üè®U0º‹ÜNú¢Í;­ÇÚø*ñ÷¶ön|<?èô“_×áÂÞ¸E œ<uæ©wjr$„“juå{ãô-Q#?“ŽÛ¸àRœÉ^½…è¹’N§oº•»Ýyg=¹£Êêë6>ŠÐæòò:$Ô!{‰A¬!Ô@'A ˆxœW*Zþ|’W2Åüi2TWV¸ËJŒu¦:Q€D¤BþŒmKn—ÑÇ#´¦ô’Æë7[‡ÎÆ'º“‡"ÒÆW-{c½í¡†ƒäC;Ú{7R½«³3«}=+ƒ>o²¿a¼²F¯[2$I¿Uñ
+­Py†;¦·”+gL°½:ýê‡…c¿»Îc	@Ñ—àF6n±ÚÑä½S+ÞòêS<i•2¹4e$’tAšöÆ½ V0›Ž—pÃí(oT“½&s(í[ÊW7:Ž‡ÆÆ&V·”Uz«ú2òÜCljÑbœ3ÏµÞ8‡¼üÿ‡VÇlËkÛó¯VÜN›×îÕ8ŸŠ,¦C-óU,^¸°ÈÿÕ·x½-õu-55-¶¿øÈGžþ#ù‹CÍ':Ÿ8tèdsÞ./‘×áÀÃù
+X e­®3Œ{ã¥f^ÕÞ+àržòF›¯ø¼ñ
+Ýf‹"?‘Žóðê€£±±Ìt‹ÍGÝ\«ÇBŠÛcs•ÕÆ=äöÁ–˜eA"]/C@h3H~K^Gý˜Ââ¶€ŠÒ˜DÍ†‚uX‰Ñ ‰+Zå¡{»&Ô<h0˜³0›Ÿ²“	Yž¯†"3)ä¶®.„7:-å¼ÉÚøÎâ21Y¶Õ=\oæµ2oo#ŠOLíÞÕÖßÞ76x««*+\ˆ‘¯†<šñ¢¿½­#?h&Æ3Ú½ISz,_˜
+[ê§+Aþt§û¡öag•Ï]ìHÇ\þRv¤¤¬u_[YƒÃjW"Ó‡ãÇ•Ö­­-»Ç#MÉ70ø÷5»Â½ªhÕÕ6—ŠÎÁð®éFÃ~±4XÝ1Œ—Ã]¹+Þ²'J>ßÖÜÜÚÚÜÜ¶q­¥¾Öe¬môùq¾¿3ˆD zÜÓ“ÝBÛâšÛø†¸¶*ÖOÃ}ñÓóµ‘ûâÚØæj¦/¢uÅ{™„/´p¯Ûò†<à^—{ú•¼ñ^Wˆ‹„¼ñ^çrò é¬sÕÙ­ZYRNÊy€44£r«-•Ñ]QA:‡ã‚åðªP?î?r¬g~ÏÎDkW[WuÌo£/~zÖÛpõ‘}—úçÌÏvþ¤ÂÉcã@þ7½+šã*["Žó¼?`Wl†y‰\¸VXüÇh÷òF€Û§•G>÷YßøùíÛD¦×>¶ð…ü=+ºy‡|‘¼Ž*(x§.‡ZWk“D‘Tä%¹ýÝ–;r¥véÒzzŠeÍ½)íf¬Ï«J··š Zñ*n—£ÔbB©2ë–ÎÀÖkdávÜÑÙ®¹Â­øì»ÞO‚­C¾¦Ç»ž7‰ã¦º˜wi:d›‰Ïí/tT»¦«ý§Ol¼ÒQ8ZUuÂÔ{ówä­^®FK<â°Š<ðòoRÐKOB°ÀóS¼àñTh·öjR½½¡ÑÙ)Ä<<ÄuvÆI:éª+©°”™‚Í6ó.ì·º­¢Ùi?{£>õß$é€@›ýõä'ÿ$(#¾º»9—å´4á›¤’  î­ïêí1wÓ/¿¹/Ïç6ñ]zÔÇkt3 „f8º`p8D{¥VTúÜsk¤Œ^»ûòèæ@[è5˜á@8â÷èboé„žœò¾j±X‡ÃQ¥ùªÓ´ëšàŒ9• bü{ÏÇ<eµ%¢½öö·¯~û±Ø÷cäÈÌLÛ™ŽÎÓçèµ»çs9ÍWû¨™¼®õ`áÉÇ€Ú*„ŠB>°×Â`(dîjšá<>%Ax”'Ÿžt¶õb¶ã¤ã.·ù^œpú&{UØs¯rÊ‡SÛ¹Å#µbo*td¹g¾SŽ×	‹ºGz[_¤Ÿh«\=¿ïR_mÕìuâ¾Ï'ñ·ôš^¯hòç	èÙZ¯pÉÏ­q1uF5?Æyý%ñ8/Ý×¦$-ôS¶û/oåÅŠÃç˜[#æµµ×éµ&Æ»çIÃÆ+ú¾;7ïÐzõŽ'yo#ZI±–@àˆ‚A<^ÈØé%}>”Ôx««òe}=©7¾UYß®´Ç’D–SÏÎÌ>{p8[ßWÕ=øð±…šÖ²'~ì;m›~ÿ©‡?¸7&TÖ>uæÜS¥%ïžßø/¢÷ú2¹ç¿¦LÉ|9o‹ðÁç¨Ò-.¶ÕÇ¶x›’·C£ñú;.v›lÑh7ö\î3•E£ÕØ}æÉßj´K¢d3µ’Û›¾!UòmÆ÷}É––¤ïÇºü‚›¿¢{©	fN—Ió£DÉ8á©W‡óÁ–`£œJ•aC°Ó×îv7éëúËUòî¿ì"Î²þ?>òÇý¯‰ ÈßÑ'`ÃÜ_xvr‚ygRñj~Í¤W@éšvÓ3"ŠDí6@	}äém3úmÀ›ÃåÐåÂ;†í<}Ž_»Ð<\wàÉ£ä££æªò»ÿëh>>¼¢ùøŽxà9#¿1 3ÌÜÚô\œÏŽ9ò®WùKzmá3ÿÈ-ºfó=C¯Ã¢UgcñaJôvGš}N£(ìÔòk”1!ˆWxváþùÏO$Ëïö“i›µ«#ôVYc¶XP²{ÂN—G+m•É™·ºÎ¢ñiýÃ
+~MëŒi€1À‹¡ nŒüõêPWem]P‰g;”]>WÅŽñÖäÔŽÆºéÞ°ý¤2åë¯¨õÏìð}>õ¶W…gä…ü&ÚZÝ¨nŒÞýNt®32ØVmˆŒ«S}ádgUhJVÆ_qVKGÍJµø¯;ÛÝåþ}jE+7‚j€šè5á‹×qÿ%óZÔ¼×5Âèpä«`¥ÝçVßý<ùåç©º°p÷e-ïòX§×`‚C‹‚PÈæù®¾K¥V3L0úz<Ñd¢õþ¥¢Ì}ò}öü{b‹§N-Æèµ~ôO>vtõÑËg4»Þü@kè5Ø9¡ “<Àr³+d	;ìUz–bÎ¼9cÂ—¾òxªÔ[&–U•Í_ú½¶ñ×]K]]K]dLe‚F?Ï!TCÁ®x‡™´>
+"5ßÂ(’y©Àâ«õVWºÊá@™ÏXà‰3ÅC± …sŽ"—ß\émV»“çGÏÌöÅãûF§'Çèµº‘žÖ©RÑ66L5‘+­M-¡@{g[3ÿ& õIÈOi% 9@$>Âœ¹I°ö0×%Ÿù¹*âŠ«ÄHÄ‚˜¶õhªPU^U®)ÔÜ‰Œž{¡¨äCïy¢Óê±Šf—¹ùÒ}è‰[•]´TXÛn?ä
+»\a×C¿ù?Ù
+Õí{²zì	ä5ÍO›ãª–‰I¡Û>ÿ n»ær‡NH;ñµûÜÄç‘ž’On|‘ô“Ÿ.oT/m¬Ž^ƒ.žç!€:Ç!ŠÅ(çÏU^jçñ%à“ôŠ¡ÐUÜŽX«®„—ÆÎ'çFŽînbl/½HMŽþŠL]êãwL~Öûè5Ô#W9õØGzE·º-€zÔWæ‹Š˜c‹áñ+@GG§b!¨ÔQ·cî]ç¬åfÑì°œ[Ø`Å¶“Ó'[EÑh ×6nÕ÷66öÖ“øÝó¤©~fOÝóß'Ï×í™©ßøŽ.ßÀær—^GïqUV	”tÛ7¬Çîû†Uë­ph"MzkË',ýÖöÄXáñèÒ"åÏfú•‡š»ºw©‡äÞ`×R|÷Š¿·~$ÝUÛâMïëZ±e&üÑÀŽFg°$2ØÜ6·Smœ¬®ÝÑXåóXýU{GÚSíœn×æºJ_BŸÈ_ÅóC1¡ž˜Mâ¤÷þ—V“X¨ËÃü;‰` W¸TX±)·)‰÷![¦`2™lVj6·™§½ñæ·Æ¶«µY_mEZ«yBŠ¯ÁáÐû$vSýƒú$÷´Z_·úÛïµN*¼Þ¾—Ì¿ímÃö‹Ë«Û?ü'ÅFÊÛ\û3Ïþù£¸ßh]Üóósùz§‘^GM¡oYÅû–ÕÛú–ù"§¨S[+pjHÍƒû–[—‡æþpÏÞ«³}^ÝÚæZ–÷7%«w‡–òÕM‹2\åí>9vî)_Í`´E³³æÍqüÏ¡ž¸K/¸_Àtã µW†=ÁŽŽ`Cƒö¥#ŸÜF«v¶óf\m$Z¿#2ûé~ç€ßß ûºÆNƒlþÀý¯µoy5Z1’.t|	önmøòyŽ-›×õõ h¬«ml¬­ã,´»:>GnëÖKoR·Ž­’ÛnÝ‡ Á¾Çö­óó¥=¿†Qøýƒ‰]ÏjãÞ±õ»ë_3øßs×x_ñgŸL¸»¾Ñe:£í´õ§‹~ûð€|•DB/mC˜Ü(”@F+õcU1HVà"¥£Œ'úÉKØ!L`Œ¶`Œü_„H
+6Ò%‘£&„hc4†1Z9*"Jþ6’@ys4º¹AÛ0FøÜû1G×°“þ•ô$‚”`œl`Ž>…Ú€júæhåæïè~Ìigÿ%´!:Œ9ú*æ¨ú¸h;‰ÍÀæßI“õ(FñŸñç¤$È3äô„á¼ð)á§¢Kì¯ˆ?04Þfø€áç’*]11¾Ïd3u›>eú­¹ÂÜf>eþŽùW–Ë9Ëç,?µ¬ÓÖ—­¯ÙB¶¶?³}Öö[{È~Ôþç%RÉ{K^)5•¶–jyƒK<ê/ÃŠQ¼ïðßKl¼2Ó’þGy.Í ¸u˜@Å³y˜¢7ó°€q|9‹[pH‘²<,!DNäa#ÞGžËÃ&Xh ›QI[ò°­t4Û™>–‡KÐf¸ŽCF+ZÐŠd`	g±€eÈáÖ°†sèF3šµ¿ã¿„(²Eœ(q§ÑŒP!ãV°†1‹e¬bçqËX‚ŒaœÅ¬AÆ4²8ÍO+1‡³¸€óXÄ²\µõ	2æÅ¬BÖ(›Ã2Nc8‹SXÒN8Ž8…,Î#†(ZÐŽVìÆ ‘ÀìÞ¶_a·"oØK_³	á€Fõ*V4zåm;ŸÀY¬i<ŸÁEÈØ‰¨ö¯»qY<Œeã–qYã¡Qth¿/-Ûe°¢ñŸ…Œ5œ×$Ï±9ÇCÆY»Og+Í\üi?ÎhÑ50‡5dµ'}Ï3XB3Îâ¼¶“¾†Ãœ¿š®ÎcEÃŽn9cYMê2…ŒÑ<îïo+kxç°Œ}8‘çïžmpîa—4ïIàV4‰p©éÜðS—òøÃ&!c¶ÿ™m;OnÛ[ëýš.hSÞBÙösïéã"²XÑlo§´™{¶Ïµ5ŒìÕà5tC¾O:«XÔd{kšt9§ÕtqÍØƒaLÞGÉ¿,£%mÔµ¶€E½ëÜq}sÀdŒaN®‚Œ„ö<†9M"1†}ÅìÇ>íy ³˜Õþ–bÆ0¤­ÝƒYÈHb¦1¨­Ó`}nX³Èi¤!ccß{9/]cÜ?ÎiÔ¯j´ëV¸‚Ó8§ÉœSÎùçÞ±ü¯Ò°Œcù]kWµ5‹XÁ1“k—K…G‘,Žç­‚ãœ×<rµh÷üE·>«ûÒ½ùã8«ÅºóšÏñ]e<š÷en­:MºÇ®ýZþ«l&_l¾„Öþÿ^]Z:€IŒ ·Ö‰žE
+5:0ŒìÅ(Ê1'öcBƒ8‚24£Q³”0špˆP¸°ft"ˆ]ð£‡Ñ‹ZÐAPJD|×xáÌJëÎ]­Â±ù5·ÄZøßŒMÜÄWfS9B®¥Ñÿlù\ÆDÜúðäé‡öµÃŒ&íkÝôñ¼iÁt@—ºMª±Q4[òSï‘ž¡I'¥#âŒ˜b†Õ¦ÊÖ†[ò­š[•·Ü·Êo•Ü²ÆÍq˜amÊ¡*1`EüÿñÉÏðŒ=˜k$W÷¦XüjŠ?/æBüù¦	ú¦½¹ õYÓ1~uq_a‚ÿÄ]ÏJï¤kÒ’”'Å)jPsIÓM²ù4ß£|Á°$apÀÿÕm8‘
 endstream
 endobj
-329 0 obj
-<</Length 13/Filter/FlateDecode>>
+370 0 obj
+<</Length 12/Filter/FlateDecode>>
 stream
-xœûÿ
-þ  6Ð	ô
+xœûÿ AJ
+w
 endstream
 endobj
-330 0 obj
-<</Length 655/Type/CMap/Filter/FlateDecode/WMode 0>>
+371 0 obj
+<</Length 673/Type/CMap/Filter/FlateDecode/WMode 0>>
 stream
-xœm”Koâ0…÷ùžE¤vÑ!¶óh«
-©@#±èC¥šYC|a"'ÊcÁ¿Åç@«Ñ, ßkßûù˜ÿxÛÜ<ºf'7ög¢Þ¥oÆ®’›åó¶âxÕTãQüð"âÄ£ý½j»¦êePËõjíë!Šãµ¯>G'çœÿ¥,äPû¯„©†ZŽýÐ£8þ¨‡O¹WWXP¡'µvâ‡z8©ä:Šã_Òõuãï•ŽâøÉ»esœšë£k¨Ù[×TÔ¾ö®c%µ›êFÚ(WWUø®ŽÛ6lÞœúAŽk¿o”E–[f*¥Ôì]u?t'u»VNöˆ¼vNºÚÔÕ¹ÙoÁÍØ¶Ÿ25©’°*Þ…ßÙÿ²=Ššø²JJ¥¿–>N­ð€ÙïçÆ…F‹Uã¤o·•t[è!I’d®Ê²,çSÅâ…Á¶Ý¾ú³íBºž«‡$Iõ<(T‘@Ù ò%T
-u•AeP9T
-UexÊ-*pßÏ|Ä>V_@=A-¡n¡VèÌB=¡Â
-ªDf”ž. Iò
-|…"cà+Ðµ_"¾]kòåPàËÑ‹_Ž^4ø4ø
-îŸ»&ß
-|9û_Æ
-àKqŠ_ŠL>v¾Œ1ð-@kÀ—>BÏ2|ŽðYÜ„_ÆýŸ_Êêô/¿Ü©cJEá¨£eŒb–ŒèÀòâ6,±Ï‚1£%#¼°ô¯ËÒCð[22FF¸mÁX0Œ=d=òÁC>Ë>é!\³à³àKÁgQ/%cà³¨‚Ïà””|Œ/Ã-¥ô™ü2Æ7šã‹wœ Óˆ˜&áe&Uc×‰Â hš6µ—ËDm›vÚ>aŸ§ú¤^Ë¿XŒì
+xœm”Mkã0†ïþ³C{èF_¶ÛRMÒ@ý )»çÔšdlüqÈ¿_¤wÒ–eqx5#½óhÄä?^¶W÷¾}ç+ûSÑ+íÔ×|µ|ÜuYž¯Úz:rŸ˜=ûst¸¥®oëGZnV›ÐŒYžoBý1y>çü/eÁ‡&|%DZNÃØ³<kÆ¾¥,Pª‰6žÃØŒ'R—Yžÿâ~hÚpK:Ëó‡à—í17d3ñ ÙKßÖ[ißß‹½GßLòM=ŠJßú¸ëÒæíiù¸	û–,²üÔI&Ñì•Í0ö'ºH…]’ç="Ï½ç¾	º8û-¸ºîƒc‘¤Ò*Ÿþgþiwdš	ðçªP’þZz;u,Ì~?¶þ,4J¬[ÏC·«¹ß…gwJ)5§»õz½žGÇâUmïûúÏ®OézNwJvž”Iª\CY¨R©ÊaÅ¥•ª‚*×P%bªB¬€ºNÊ(¨Ä î¡äÌÔÔJÜWpõ€˜T¾†ºNJÇKPª\BÑ¢NF‹Z4ÍJøà®ÁWÁAƒ¯Ÿ_>¾JÎŸwá+¡„o>ƒ›Ðàs²|NªŸCe|ûøJ0ðUð3à³Ÿ»Ÿ>'ûÀgÁgÀçÀn"Ÿ‰FIÏàÍð¸	>‡4à+døè»¾û¤,ø,2-ø¬ôO2…§Xð•_÷b…O”ðá½XðY‰¡ì|…8€¯BW,ø
+tÅÊûwð¢ÀgpŠ_w'|è‘>Ü™_®8ðYø9éŸœ>#™àsâ¾D|V2¥“÷YâÅrð2+â0‰3ószÕSßsÓÈL£*Î¥&ðçìíÚ.îJ¿4´Ïó?ªçõ_ ý•7
 endstream
 endobj
-331 0 obj
-<</Length 10526/Filter/FlateDecode>>
+372 0 obj
+<</Length 10601/Filter/FlateDecode>>
 stream
-xœ­|	x×uîïö…b#	.AÄ€¤n7 7qHJ ­…IQ²µY¢$ïvã%Žâ¤Lºù%jš6m¿ÔÍ@n¥i7Müä¦q^¾ºuÒ6yißûÔ´I›ZmVï»3 HÊ’“ô•ú¤{fî¹ÛÙÏ¹C °à	ph[¾¸.îû¸ü> ¶cg×Nmµ<	ïvëÚÉí¶ïO%? B¥ÇWÓ+þÏÿå×€~#€®ãÇWÓ¦MÝßý õÇO­?ðþwÛ^úW ÒsòÌrúõä«A`à
-€J?p–šKžû ˆ§Ó§V_*ñT ƒýâÙ3ç×_¯|c¾àgÏ­ž}ãÊ£ Fžˆÿ?û±#¡z€–å6±€Ä§ ¹äÂôJn“ÜÌmæZ·úr›ô:¹‘ÛÌM±^úºÚ?…A"Œ0wþy7!ÜAú:y?ÚZƒ­P=[)·YÄï%ï.Ž‰‘'‹ã¶í…~nk7ôsêz`€Ç_åfð÷¹Xq>¹8ÇÉ…ù§@,$‡S¢8qö}Š~n1©tx•ÆÔÒ1ñòBR¡þô§0byY:êõù¤Ä¤øUÄ–¢!…ÈŠ¸t,¤PYòI¾ÂÉâÊKœÓ…hLqÄÄ¥¥h†:cÑŒŸ‹)46ÿ€¨X%…Æbé…Ÿ}à*¥4¶U|«U>ööªÝE¢U¢BcRôªƒ8bKQIÁlr5uÕMfHáe…*®X’­§¸c±<‚W\•—g¾añj#±Å†—‡ýpÒ§pþTâž¤Oòy/'Eev6éS")¯¨ô0¨'•3vzEiœMúòO¢ÒÆúÛæË³Iñ˜xùrZTÌ³É%¯¨ˆ¬ÏÌ .u-y—R©”W¡~Å[VH*˜`È>ÅóN(5ª™H_+Å2Ã¸¦ÃÑTj%RH0•ÊŸ %®(î˜M…,‹
-ïO¯ˆŠ!6›TRT1JQ¯Ï—RÈRHÑ«äV¸ ¸’1Š¬“×«mŸý«˜–†—]³OTŒ1ñ²xY!ÁL›Î¯ðû’K³Þt"•”R¾”¨Dæ’
-	z]ò[	)Y1Å‚WA56eÅ$E%QM+ôè1…,+dI14‡“,²ÝÚcË×xÙJd)ÅP–âênÍòU“±áh³¯(8y§ YµYHPRSxÿ’8|YJ3¦ªÄ†—1D½J¤H0…óKé¸¶„í.Ã•úÙ$¹Ó ;“)ú’Í
-nx6éóJ¾T³/¤”ÈJ‡••t<¤”Ê
-YE¥$¶—M *%R4¥”²§DRTJU~	²¨”ªD¯ñX¾,¥!¶$^^AŠJ!¥Lž˜Ofø•xª^±­J„‡<±/91§½ôúRõŠC}ï”3(‹-$3ee1…¤£Šd*§P4SÂþ)¥þ¨BÜ’¨pþÙd†‘OáýÑË—E¶li³ORHº {µ~6„úÕ7)¥$6ª”ÆF—º“YwaapHq…Ä\%„¨ÜrÉÈ€Ï'•2)*+v)ªØ$Å´—>U^N Àh4Ê(à”¢
-IgœÆ òî ·.RÜr®`HñÈÂÚr9CY[!g8ÖVÊžµ^9£cm•œÑ³¶ZÎX[#gŒ¬­•3&Öe©@E¿41Ÿ”Ä…bÚRämîbçýZgh[gC±óœÖ)ÊPJ‚w=§BÒ¨•sûù|rb0¤ÔÉÂZIÎPÖÖËŽµ~9Ã³¶AÎèX3zÖ6Êk›äŒ‘µÍrÆÄÚYìS¶U—”ò%1&)d‰ÉDš)a“Ù6Yi*­Í!e—,Š£â]¸)¥{$fØßÃËNß^`qÆ®f§ìjÎèˆk8Ù–ROÞFž»átÈb§ºóNyœá·®©à÷ÂÞÃýª_ŽH=™âbgí’Å>qô.ûWK÷„”n¹ÅÓRz~ªBbË=!e·œ¡pûÅq”™…úÇ/_•F¥´˜<êeVWŠ^í!Äål){dnÅ#EÞ¯ð~-cET±Ä‚«—[$Qì»ÜRzw¢‰-Ú|Š^Š°Ee‰Ù”È¾äK¼¨½/ñºÊT”YZsL¼,©#¤‘%E»]]—˜µÓ¼[Z‘],½2›TøXÚ«èbKÌÒÝ>&-‰¢Â7H#é¯¤˜c#Ìc™cê*Kâ‘4›ª-1fèüiE÷–Y¾mÂÏ6Áù—Vò–tk­THé+ÐBEE×§…Ô×Rú‹]ŠYí‘FÙ¢Œ‹E²Ãh”V0Ÿlû$Ÿêoó/E¶¯<+½_ÑùÇ·Ç.ï$íynILä·í$V`×pn?rÅY[GO,9ëM¤’b_ª%ÓFœÁ2´£7áÝÑ½ãØ·“•=Á·[0.+½ÁË¢ØÇdìrÏÝQ}¬Ei†”aõÈL>4Ê§«ÕŽÎTûÄ©'?ÿˆœ1óþhaÈÏ)Ò£ÿURÌÎÄìXŸÔãõm“_*¿ÏQ9ƒ=ÁUÆäzƒ>Æ3¶ÑüiŠ$—¸4µ¿
-¦áŽ¥«9¤ì½Ëû	9ât(ÝÍ!eRVv7‡”)FÅaIlG.Kéµ¦e&ÐÊT0¤ÌÈW‘`H™•¯‚0`Ÿ|•¨oòU¢¾™c8£Á2Ïp°Àp°Ÿá0à€ü€X0¤$å—Xè))ù%¢½[”_"Ú»{aÐA†§B‡ž
-fx*t„­9)KlM¤Ùš8ÊÖdÀ2Ã†”†Ã€U†Ã€c‡kê¾âÁr\ÝƒN¨ûbÐ½ê¾tŸº/T÷Å Sê¾tZÝƒÎÈôxV}R"Ár¿CÊ9Ftõ))çåÉã¬k Ã¹ â<ÎE9ƒþâ¬—Ô'uÄÈF<¨ý!9Còk CxDÂ£rÅùSŸTôÇ5¡?¡ýäÉ#¼CÂ“Èž’3,Î÷´ú¤¢?£ýÈÐŸ•3$ð.d—5!¼[¾jQ#[Eï½ÊSn8)ù¼¾T*TŒ«
-W?û@ÁY‡ C
- ô—ÁÁ„”Á…®HØåt”	¥åÈ$ Ž‚[%„ ¥äO%3€Ý¦ãÁtzO0,ø¿/ÝáînÉÃuˆ`H‘¿Ën2ÞÁwuñ»¢ß‰>øøã$ùýå['÷<µ¶öÅÃ—.eßsãÛÙvòÚ·YR Õt&Fõ¤¸‡ã d}JÇSJ/Ði³Ù,˜A¨ô¶Ê Ã44$½žs„R@2|©ö‹µeb)_"þÍ735ð½Arfe¥ûÔîÝ§²‹tãÖÙë×A‘È…ÉÉM8 âO#%Ñ¡¦šò:Pž›œPL³ÉH5t:¤	.MÏÓ4(}xJO8îAnÚ;¡Xf“X7t:’!ÞÑñÓgû&J¥R§Ë	x+œ¢K„½`´U=BØîê
-·»]N½^ªkx\Žö®ÎŽ©Nop¹Ý‰¸óÍí=ÒS«£—úfz‡kë}_¦/õT5¾óþÄÅšÊ…ß&úµÅÙå:1Wå@È}_£×aG Ro# d„\œ¥HsxÓ&£Ž‡Øy›;è©kèÂ‚Ónïêöè_hiJØÍ¼Ao)3íî +·~ÕQJÈ€1—CÀUúIÚ€) zL<Ì$!”Û$NnÂ ±H¤šèøBut¼ŽðkzpipÜ£ŒZ4m ”>L§MFo…Ç-”E“¨ãa £Í$uz½!ÜÑÀÕ54tvˆdð¹óÔsÍî&Ã­àÐ}ƒ«=‡—)Í~F¨_ê¯¨gÈ'ª#£{³Ã}çggÎ<rÜVnMÌ;….w•ZÎAkn“|^W%é‹‘R3Ñ›ò::YJx2Q%J/ÞÆ\¤9=U	X¥Hà¸yLvfÑñÓgû&b¢äq9I^”Jì6«QqóÔå	t†‰iW ½»³I“ÞåtÿàžÓ½éîæ‘Ÿ‹¸ªÉŠH_íîšÀ`ÃˆõégÎÔTÎ}æVÏîª¦áX¶ÊÓ:×s`™ÑŠ`À‹t*"n ëS”rL3M'p6fPÂÂâSÔâòt:ÔFÉ×§@]âˆj è ÞV®Žô¹çH-Ý¸õ©QP„s›$Cn¢~¼±Û	¡µ5›^ÇšWòr6S³G§ôu;˜RµÕ¯’QCÒíàÇÝçxûáŒ®*/×_åw»ÊJ-&T’JC‘Ý*ÍMl¬èêî´S—ÓýùþÄÆ•²`cóÞj±nyOj6nàêg<RDJ,5µ[Ç¢‰y¡¶KËz<§îÉþõžê¦¸Xû¤Il%U»ò¹	'ÞõIG™Ý×¨â ÇŒUÁðæ	ÂìÂ%v˜¼pmëvÜmä]1
-Ø 8á”õªEoÙ2A4&0û%M·O&ä6¯ŸÜ‘ZÓ‡²Ašâþì‡g¡×áDK$èàÕÃ ¸x‡Uß² Ëð–œ4U\^ÿüŠoç‚ªlVå6É“ä&šÐÙUN8ZÁsáè$8®ÀuBæ†²Úëvõh"M:ÉnÕuv44Zhg‡ªu•ë.§ÛSC™Aÿjçáºq8ÔÖ&¶WÕG›R3¡éª†Šn_KpO¨a8Ø4cõûÚ*«Bµ>Ù&u6öÎÔ–·–9›«|u¥¶ún9mdûmÂß’R	5/ØÖ°s¡„€yö¢vw†]M7þvpP³q-¹Mòoä&JàE(Ò¼¢„ùüñ„R«Ô+xM”½ÍÔmY]Õ7
-^Éåt“’ÞµÁÁµÞ¾cƒƒÇú§¦¦§­}çfçúúÎ%fÏõÅ×ææŸŸ[‡PN$ß%7ÑŽLÄê·Q^?®§&]A—»,D^§çOÀ` if[Tµ+‚:éL¦SVb4"m&ÀãEMïØ9º`9éPzémÆ:þ?VþÏ-Ê´FŠv„	FãƒÓ‘é==áŽPs}·²¢ÜíD;i·mY‘Î†m*aa—äÒ"ÕT›ÎÜ6åCO¨8ÿ‘:Ûà+«¨s”Úçw9ëm/¬
-åm³í:[™×á……¾Ó“Íý}Á`_×È|¸uÞî+­,ŸøV|°v·›·4VÕ¶Øxg<Ø9ÝlÐò¥m¾ðd“`ñ:=5Ýý¡ÉV’ìììëëìÌ>ÛßPWÉóŽfW EÓ5¦ß‡ÉMxUã¶µÔÌq%“&‚½yZMD{O'ó¼Ù‰·%•Ji“•©f¶xÂqŠóS—X¼“çÎV¯ã.ãî6„±Í
-@€P_/èl[¶.¯òš¡+k®ö”Y%µ±
-r#ÙÒeá¸öìu•å ý¹‹ÈªJõ2I	Í\u% >ø„
--Fsa‡ÛÍêvlƒ8‰Ó"g÷ïÜ?j´ëyc‰qlqÜTjàvÃèì“÷™ìFÞPb"7²ÿè‹Q©ØU¾.Æ}ÙŸ¨{Ë}ŸŒÐwÀƒ³“è‰‹@Ï´SR£Ž[ŸÒBèž¨â­×ã¨!ïJY?åž¾[*â"(+µY-f“Ñ ×ñðO!Z¤Îîî°+ì’Šq§þ;Óýc“æá'Ÿô5Ûªì‚£Õ”'æÝ•+±ì¦¼KgØc¶°=Oä6ÉkäœxÏ'+¥¤è9BˆÊFåwž|Ï_ÐúwÆwy×AL,‚Ò»ÍÌâh'qêo£…|ö­©±¹`[Co““ºIkúéÈ¾I*[9ÙØ¦éŠ5×Jþ¹J´EB¥fž#”# t’EM—TŸt”í™Or»¬ƒŽ[>‰­Ù½]l8;],­¶–•	M]%–?[X¶TXx‹Ó|`öSBëðWõ|Dßª'ÿ˜ý¿µcu¾1‘ØnÝl›iòJéëp!1[G­„yÈ	Å“—	ÕQ^œbÔPsLÂò#½þ‚~Úñ²ÔPîÄzS‘ .¸„²zIŒ¶ª`˜	BÑ‰Ju.U$–ÆÆ†Ç=Í¥e5ñµ5ò‘ÝÔÞ&CŸéðT,{ˆÑ‹ù·O›¨B7³È”TX)G+	8nrKÕÈ¦èÊ=®R»É€*R¥Ûéçòº¬Õ|†á:Þ7tß@ÛpE“£U7ÎÇ|{Üõ53yo'V´îÖ…ž¹µJg{µT°wôMr>|0bËÍÏñÑtkad^ë·ÝbUªæ‡¡ÜÏvÇÛŒ»¡LLK5Ã"•IŽúzÁd«Þ­yv„P†bË$Uœö–4LËã	¹¥+ž[»âj·Knê(ÄUÙçvþ¡Ü&®á,¨ŒxÔ(ŠHoÐÁB,\ÑÁi®ëÑ
-Iª(—$«ä­–¤j¯”×@Õ|‘=¡ “š¹ÞÊ l°UhÄ‘ÿÌ'Z<Þâ1Ü÷{äFö»õc’4VOœYF'´æöãœCª#•¼Z³ ãên\Àt}µ•=®®€¾NÚ¶Û˜3ØF¨ž–Kõ¢ä¿·9Iu•·¶#IüÝzV4G³ã™iÒ"Z¦<Wf­°–9
-Ew‡)`p%ôµƒ¿umñ½‹ôz¶6÷…ì7ÿùÞ'Ôx.‘Û$?ÖrVbÕDªÄLtœZáxn2/KÛ_íµãNØoA,zÖb²šÏÙµ<”Ü%õ-$ö„ü”Ô÷Î³ýÝ–úÚ­Ì›R_]]C@2H[Áö•RHSÝ¸È¢	ê›i<r´÷ÈˆZI‰Hâ ÕWÝN¯>Yxæþ¹‹ÃÛ) hÎm’ïÑ+±+Òâ­dÚÌ2”¼ý{è¶D¡¶ºÜmÔC&rÞºlO´Lagªàöx´€Ž”Ž\¶JéŽ¡±ê]µ‡k;õõ­Ô…j÷ÊÝ1_{å¡ÞÉ®ekGK—¿¹·­®±ÊÞdoŽ¶¶Ï„d©Ëëëk›*-Sãí…üûuµ2×i`æ˜§ÜÛì5×ž¿À3)4Á$B>¥ò¹|ªí]$e¿þ£Ñ‘oŽdÿ†%‹ ­§P		»#]&¢cU%
-OukÌÈj3ƒçÉ}¡> ùª½•åÎ2(õ´:–S
-‘,§ÑG’„°øg±ÕÝ»ZÆÏî},=¿wjjõÜÂáCûÏÑqdOxª„·LE‡Éƒ{Úw·ÝÚŒöïfg6ç–È>úŠV§P“£g˜âa{ÂCÂÄL,}Ùÿ0wì'PõŠM¤°Ãƒp¤ÍD(O&Áƒž®±úŸv2=Gó§ò¸„Øa<>ƒ¦¾ù39$N¶ÎñåØñÞÙøGèÒé©Dbê4ÝöÅ'	Ù ®ìwHj02Ô‘Ëaˆp¸F~3  %0e@®‘¥3¨É /·IÞ¥î¯1âç(%*á©ZRÙVÎ3›ôÛÊyZ8 Æ"zýWèêiëêœoHXïõD'É³áÝ‡{´ùý ù½/“q«…R¸	eq6ëeNtE>Ü‘|@Ào£? š®Îš×³|¹Ã©×3-»—žéëoŒWµ4ÞÓŸ:6üÀteOÅËí‡ßw1Ü=C¡®µù‡ž™¥ü¨–¯Ê¹MòEzx¶ç«ë;óU›•À!X=6æP
-QWÁDoÏU¸têÔÒ‘S§ŽôÄã==ÃÃÖ?ü›ûØo~øÅèãÏ=÷ðÃÏ=÷8;En“ü)}"îØÜ„ê„R¦ç”…;ÞÙd¤:P¢£'ÀóÜ5V)_°q‘*pàu¿VDÜÖŠ8*ËY•ÞÎÊu"ó¥¢-ã ’ÏásIšýR‰øÏ“+¾ÆêÉžÞ}{|­Õ²‹~_ð´Tw§ºúZ»|]U¡™Xt¯ÓQEÂ£bµ“ÃÃéö‚<[è,p²ª<8°@r<_Ôþ¼r–Ù­°Àâ÷éµJœ¶¶´]ˆ?³÷ôÀ3'OÝ?w`ÿaºQ¿0¶¶’ý	í.ÖúhˆnÀƒúˆ¯LOÎz}»·óÀ#T¼ê®ÔHYKgÜn—°xÏ?9¤Rž7ÌÞóOŽúR^§§Ùã¾±úð½a²pë,yÞ7V¿ëxgöPtä6é*½‚To—•‡ÞZÛ(w—VÕo[ÛØ7™L<>:úxbî±±±Çæz´Ý›LÞÛ–´ÎàÄ‰_Û·ï×NœøÀüxìÁÄCï}ïC‰cZn—Û¤Ãôu4‘™|ZªÌ:®–!“‘/8æÛz,Zã.cî„^ôÐAè8ÂéÈÌºë(wÂl ,ÚÖ³ˆ£m
-F£é¨ÕBM¦SÁ_·¾ý+±XZµ(sü¼+ýÜ‹0ÏÎRï&45êë$AÐ2›±öN™Áí	#‹Î„mÙ‚·*~Õê©ºf[µÔÙê™îÿýbò0h=<õì³±ìÍÐ.?`°,ŽË%4é 0B`ú6–¿CÓ,¿Pb1ÁƒOWðeL]Eeùíç?ôë¿²0qþüùótã…+¿þûñw?òÈÓšžØ¢¨@CDrÚ„ß
-k·iJ*Ê*ÊTMé„=ùÈ¶;lðHùK3ƒÁþ¿”²”Ûx‹ÛÒ»ÿ—>”µUÚy[¹5šýö}Žf§³Ùqß›ÿ~¿[v¹‚žûA! ä¯èc0Á‰ùˆYG@m„ `âÜ, $Dr\õ,z¢Ó]Ð©E
-úôVo¾#±›Íf§Ù)e•¥›7ØfÅ*¶9G§¯“°ò¬ä:~'¼µÒÎþ=8póÓ•cÙ“íPºÈóÙõ¨ÂèR›tãtY¿]Ü6ºpŽ-º”|îêÁ”ÍSÂÛ]ÖÉ—>wpÉæ-åí•Ö#dŽôÌ-WWËîe?—ÍdÊÃ55áòL>Vú¦j/[#ò[c%ð¼îHþÜê—×0	ìÐÅˆÉås©1ÓHvÑ‘×FÿUõiDµS•ô
-ªµøÑjáYM«>t[vZîV³ÓjR}÷ì´˜žÎ%Þ11ùÔ\ï¡ªPe¬©ÿPGøÐ`Ëxm°ñˆußó÷Ýû|¢µ.\U;t1‘x0*Õµ…v©µo€ü„nÀÀò*–š‘#ª‹Ýòí!o¨¥NŸKþáò­WèÞ‘‘[ŸTÏäèéÆjYëÿùZÖ³©˜¹ÌÈ[ÜÖÔü~k¹…7
-æá…wÝwØh7òúãÝÈ~°óÞžžû:Èjöƒ÷iÐ­³ärÃx08Þ½XðEÒÔ²û„
-‡¶7pŒ«ô	M¤¶Ý'Ô¢¶<%]ðJêÆXÜÕÕ-8‰H5Ô%,žxÄâ¶ð‡õ‘ãÓ¼žòá‡ûóœž£Ùß¬òû‡êÈ‘[gÉ‰ê±Ñêe_$sª«ÎþZá¾1L¾®Ý\S>w+)^:îÈÝJˆŽî|í¸ö[·ånìQ+hI€·Þ€çKÕ;n#oCtüôÙ~†‰îpîô×³p]g·fÁîî°Àm¿³$ÏðÕÍÚÅeÄGÑ¯/-¿üb²ªQ½¸¬®n¹5Eô[·–¹\îk¹@þ–z²xKM0OÑÇ`ÅÜêØwyóW	BA	žP‹¨ù¥|ŠÄnÁ(¡Oƒ€<½£G»³Â*8óù»víìêêfÆoæýëòPåàSqò×FOé­Wâ ¹@¾A7P)"Ú„Û2t[u”T”©uÎfÎõ…/¦JkKy¡®dþÀ³äýŸ®ñûGê?=Õ¬M-@~‘Ü€‰Y2õkRˆã™š_º=Ž7ÁT&h&µ“0e'>W-Áÿ!“9£L.Åäì»X‚@ÞT3Ê;Î½þ¶sû´¹C$•}…üVöwÉ¡vZ>²ëÖ·™™$˜%ŸÀÇèUèÐÿIžPÆ?»`r§Úá‹dÚÞrû•Š˜µËä2–Ý9°Á°\Ê%¹Rò‰<øÑ­unÀÊ<ŒV•¹“‡¹­"CXE†3¸ç8"þò¿úÂýt#û)2þ£ì½dáéÿ©Í]™Û$Ÿ¥—ÑŒxd¨²‚r¼D(ÇÌ<åTËC85sÐ¥¡ÓíÌjª<.VB6êÑLšß’4HÅèt+¿*¤Îß<&6WO÷ìÙHMÆgêzÃ±jÙ¿Ø3w2Ò±g¶çˆµ[êªi‰t6ìÅ._kW}u‡Z˜Ú³×ÉÛæ¢=	ìw‰@9ºq{¥mý§WÚ^{-µ*Ô¼PUvjáuº‘ýPïroïr/9ª}À¡)·I®ÓË¨…ŒÝèŒ´wxŒÜvÈr‘m°%DÚÝ²;àJPKjó¹j¶]„©9¦K»eå¶GïÚ5XþÞëG}‡»¥î©«-žKW5:«ÛÅð!A”ötÊ½Mq]ÏpÛLKCxÆšmoÚUÊWŒµïÚÛ´´××ÛZÂ—ÊýÁÖé9^‘Z£=­íRö•Á]Me#rç°jÕs›äe5cmÄPdÀ£§ ¥„ãKe5h€çÀ³l°À|V7Òk_¾Ø¬u¢·ÂYfm´5Ö×låA‡ÔªÆÏQƒ®&R=û…Þ^q´Ö8Öß2”OU¶8»kØ=\Ílcb¹c!<¸²{ø4ù“ñÆÐ¡ôÔ­ª:<Uk—öìˆ?»öÄ•Ñ¢^´«‘‹y™!ü‹
-Ö§ôº¢#ßñ°OÇ˜ƒô	‹sd×ü|ö+t#û/Äqë,éÌ~IÓ	™Uoéc°!ò‡FµÀªÙYaËZä¥Ë)a2H	ÖòoR‹&r‚S¹ÚÍ¬‡3|\ß¸o(û§äƒ{ö6»ø>ûBr4<þÔ³ÿí*kbn“&èXÐF"1'G9ô¶·ýuž£“­„Œ³L¯Tó<V5g÷W“i›uwwc ªÒÚaëhÔ3ƒâdrMÀAÜ)‡n·§«;¬Uö>ôú?ì¡XµÏ/·öìôï©sz†Cýq9æ“-5Se»ë"îº©€ñSSuƒUm)©®RoouÍP°:ØuëÕP¢[Žwyš¦êå‘¦±=Áx·ýHÃìý‘KåµÆ¸Ù_U×ô™Ý‘ªŠæ•ÎªþBÔÙ@¯@D$ÒoµP­a†‰NBžÓñk· E{T]å­Ì_‘äëw¿"é”:Ã‚^OîfrúÙñCU-ÑöèÑÎûOHÇ»ß¨=‘CÛk;*ë†.&yŸ«ìãÃÙïú‚lr›´…nÀÅªì’Mõ Û‚a¡ÔjÖëà"®b0¬Þ¬©J‘/l‘Xì¾¹¦á <Ò4;p¯µó¡ãäéìƒS‹~ÿâygöáãu‚¢-·I^ÍëéXdØCx®œèøZŽp“Ð1w¦ƒZßahíc¥Â'j¬à$ùª*]¦ªZÑ)ÿ‰š¡`¨¹·Ri«Mtµc5ÆÑþÖHoÇÀÊžá3ƒÞGOMho+­™Ì-w,±FùÐÑ©ÁñìïÅßuì‰+£ê°Ç¾´êªZärr›œ›^A ã 1#€½ä@'¯2Ÿ›½FÌÅÊ!»u>H_G /k7wÖj;Õñ5%”ÓÑI¯úh,<¦4”:#Ñéø4ã.N™)¸#&=å¸KSV‹VõN(¡Ùd¤uã	°xüHC•‡Žãu'îŒ˜/hð×Kõ’ƒU¢Áf«ú‰ýÉ—Ôj€Þå
-¿åÚ<ú¥ÄØØÄd{@¨‘ê¿T¬
-°;Äì!V
-ˆL&Ëlá¶bM@½Peô%Säýj’UÎ8JØ5fA0;îP4Þ½þx-–HÄØß†¶¶†@[›õäÊÑ“'®œÏLOOMMO³¯w@r©Ü&~L¯€CË„ÒÄø´ý3;/‹qžfµ€§PÎ60ù(¹·'û«Vú±[I6×«t/ºé'™MÏèWâì[6€¤
-wqû¶_ÅeôˆÛv_^[[^^[K÷VW”×Ô”WT«ûcÑôï(aTak÷Ò(^K³Àøq¦´V‹QÏ*müÎPFÕVÑí·	¦
-k}y¢ïëF}?§Ë´úÖÿÞ›Ìßœá·ÉâW†—îò•a"Annò Î6³° ß<RÒ÷ï0pì«d|kb÷³j»oüò­d¿n<Ã}Vƒæ˜}‰úíìÆço} »ÇxF‹‚¶ýLÓ÷ EEp4ˆrHà?'ÿ†¢×U[$7°H~€0• "ä#¨"Ýh¢5h!?@ˆÜƒý
-ÊIåTÄùKXI=ÊÉu´pýHà‡bïðC´’ï!A› n4“Å"Ä"93ÝEï[ð‘7á'oB&o¢‚va‘¾‹ôytP6ÿÉga'oB %´‹´´U\<ô,ª{ÿ~îkäMÌ¿ËåÈ¨¥^„ðCÌÒÉ›¨¤‹òÑDÞD#}N}'Ó4Dzôi o¢ëD‡PNÎ@Âþ\
-È½ÊæÅ¨<ÃÄI¢dŠüí¥½tžç8î÷îÇ¼‡OéRºoèƒú§õß3tÞiøªqŸñ‚ñ#Æ¯s¦O›]æ~ó/š?nþŽùÇ– åŒåãV‡uÂú´õK¶mÿË^m¿Ïþqû×K|%±’÷•|£ôWJ?\ú-¡TN
-W„?/k.K–]w4:æïu:ÇœW\p•»×wÝeî>÷i7“
-Æéi<+Ö`ÅžÂ{ |Ùneyü«˜ó& Ï©rÃ`‚J<—‡)ìøÝ<Ìa‡ùm8:$ñ“<¬G™ÏÃü*y(a¦¥yØ„rZ™‡-h§íyØÆ‰t%ÛÑ¡{
-/@D;ÚÐŽ0Dagp«ÑˆãXÇ:ÎbZÑŠKêŸ¤‹8-XÆœB+š CÄ%œÀ:ŽCD«8UœÃE¬b"Fp§±ÓHã[A,ÇÎàÎa«bÅö'ˆ˜C§q"Âê|k¸€“HãÂhA:ÑŽ^!Ž(fÐ»ctal¡ÛÆj#fÅ0ö«;<êÞÄóÇ¬«ç;‹±-êß6ôâÒ¸«*Æ1¬âu¿íhA—Šñ³ídçiO¨'MCÄ:Î©4^U×9‡û âŽÝÆêŽµÙÓN«´×h=‡u¤Õ'mÎÓXA+Îàœ:“6†ÁìtT®œÃ	»eÛ³H«{GDŒåqv©XÇƒ8‹UÌãxþ|[RÀNë¸¤žq‹'qB¥£™v¶êJ~Ç…óÎa“1£ÎzÇÌ“;f`ry;Ÿ¼·ílçº[ü¸ˆ4N¨;Š“jÏ–”3n`ûTx{ ÞFóXVi{ë*uÙN¢EåÅZ1ƒLÞ¶“ŸN£µÕ¸vŠ|×NÇøÍtks1Ž9±"¢êó8æTŠÀ8æ1†,`^}B	aóÇ°:v	öû˜Á4âêˆqÖúFT‰œF
-"&0®â°¹WóôÑ8Æ´ã¬ºûóêÞ5)<S8«Òœíœ«ê	~‹8–Ÿµ0ö¼:f'pLÅdÜeTaº—ÆZ^*Î9œRiY-}Ñ$‚õjº´Õ¿†3ªU;§ê›UÄƒy]fÒªíIÓØõŸ«-ÿ)™añ¥ú“{íwüMX¤S9Ì`c­ˆc&°¥H`/°ˆHâ Æ1‚YH¡ÓFšàG:ñgÁÊÆ.´Š î½hDº±m˜ÇœèÃ!ôÃŒ¸±^T!ˆJ˜ÐŒTÀH8Âã‰ŽèñwìÈ:wìÈ1ýC«çÎ´¬.œ>ÑnëVÛö°z<q×É!ïM)DûµÞ³¢Ë¯àÑS‡öw²©Õ7ÎËÆwðçŒGûõ{õ{Œ²¡ž7™ó]ï×?CÒß«?ÈÏòQ}X×HÕ®Òè¥îeñåª—Ë_v½\ö²ýeKÄ	–æ*¢CDÞò‡u~šyõx¦ž<»/©DžM²ç•x¦‘=_3B{xÊ›	°Wd|„<»<_è`?çsú§èº~EŸä'ù>}‹®šìÍ×Hîi…O†"þ’nE8ûå¨ÿÔW¿ª
+xœ­|	x×uîï;HIpp‚$$Ep“¸ ¸‰«@Jh-„HŠ¢­Í2%Ùr¼4^â(NÊ¤Mê—(išæ5ñkÓäÆvš6uã8OyÙÚ/n“´}ùÒ¦Ÿš¶éb—iVï»3 Hj±¾’ŸtÏÌ=÷ÞsÏvÏ9w$ f<
+mKÖÅ}¿+¿À¤íøÙÕSÇZÍä‡€Í²zòãù“(ù	ºÿÄJzÙÿ…o~è? ëÄ‰•´qS÷] ÿ“ êOœZ¿ÿý¶= ô ñ“g–Ò?éæNƒ¥ >~*}ÿYj-y
+ü âéô©•çJ<Àà«€°pöÌ}ëßžþæÇ‘6 ß?{nåì·®<ôA`Ô	þ;~à F0B€–å6±ûGœn ä:Ó+¹Mòzn3×ºÕ—Û¤×ÈõÜfnŠõÒWÕþ)ba„¹Cô«ä]„p‡è«ä1ülk¶
+@¶Rn³ˆßKÞU#Çm£…þÉ5ôOÔõÀ ¿ÈÍàos±â|rq>Ž“óN,*ØŸN‰âÄ‹°í›P„¹…¤ÒáUS‹ÇÅËû“
+õ§?k€KKÒ1¯Ï§ ¥ &Å¯‚ ¶)DVÄÅã!…Ê’Oò…N—Ÿãœ.DcŠ#&..F3Ô‹fü\L¡±ùûEÅ")4K/+üìýW)¥±Å¨â[©ò±·Wm.­“¢WÄ[ŒJ
+f“+©«nÂ0C
+/+\PqÅ’l=Å‹å¼â²¨¼4«ðW‰56¼4¬ÃIŸÂùS‰»’>Éç½œ•ÙÙ¤O‰¤¼¢ÒÃ žTJÌhØée¥q6éË?‰Jëoc˜/Í&ÅãâåËiQ1Í&½¢"²>ƒºÔµè]L¥R^…úKlIA"©`‚!ûKÌ;¡Ô0¨f"ýb)–Æ‹:K¥–Ó)…S©üRâ²âŽIÑTHÑÉâ°¨ðþô²¨èc³IE/Eƒõú|)…,†Ae·ÂÅåŒþXTdl»^|ö·b\^RtÍ>Q1ÄÄËâe…3m:¿Â7ìK.ÎzÓ‰TRJùR¢™K*$èe|É“Rô²bŒ¯‚jb6ÈŠQŠJ¢)šVè±ã
+YRÈ¢¢o)FYdÔÚbK/ò8&²”ÈbŠ¡,ÆUjMòU£±áh³¯¨8fy§"Y´YHPRSxÿ¢8|YJ3¡ªÌ†—	D½J¤È0…óKé¸¶„õÃ•úÙ$¹Ý Ó)úœÕnx6éóJ¾T³/¤”ÈJ‡•åt<¤”Ê
+YE¥$¶—M *%R4¥”²§DRTJUyÙeQ)U™"¾Ècé²”Vì±Eñò¢¨Ø¥¨RÊä‰ùd†_Ž§êëŠtHqÈû’sÚK¯/U¯8Ô÷N9ƒ²Øþd¦¬,¦tT±™É)ÔÍ”°¿J©?ª·$*œ6™aìSxôòe‘-[Úì“’.À^­Ÿ¡~õMJ)‰*¥±ÑE…îÖD˜R\!1W	!ª´\22 ÃóI¥LŠŠÃŠMŠ*VI1.FÅÅÊË	ìp 28¥¨BÒ§!¨¼+è­K…·œ+R<r†°¶\ÎPÖVÈŽµ•r†g­WÎèX[%gÖVË=kkäŒµµrÆÈÚ ,ø¯‹óIIlQÈaf-!EÞÖé.vÞ«u†¶u6;Ïi¢¥$xÇ}*$ým«lŸÛ÷ç“3ƒ!¥NÎÖJr†²¶^Îp¬õËžµrFÇÚ€œXÛ(gô¬m’3Ö6Ë#k[d±OUØVY\TÊÅ˜¤E¦if„-LgÛd¥5¨´6‡”]²(ŽŠw¦”î‘˜cC/Û}{AÄ›0Ì4NÙÕœÑ×p²-¥î2¼=wÂéÅN•òNyœá[×THð¶´°÷p³X ˆH=™âb{í’Å>qôô+ˆ¥{BJ·Üâé)=o†ªØROHÙ-g(Ü~±Ee.A¡þñË—G¥Q)-&y™×•¢W{q9›CÊY[ñHQ…÷+¼_EËXUÌ±àÊåIû.÷„”Þhb‹6Ÿ"HÑ¶¨,2ŸÙ—|Žu¢÷9¾AW™Š2OkŠ‰—%u„4²¨±›Íu‘y;íTâc‹Ë’¢‹¥—g“
+K{]l‘yº›Ç¤%QTøi$Ýã•Sl„X¦˜ºÊ¢x»E$Í§
+±E&?­èn™Uá~Fç_\Î{Ò­µR!¥¯ÀQ]CžR_OHé/v)&µDe‹2)YÈ6£qZÁ|²Eì“|êy›)2ºò¢P¿¢óo]4!ÞNÛóÒ’˜Ên£$V×"pnÞrAÄY[GO,9ëM¤’b_ª%ÓFœÁ2´£7áÝÑ½íØ7“•=Á7Z0.+½ÁË¢ØÇtìrÏQ!Ö¢´CÊ°ºe¦ŸçÓŠEŠj[g
+*‰}b‹Ô“ŸDÎ˜x´0ä—TéÑÿ.-f{b~¬Oêñú¶é‹/•§sTÎ`O°À•19ƒÞ ÉŒšßM‘ã²—föWÁ,ÜÑ¢t5‡”½wx?!g@œ¥»9¤LÊÊîæ2Å¸8,‰-âÈe)]àÖ´ÌZ™
+†”ù*0)³òUì“¯õMB¾JÔ7sg4Ræö3`88(? )Iù9:CJJ~Žhïäçˆöî.†Gtˆá©Ða†§BGž
+ekCÊ"[“i¶&Ž±5°ÄpÆ‚!e™á0`…á0à8ÃaÀªJW<RN¨t1hM¥‹Aw«t1è•.TébÐ)•.VébÐ9ƒ¾¢ ÏªOJ$RîÕÀ¡`H9Ç˜®>Eƒ!å>9Cò8ëÈpÎ«8$sAÎ ¿8ëEõIq¿²h C¿$gHáAdoÓ@†ðœÁ@q¾‡Õ'ýdèj Cÿ9Còo×@†ð˜2„Çå‹ó=¡>©èOj C‡2ô§äÉ#¼SÂedï’¯šÕÈV¼WyÊ'%Ÿ×—JEƒŠaEáêgï/Ö!èh'ýup0¢ep¡+v9eöR½žrd GÁ­‚B‚Rr”'„’ÀfÕñàÀÙu‚'¶ûì~_  é»ÃÝÝ’‡ë»>Eþ&»AÈxßÕÅïŠþsôG!É‡é¯ß8¹çñÕÕWŽ\¼˜}÷õdÛÉ× € 9·Iþ^Œ]‘o%Ïñ„Áq4J/M¤y<ˆi‚Úêr·A€LdÕÔÕ5ºÝîp{WgGCC ÐB;;ººÂín¾¡Aª\N·Ûãq»]NA ¥#çƒ­Rºch¬zWí‘ÚÆÎÃ}}Ëu¡Ú½rwÌ×^y¸w²kÉÒÑÒåoîm«k¬²5Ùš£­í3!Yêòú:äÚ¦JscÅÔxÇþv€¢%·Iþ¼ŽxŠ4ƒãH„<4¥#”)¶—x\¥^»×¨G	)4ªòtª”Tò5rIIïêààjoßñÁÁã}ƒSSƒÓÓ–¾s³‰s}}ç³çúâ«só'NÌÏ­‚ <·I‡é«h"3Šq6)3ŽZˆŽ«%ˆÄhà'½ŠùÖ³Öã¸Ã˜Û¡§R)m‘ tátäQPp:Ê­™ô GžÒ6ƒÁxÌb¦Fc‡q:¿zë±³¹UˆÂ0Ç/»Ò/½H*•Š¸4¡©1P_'Ùíö²zÉn·jƒa»ÔÙÝÙ‘×%©Îå
+w‡]a—dw2uëö‚T×Ði—ì‹ccÃãžæÒ2oUüª)þøãuÍÖK©³Õ3Ýÿûä·tS{õƒ–#SO=Ë¾Úeäôæ…1bÍfú_ÐÈuøˆÔW•
+2I	.NéxÊqç¹i >øìvÁZsa‡Ûí	wuu;¶AœÄ54$AÐs¿ùŽ£›ÀJcãÆR=o°éGg»gÈh3ðúã¹žý_4ˆúHÅ6¨’ðu±`0îËþ‚éx8·I2äuTÂOEl6BhmÇ*èxB'5e(!ª¥>4%žGšÓQUóó’¯ÚêÇÏ#é4ëÈ‹ùÎs¼ñp&@W•—Àë¯ò»]e¥f#*I¥Þêzê˜‰uw¨n@PÍe—{í]Ý6êrº¿ÐŸØ¸RllÞ[-Ö-íIÍÆõ\ýŒGŠH‰Å¦vËX41o¯í’Ä²Oã©»²¹§º).Ö>f[ÄF‰É.#äuØñe–RÇq”L	öæ9`1í=-ØÜN¼(E;+s$„0Mà‰ªù)™Ö^œb®Ys9[½Ž;Œ»ÓÆB ;ìõõvµ"¶‡™B…Ûó>ToOÄõ\ùXsµ§Ìì(©UëÉ–.ÓÇµd¯±Â&B¹MòÈëÐCD,©&:¾†P¯#üª@ .Ž{h
+:Më	¥Òi£À[áqÛK¢QÔñÐ½Áê’:AÐ‡;¸-Oér
+zŸ»`{ÄT³»Ic 8tÏÀàJÏ‘%J³Ÿ÷Ký5âùtu¤ctov¸ï¾Ù™so;a-·$æö.wË15¹}‹¼'Þù¼ƒ£ìÔÓXî ÇX§ã)¥çiç[n~«Ûq§‘wÄØnà„SrÔkV]à;ÓS{Çë¥éö©Ñ„Üæïõ“ë#Rkúpö«¤)>ÐàÏ~B9‘ü¼Žv`šø#¿•òÂ¸@º‚v™‰ ^'ðkÐëIšFŠJTÔéŒGa4žŸ²ƒi)ZpÇÎÑê>Øñ|”^|ƒ±Žÿ•ÿk‹2®J‘ÁŽ0Áh|p:2½§'<Ð1j®¯óVV”»h'íÖ-ïÐÙ°­Q]}Ø%¹´CYªì@kº'pÛi‡KuÎ¦Î6øÊ*êåöù]Îzë³+öò¶Ùö@µÌ¿ëÈþý}§'›ûû‚Á¾þ®‘ùpë¼ÍWZY>ñ½ø`ín7on¬ªm±òÎx°sºY¯äKÛ|áÉ&»ÙëôÔt÷‡&[If°³³¯¯³s0ûTC]%Ï;š] ¹â ®Òçif˜~Ydkn“|‡^ƒ"^‰”šˆŽxÜ”×ÑÉRÂ“	M/ªAéÆÌ<ƒõšóv8pßMHªÖ0…^üMf{1ùy\Næœ¢K,±Y-â0e¦J)Ð.¸r&<©N•ÂOî:Ý›înù¹¸ž«š¬ˆôÕî®	6ŒXžx`æ¾šÊ¹ÏÝèÙ]Õ4ËVyZçz.iÞ <÷c2BßÖ"&'ˆ‹@`¶#©»â¸õ)!„å‰ª|‚€cúüÖY?åž¸S*â"(+µZÌ&£A/èxxˆ§°bÜTüótÿØ¤iø±Ç|ÍÖ*›ÝÑjLÓ€îÊ•XvSÞ¥Óï1™Í,úü4yUèf¶BI……r´’€ã&·œ¼ê“Š±³ÇUj3êQEªò±s‘¡š§WÕ=ï_C'ú†îh®hr´ŠÁáÆù˜o»¾f&‹Šívwëþž¹ÕJg{µ´åUé58Ñ	:xÕ­¸pÿw‹ëséoq}	Nš*z>zíË¾®O[3÷c|›^ƒEOVJ&AÈvÐ!Ívn4èxØˆ/p>\äø³-M	›‰×æ2ãîº|ãŽRB ˜ÈôaX0÷Ë€&'ïl2R	BA	¥ëSl~QGxþ<¯z|Jè  OìèÑü½»Ó®mš)qgWW7ÛýÌûÖå¡ÊÁÇãä/;žÒ_ŠƒBÎm’Wèe˜áÙža¬ïÌ0¬‡Ýâ±zô:˜‰Y(ÚŠæ¹¶g?]<ujñè©SG{âñžžáaË§>ú[Ÿüäo}ôSÑGž~úÁŸ~úÆÓ:œ ß 2Ì#M DGr„ð:‚UPª;*ÕÍ¨WÈf;ûÑ[½ÁîN©3Ü©ê³ëÛÏ??ôüó'^xùå—Ùœ–\+ùßä:*Ñ	•šxŽPŽ€ÐIN³BpŒmè&.·ËbÖëX(ÇÕ£&yLZÝÛ_ÎFJ«-eeö¦®óËû—ÌfÞì4œ}ÁÞ:üçzCõä²ÿQ;Vç‰õÆëm“!Tå6Écäu4¡#²«œp´‚ç8ÂÑbÒùÐMIgµ×í4h"M[ô“N5çÜ‘rzj(;1þ¼óH]ƒ8jkÛ«ê£M©™ÐtUCE·¯%¸'Ô0lš±ø}m•U¡Ú
+ŸÇd•:{gjË[ËœÍU¾ºRk}·ˆ62_žÈm’Ÿk¾œX4Ï]b":®¦šò:Ž€ç
+IÞö×D{í¸ö-ˆÅ˜³èÄóÑšæŸÉŽ„BHGÈ›	·Ÿí-LtÓ‘`³0/Z8Xú/é¥-ï±=™Ö»ÜnÒT7.rúh‚úfë=:Ò7Ó;\‘ÄA‹¯º^ûB²:ðä½s†Wf—êÄ\‹Ø@0‘Û$_'×áÄ»Ÿ·[(%Å‘#„¨4Žñ;SO¾‹çÏký;³œÛŽ¼ã ¶q;Ai‰ÍjbÞËIœÂÍÞËž?¿756lkè­cábÝ¤%}˜td¿I*[9ÙÈ>£Põ(L~N^Wc‚?”pDUì„ò\~{ÕÐé
+a,„jN	„ã(¦>-ªÝqÒß‚èxóÙÞÂDŒN—yùÃ‡¿Þn°V=[ñ²®5<.Çvá3føf‚GŽõí©‹ÕÑ‹ªìë}_£ÏõT5¾ãÞÄ…šÊý'Âvá´æàK8‡2TG*yB&	Á¸ê œÇt}µ–=®®€P'ms¶1g°P–Kõ¢äµ9Iu•·¶#Iç³}2H_…éˆI«±0Ï3¡xò±†ºýSLÔºaœ„óÂ´7âe…B¹µÛô¦"% \pi5ƒµêv5×¶zEME|uµX è3™Ši‰@_#¯Ã‡EŒb¹‰c5¹¼~¸µ<_Ÿ0èuÜö¼´R•'C)øÛ1o0þ†2`_ùà“Ê$G}½Ýh­Þ–/yv„úbË@œö–4LËã	¹¥+ž[»âjµKnê(ÄÙæ¶ÿ¡Ü&^Ä9˜Qñ¨R§…“@;b¹›ŽØ‡*$©¢\’,’·Z’ª½,Á@¾J7 Cm„%žëÌ¿ÑEvâi!:»·–³½Ø}®…9RK7n¼0ÊÄÐjº#ìFUó•ÙZ¥L&“Ýd·ÛµÚChU ÎvHIÿ•ÚWjËÄR¾Dü«ïùnjàßÉ™ååîS»wŸÊ.Ðg¯]ÓhÅ§è8T¨¥‚õ)&„ó„‘É
+¾œ•|Ãö…96¤¸?¢ð >â+(…j(XŸâ¹b˜çÇ^Q(,¨§wƒêÁ´b•Ûí²/Üõ©”çõ³wý££¾”×	t#{Â7V¾;Löß8KžñÕï:Ñ™}6c^§×`As$`6é9VÛËG™Ì¶­l¥ÌQXÙîëR@ïJ$è×}ìÅ…÷,ÐkÙÚÜ³ßý§»U÷cÔÅ
+_¤F …í\œÚ’˜Ö
+Mb;B‘Ï}zÿ!³ÇÌ›=¦Cû~\Ïþ°~L’Æê‰3Ëô:—Ó|
+ùk@@Öˆ€
+ ÆÈ‹dMé²õ›ð×¤„T‚CMÄ¦x]G)!`Õ÷¢ º;Ã®¦ë=8¸%‡‡èjYÜ]áÐ*ˆà˜ÑG5l‹»kQ[žW–‚DÔM0³éêê–ôœÄ¤ê²/¬½Íì6óf‡åm'¦yòáûóœÀÑìoÕùýCuäè³d­zl´ú#ÙO‘¹TŽUgcKÿ_Uu¸)ÒÀ¨á)·Ê¶uTU°|`ÌØ #"5’|.Ÿê§È¥ìw~ö3º1òÝ‘ì_±ù*r›äOéÃqwÄê&Tg/ež‰Ò|\^­®ç¹£jÞ¦Zo!&‰T¯ãøÕ"â¶îTÄAPYÎnBl,í‰¨¿9ÚSk‰ŸKÒâõäù§Ée_cõdOï¾½¾ÖjÙEl÷´Tw§ºúYº|]U¡™Xt¯ÓQEÂ£l±“ÃÃév&L&·zº;*!aw¤ËHt,¡ÐñT·Ê’7SàyrT(Ø£ä«öV–;Ë`G©O¯Ù¥F;õÔÃË“+ÙÀÂË±•Ý»ZÆÏî}8=¿wjjåÜþ#‡œ£âÈžðT	ožŠ’ö´ïn»±9íßÍxÞˆ_%ò(ÌªcÇNªà	ömwˆÝÛâ3¡X,ŠÅ~5ÚÕ‹uuEU}0åÉ>ú%ÍÇ¨Jý$3\l÷1&&bîËþè£Üñ_|P[ŸÌtf8™/–<¬‚ç‹š”Wng™ÍÂr¿OÐ¼ªÆI²o1âs{O<yòä±s¡õûÇV—³¿ cC#£ÝšÞvä6i%½‚jíFÊbæY¥¶U_º)«.w«Yu5©¾sV]L«çoŸ˜||®÷pU¨2ÖÔ¸#|x°e¼6ØxÔ²ï™{î~&ÑZ®ªºH<•êÚB»
+ûélð i3Ê“Ið „§«,ÂÒ¸ p4¯!—½6ØìŸ^syýpHÜvV|-v¢w6þ‰#¹xz*‘˜:M7¤}ñÉÃöìßWöŸIj02Ô‘Ëaˆpx‘ü
+§W}WIÞk•¨^‹ñË—Û$ïTékŒø9JY¦¬¦Æª¦“p“QØ–„k)Ë
+Â7îïêiëêœoHXîöD'É+Ùðî#=Úü~€|‘^†—ÉÃb¦nBY¥œõj1(åŽæKÚ ¼ð6úªëï Ã-‹ÌzÃ®ÆÅ'GúúãU-wõ§Žß?]ÙSñRû‘÷^w„ÄP¨ku~àÒ“³”Õâg¦+ô
+JP½=¿të_¹»´Ú^ý†7~[I¹›L&}$1÷ðØØÃs½ÛîN&ïnKZæ?¸¶öûöýÆÚÚçÇc$.½ç=—ÄÔóDQvœ'U·œ'2;ÏèÃ°"òƒ@h~Ò®ž**ßò'›7RÂl›¬æß¤"fí¸³;Õãn€vû:}.§ÿ]¡qßPöOÉ‡öìmvñ÷þÙähxüñ§þÇaFWîÛ¹@¾9S¬F•Æ_ÐèÙÉÊ‚©üò[ÓCo·çk©Óç’ì÷%ò½/Ñ½##7ž/zºì¬Ö³Í;æo¨5Ý·—˜0@ïÓ<#s ¢Îü™|øýû'î»ï¾û&èÆ³W>üûñw½ímO0	shÊm’kô2j!c7:#í·Ýø™¯Ùfý-!‚Ðî–Ý¿½µ¤6Ÿ¡©²ÞVVVuÎ¥U¸í’×ŠÊù*òÏúŽtKÝ5RW["<—®jtV·‹áÃvQÚÓ)÷6Åu=Ãm3-áKh¶½yhW)_1Ö¾koÓâ^_ok	_*÷[§CäDuDjö´6´KÙ/îjêh(«‘;‡UÚòôaáÄ|Ä¤# VBP8@Ý¬<@ˆä„j¿ÑéÎëÔË#
+úÄVo¾#±™L&§Éi·—U–ª5 0+¨³;HG§¯“°Ò–ä:q'¼¥ÒÎþ-±:xðõÏVŽUxdO¶Cé"Ïd×£J!Zø®êå[#ò­Ñx^­;±uo*<c—Ï¥F?ý)ÙE7F¾>ú¯ªåx úsºq›;ÖõÿúëS©˜©ÌÀ›Ý–ÔüK¹™7ØMÃûßyÏƒÍÀ%†Eº‘ýPçÝ==÷t•ì‡:îÑ gÉå†ñ`p¼!{A«Ô‡Éw´¬œóÕ’b¹~Gu§„èèÎ×ŽÛaß‚¸­ºÃRm-½ÒÊ, nÍîóW,;êø7!:Þ|¶·0Ñm²{§¿že÷ºÎní†½p1Ó¶sÛ«ýäI¾z¢Y+ùG|ÔýF±ÜÿµO%«Õ’uuË)"l«÷“\ ÿ—n RD´é	·•¶lÅù%(©(S_'öäÅßæ\_|%µ¿´¶”·×•Ì|%KÞ÷Ùú¿¤þ³ÙÓYM×jò«ä:ŒLÕ¼Î*æô.Þ|Va,³—iga®ø\µO&s ™\ŒÉÙwÆ´¹C yM¨o;÷úÎÍü7ñ¹B$•ýùXöwÈávZ>²ëÆ˜‘Ì’Oã“ô*tèž',¾›œPüì®šIXµÂdÚËN›2“TÄ¤%³e,‚sa½~©”Kr¥äÓŸ8tèí6€(ä:*Ð‘œ6=á·¬mY[*Ê*4’»ÛX¯÷HùÄV¯·ýæ¯¥†ÌåVÞì6÷øµ¤F­•6ÞZn‰fp£ÙélvÜóÚîuË.WÐso>C¤°°µµ¬ñv¹êM#a#§w-ÌqÄ~äkÿrø‹÷ÒìdügÙ»Éþ'þLÛWen“|ž^F3â‘¡Ê
+Êñ¡)§fa„S3]:ÝÎŒ„ ¦Êãb%>ƒ€fÒ|K¾Ñ u#…­ø¥æÿpò¸Ø\=Ý³go 5Ÿ©ë7ÆªeÿBÏÜÉHÇžÙž£–n©«¦%ÒÙ°[»|­]õÕRhÿÔž½NÞ:íIÈìÔ(G7nÎz×ß<ëýú×S+ö;o¯*;µÿUº‘ýHïRoïR/9¦U(s›ä%õ£C‘@AJ	Ç—Êî© žÏ²°sXýKÐ¾°ZêDo…³ÌÒhm¬¯Ó[Ëƒ­ê©º G‘M];…Ê˜ó½½âh­a¬¿e(žªlqv×°[ÔšÙÆÄRÇþðàòîáÓäÆC‡ÓS7~¨êðTuÜ¼A^:Ö¨#þÔê£W4›`zÓ®žI,â`¾”ð«,~YŸtÅccçYÄ>‹cÉ´Ï¾0GvÍÏg¿A7²ÿB7Î’ÎìW´8CÌmÒ½3:ÁH$æä(‡Þö– ¿NÏst²•q–­‚ãYq¢ð-«Ž±»ÆÉ´Õ²»»1PUié°v4
+Ìðœ¬¦)‹£„ìŒAÜnOWwXôjÜ(ð4 l·…bÕ>¿ÜÚ{¨Ó¿§ÎéiõÇå˜_L¶ÔL•ín¬‹T¸ë¦þ…¦:ê«ÚRR]¥ÞÞêš¡`u°ëÆ—C‰n9Þåišª—GšÆöã=Þö£³÷F.v”×â&U]ÓçvGª*š—;«úÙV½‘H¿ÅLu´†„<§ãWoJ¼Š¶S]å­Ì_iæsõ;_i²«)» Cžœœ~ê`üpUKE´=z¬óÞ5)âx×·j×òùW{mGeÝÐ…ÄÛÞë*ûÝáì}j$}0·I[è\¬ÒÅ
+öª§Ý–ÚK-&Aq“@µJ¯*h>É!±Ø=sMÃAy¤ivànKç¥ä‰ìS~ÿÂyGöÁ—:AÑ–Û$_ÎÛÌXdØCx®œèøZŽp“Ð1·¯ƒZã`—&ZQ±ðA»”|U•.3-9ÏP£/8îV.m]Ÿ]íXa´¿5ÒÛ1°¼gøÌ`Ç„·ÅÑSÚÛJkfsKûÉX£|øØÔàÀxö÷âï<þè•Ñ@uØã_\ñUR3)·É¹é0	˜"ç ¢Ç$ù²–«Ð‰©˜E²ïàÑWÀKZ5ÜRm£:¾¦„r::éU…Ç”†Rg :ŸfÅ…)¥ wÔ(PŽ»8e1kÙ°wB	Í&#ÐÃ ÓÖÀàð#ET:Ž×­Ý1ÿñ` ½T/9X•Án·Zkƒ>»Ä~óÅwµö.¸\á[Jñä¡¯$ÆÆ&&Ûö©¾ñ+ÅïY]>{˜Õæ#“É²k¸m ø¡Z¤eü%Sä}êí0«Šp”°«‚bvÜænØpç»ác‰DŒýihkk´µYN.;yòØòÉðÌôôÔÔô4Kè@r©Ü&~N¯€CË„ÒÄä´½\ìe± Áìñ‚J;z&Ÿ w÷d?`¡Ÿ¼‘ds}™îE7}žù×Œ°“
+SF@Ü¾úòÚÚòòÚZº·º¢¼¦¦¼¢Z¥e ÿ“\G	ã
+ûpY»gFñš™$aFk1–¡ó;]ÕZE·ßj7VXêË}ß1ýœ.,ÓêßßËèfUh|œ\/VË/Þ¡ZžHëjX=g9ëÌËáÄŸ-éûôûúß›Øý”Úî¿|ãƒÙïÎpŸWç ù§Ì¾›ûAöÃ37>˜Ýc8£ØÛ~öÑw#EÝh¦5h¡	”Óo œüaräßÂ5€JHŸ „ÿDœÑJ('×ÐBE$C‚¼†òdòêÈ7a!¿*Ú„1AƒHà§h%õ(çúUxˆ\ÇÁ=è;°@þ	6NÅëFýÈ¿b¼†
+:‰Ò†Fr&Ú…Ú‹ºê<ßƒ¼?}êókñãÜ·i9ªèª:¾‰¼;-ÁWJûßäräYÔR/Bø)fÉça£1·’r,BF#}4‘®¡ƒ>ƒä5´q=èÊÉH8K¹/³µðŸª<Çðq\'×¨›þ×Ì½{;÷þüèÞ©û¾V…÷¡·ë{õ¿¢ÿŽá×7Œï5þ‰Énz¯é3¦ošÍf¿ù¨ùÝæÏ™¿fþGK§å°å«ÇÚoMYßkýŽ­ÂÖdKÙ>lû¾íG%­%{J•¼§$[:Yz©ôšýQ»bÿn™¥¬¯ìRÙ'G—ãŽ/8Çœtþ™«Ã5éú{·èqŸuÌýGªä÷áiX°
+#(Æð8Þàk6Ô@íc¬:Ê<­êƒ	*ñt¦°áwò0‡1üAæ·áèÄ/ò°€2Ÿ‡õø ¹”‡0ÑÒ<lD9­ÌÃf´Óö<låDºœ‡mèÐ=Žg!¢mhG"†°Œ38†ˆhÄ	¬cg±­hÅEõ·é"N–p§ÐŠ&ÈqkXÇ	0^Á}XÁ9\À
+–!bgpë14N±ÄrÌáÎã–°"Vl‚ˆ9¤q÷ADXoçqiœC-hC'ÚÑ‹!ÄÅzwŒ.Œ#tÓXmÄ¢Æ•Âû°¦Ò&î˜÷Î`]Ýßi\€ˆ]hQÿ´¡§Æ=XQ1Žc÷«ô¶£]*Æ[£dçn×Ô¦!bçT¯¨ëœÃ=qÇo’ÎšJ1ã6{ÚÓ*ï5^ÏaiõI›ó4–ÑŠ38§Î¤a0ÛÝyU*ç°¦b·l[ci•Vq´@ÄX÷­kÅ:ÀY¬`'òûÛÒ¶ûãXÇEu[8‰5•#ŒgÚnØªËyŠûÃ8&!bFÿôŽ™'wÌÀôòf9d)n£lçº[ò¸€4ÖT‰ÃIµgKË™´F0„}*¼Ž=oâÎ}XRy{ë*w'Ñ¢Êb­˜Á&o¢äÍy´¬¶šÔŽá|QîÚî˜¼™ma"Æ1'V@DT}ÇœÊ‘ƒÇ<Æ0ƒý˜WŸ‡@C˜Æ<Æ1¬ŽA‚}=ŽL#®ŽWa­oDÕÈi¤ bã*›{%ÏMbÌ:ÎªÔß§Ò®iáNá¬ÊsF9ÛÿVÔþòq<?kaì}ê˜%¬á¸ŠÉ¤Ë¸Âl/Õ¼V0œs8¥ò² [ö¢iëÕli«gT¯vNµ96«ˆò¶Ì´U£I³Øõ· Õ–ÿ’Î°xSýÉ}í·ýÿTö±ÿ		ÂêôqìÇ8ìÃ^Lb1‚	ÌÀ	l8„Fs(Á8faG+êÙ¿þR¥[ƒR´¡	åðã(CèÄËÁ…vT£SèF ^xÐˆ=˜G£&Ü…¸±UÂˆfô ÂDtDÀ·¸ãG×¹ãG—VÎiYÖŸ?½ÖnëVÛöp70ñ"®%’BÞ“RˆöOŠÏf FÌïÇC§ïîd«oœ—oçÏŽ{…=Y_ÏMù®÷	OÒKÂÝÂ!~–
+a]#U»J£Cæº—Ä—ª^*ÉõRÙK¶—ÌcF˜›3¨ˆ™¹å—u~–ìñL=yj_R‰<•dÏËñL#{~Ñ íâ)o&À^ý¡áQ>òÔÒ|¡ƒýDœOÓuaYHò“|ŸÐ¢k F[ó‹$÷„Â¿;CN·, Î>&ÿÄ€ß‹
 endstream
 endobj
-332 0 obj
+373 0 obj
 <</Length 10/Filter/FlateDecode>>
 stream
 xœûÿ üü
 endstream
 endobj
-333 0 obj
+374 0 obj
 <</Length 404/Type/CMap/Filter/FlateDecode/WMode 0>>
 stream
 xœm’Moã †ïþ³¤ô5ŽÓ¯(ŠÔ:µäC?ÔTÛ³“)ø¿‚ÁiµÚƒm=ó¾0ï`Ø¯·ÝüAš=ÎëßÞÑ›Ñ	œ7Ï½-Û1¨Ã¢D9©~Öá1@Óm;­BÁX§Åi”8yþgyÄ£Òß†ØšÑ3Œ}¨pÂÌ¨ )tuPáüª`ì:¯Œ^AU0ö¤ec†Îeîå›3b‡JK—;Á>ö-ªH%B¦ôCoÓâÝÙ:}0P“KŽ6; Êw<*Üf)ØH<òê$:¥0›Âþw£µ'Œ!§*j™¾eþ¥Ê<ð¥š§„ê»ôq¶˜7(?Ÿœ ¢ˆÂHô¶èz}ÄbÍ9çX·mÛnbÇôª¦eûƒøê]²WXs¾¼Þ$Z$º½#ª‰8Ñ2ÑMv^“¶ º!ížè–è‰èŽ¨&º'Z=Ð.yÏGÒ*¢†´ìÜ’FcåüqÀø/'*FçP‡ôÓñÅ³R/÷ÁW¥']¤éNFzmÿ·‹ë
 endstream
 endobj
-334 0 obj
+375 0 obj
 <</Length 2165/Filter/FlateDecode>>
 stream
 xœWmlw~îöã—³ûî'¶ÏowI_j;¶óž&Mœ¤õè[št£¸©›dKê(qÚµ›¢2eLÓ„&^…DùP*„&¤!4Ê4˜*¨býPñ©Ø4Ê&ÄKt_š6í§%ûwÿ—ßóüžßó¿“Á °á2X`~éâÙ?}ã®à« ÷îB¥|¦åz¾ ¿°P)ÛÞgþð_XX®½¹Æüà¯è^ªÎ•]UÇ« @x¹üâ
@@ -1129,13 +1243,13 @@ tÊcT(³zæI:bÌ(FsÔ	ëtý~Ó]K4ÏÜ.>1œÇUâ,QÁy”¡?ôOÝ=èGÌ/Û.zúÊš©LŠvêQm¶÷î®+_4
 ì8,M¦›çîi¸;N1424-ã´éˆæùªû¨ˆa¡q½Pž8k˜£]Y¡çM§,– Óó;NB¥O¹ËxÐkë;Æÿ“§\€VÌâ&p%Aã8QÌà(ð‘ó9ü
 endstream
 endobj
-335 0 obj
+376 0 obj
 <</Length 14/Filter/FlateDecode>>
 stream
 xœûÿÿÿÿÿ ÒÜ
 endstream
 endobj
-336 0 obj
+377 0 obj
 <</Length 534/Type/CMap/Filter/FlateDecode/WMode 0>>
 stream
 xœm”Ioâ@Fïþ5KäÀ¸ÝxIB
@@ -1146,7 +1260,7 @@ Dø>*–~}^[–‚ß/¹AˆËÆpß%w…=³·RJ©5­ò<Ï×SÅâ‘Æ´ã©üSt.=\ÓJ©h·v¤%!hÚ‚"PŠA‰RÉF
 Ú8ŠeÍó¤æ¤@;Ì“Ì±…£pÚ¥42C8ÆH%SApŒ6 qÌ@ðKeø-dü"!øEè:„_$õà—È*ð‹%¿;ŠŸô¿kjø¥	~)vB‹ŸÄà§á ÅO~N[Ëù¡3¿;¨á—àü4üb!øé»pr³¦«7½°û]/Ç®c;¸æ.öt‹+Ë÷—Ú6í4Ë}Ü¿ý[Lô–ÿóq:‘
 endstream
 endobj
-337 0 obj
+378 0 obj
 <</Length 4898/Filter/FlateDecode>>
 stream
 xœY	#gu~ÿß­î–Ôj©Õ§ZWël#itÏ}îjFsì9{{mwgØÝvgmÖÆk‡ 6¶ãB‡Ãæ4à E
@@ -1174,13 +1288,13 @@ w©RÞ/(JŽ<¿ëÀÝërH&©iÚsõ~ÅC2“ô._R9êI~‰ó;û{¦€ »zào´³BÒ cF=DXõw­&[ Y¯	F
 °0ó'>eVë³ú°ù?Áë|² P„m°&áËÐ{`ì†)€ƒ°f`?P‡LCvÂðCR„	¨Aì€87@ÜP€8P†íPþÿ\ôÞ
 endstream
 endobj
-338 0 obj
+379 0 obj
 <</Length 12/Filter/FlateDecode>>
 stream
 xœûÿ l{
 endstream
 endobj
-339 0 obj
+380 0 obj
 <</Length 548/Type/CMap/Filter/FlateDecode/WMode 0>>
 stream
 xœm”Ioâ@Fïþ5KäÀØÝxIB
@@ -1190,7 +1304,7 @@ xœm”Ioâ@Fïþ5KäÀØÝxIB
 ð‹¥‚øÁVÁ/•yâ·Á/†Ÿ†_Š^´œŒ´ø%÷}Ór†èNËbo4#É„c,ëÂ1Gœ¯†c,kŠ£t Ç…dÂ1‚•†c„=ÕpŒ¶î¢Êœ®ìô2ïo¤»Žíà¦{Óí¯,ß_xÛ´Ó,÷q·™‰Þò¿·uE™
 endstream
 endobj
-340 0 obj
+381 0 obj
 <</Length 7690/Filter/FlateDecode>>
 stream
 xœ­{p[×yæwÎ½¸@ @€ ø¸àÅC$.Àø&EA ¢ø”DÉ õDR/ëÁH”,×NâDvëeeZoÚ&é8m¶m²= š‰“ÝtÜ$3«Ù¬3Û­»I¶iÆ™¦¶'^O\UI“lìœ{Š”%§í”áþ÷œÿœóŸÿÿþÇ9„@ Xñt,]_SöU‡Í þ+€_ž^=sñT»ü!€¼TÙÎ\xòô½ë ú€÷+gWrËÁcõc õ ½gÏ®ä,sæ¿Z_8{qíÆâc¦»@ë÷ |ãÂå¥Ügÿäq í³ –/æn¬’·«ÿˆˆ ”K¹‹+w~×	D€taõòÕµ½M¦<Ð¹`cõÊÊê/Ïµ^º ?Æ¿ög3Øƒ=t ¯Å8ýLñ.¹S¼[l¿ßW¼K_%¯ïgx/}UïŸÁ ÑŽva‘þòB„Eú*¹‰_lµ‘lõ¥ÈÍ­þmkÒ¯Þ_•~UŸ7Œ!¡]øëâ~PLmÍ§m›O»?ƒ¦0Neeê%T˜bÒ¡Å4ëö±]™ìieýpšÑ`îËf˜±´¤žòùý†”:º	‚T6eDcJöt”QMõ«þ(4eù–àªE2Åœ)%›Mæ©+•Ì…£©…
@@ -1233,19 +1347,19 @@ nèët!†^ã½äÜ)Û9]®¬áŠ®õ}ö+x
 3(þ(~]ý¿ 4„@'ìÅ8c&0Ç `?Ž`iÌá á &1ELÁ8ŽñR½È P´!ˆ0ÐŠ¢šß¸¡DÀ·…Ó'×äk—ÎuÄ;ú0õnLç	ùx†ã+y«yÈÉDÅSX:”êËhÓßí«æ³bÚ¼Ï<,iæ&Y¶”šoHhVš—’b·4éÍUÉ½‰ú„;Q“¨NXòËamË£6¹·‰¿¼ãË<æäùi–x>Íß—Gó»øûKfÍøòaÞôó3 bâù¥…rÿIØ¯Hçé¢´_c’b’«Ú^"Åç˜ø±<Åè-Ó²„ÑQü¶‰V1
 endstream
 endobj
-341 0 obj
+382 0 obj
 <</Length 9/Filter/FlateDecode>>
 stream
 xœ{   á á
 endstream
 endobj
-342 0 obj
+383 0 obj
 <</Length 343/Type/CMap/Filter/FlateDecode/WMode 0>>
 stream
 xœmQ=kÃ0Ýõ+®ƒ RËÍP!Ð85xÈqigG:»‚X’<øß)rRJIÜ»wzïîèÓ©^¼	}ÁÅò™Á,ÇE±o¡t§ùÐ£òDbÊº«¹CEµ«”ô„ÒJñë pâüGÙb'Õƒ4 œ×=¡ôCú+®`v z‚J òÒÀæ„ÒO´Njµ‚œPú®D¡û`Î‘,i@v²š×è¡•JØ¤— Kò’ûÅ›÷‰Åõè<ö•j5,o,1˜Ä ÈÎØIçí³hlÛ[æhZ©:˜Mf%ëÁ˜+“À"ŠJÄ7Íš!KßÑÔ%äèc4˜>È¾öZLA~³Èµ@gŽ¶Q’5cŒm`]–e¹	Šò©êÒòïÆFv¾5cÛ×ÈNx¨ã¹åƒµ¨|œNt,H…÷1mBU<q?ÓªCt, ˜®Êb
 endstream
 endobj
-343 0 obj
+384 0 obj
 <</Length 3370/Filter/FlateDecode>>
 stream
 xœ­X[l×yþÎì…Ë‹x/’½ªsVÃ¥(î™%-Š-Q9Ã%ESW$%Ïøí»”“"CQ7ÇnœÄIíµ]EªE[ W )þ¡ZT6ZT½<4@[H6èKŠÂ"jÓ‡Z,þ3Ë)KvRd	ò|çüßþë9³ õxôÍ_]—³½ï ø3@ô-¬^Xžë­ÿ& ~46\Xº±0÷î÷~hú ÷.–übúwð@ó ¹x±ä×þSìë@K'€Î‹Ëë×£I¼´œP·´2ïãþ
@@ -1265,71 +1379,53 @@ g=„Ì¹¢9¢Â¹ªœ¨îzMÏ´Æõ²Æ2ý5ˆ
 £a«ÅŠÇ[ñÎ`§ 1¥÷¿´cçS;vàN}¸Â[U”Û<Ûi÷A=®ÂÇ"–àcKZò ï¹ZcÁ×qò¡ì\Æ¼Îí*ÖuvÙ‡%du-. SÃ©‡<ùüõVmWªu£ãzóiÁ$&0#ŸÐÝÎó	ÌèŒ¼€	Ìâ$¦p³z>¢ß<Žà4f1¡Ogw¦p£ZcBãP6¦;ò4<HLbBsxïR%?aÅø\¬jï/kßÃ.\Ä2VuÎÙsŽ%áÏ^a‰…Ê®[º—µÎ<± ™\]ÎÊ\•®`Î–u.·zãÁy	;‚¥áYz ¿€}Ï­é3Ç»JÜ¨œeîÖÐ§ðÄ®ÿUÍþ¿z¦ò,Ûüzä{p~ý5Z0y;íBü²G"üwj5@=\ÿkxcù•3¹Ô¢G¯´•ßˆ®%æçâÏÅ%TMg´¶®"úÕø·×â_Ž¿ÍGíx¬ÛÐ¢f{¤~ÿygß½wÚïì¾Óx§~¸vµ¨ï	ð„=RáOý°ðCöo4èoŸqiøm—çÅÑ ›ç·0ê%ƒ¼ôQâMˆèðÛó³[þ·½ËXãnôTt(žuµ=·Åæ·(ú~``ôV¬Çè(€ÿC¯K
 endstream
 endobj
-344 0 obj
-<</Length 6155/Filter/FlateDecode>>
+385 0 obj
+<</Length 6612/Filter/FlateDecode>>
 stream
-xœí=ÛŽ7vïúŠŠv×V9Šw²Ç@,ïC‚8@`½eó`2H‚ÑìfVA´°ºx;<‡uéî‘¨«§«Xäá¹ßøúï?üçÝ/·†~zóâ¿1ð7áCpî‡Û÷¯oùpûç3ÁÅd¹óvàŒOž«IÊùRá¬þ|û0?ü~°B|¸Ÿ?çQîãp÷/þãÅÝ‹yñûŸÞ¼þùO¿<|÷ÝëŸÞüÃÿþû~ïWvCÙAæì0)Î¤ÓøÈ‡ÿˆ<*â£iê~:=i˜¶å&n¼—áÌŸæ?_åé¿øáíÀ‡·¯ïæ¼½+ÁÁ‡·ïÿõÕ8çà\,Ÿr4ñOjùÔË§•Œ¿ÙxûòéÆ{û/~ÿYŽl–c¸`ÞJ3LF³I™rIÞ„ÐgÚÎÿ¹°#R9i!ë5‰Á1³iQÔŠÀjÜüùnþ÷ÃüïÃé¡Š_NÿÞ7þôžÇQˆåÂŽR¿*îâ¢…BFz3LÚ°°…WÌ²œÉ—%IµÜ!#èð;W–¼Ü+Ça_¡p¿//ËžH>5?ÝÂO&EÀ,e™™®@Yãÿ‚%Ò˜Ãß„!—ƒˆi ²0î™Õ%4ìÌ9Œ	—'ÈØCt54ÏÛCfûÈ->ÿ®úë‡Q$fcF±€ì¡&Røë]çžÇñ&î¶Þt««§ÿ19./Ý—÷Kà÷¥çãøju¹pÄsîêù§_!>‰jø,\uW\[Ó€§áLí
-Œ *,çú8Ê¸;R%¨¤¹)Þ‡µ#qóÁÜáþ oL÷FZ‰Æó=ÀÛå{â^¤wá¸öXA—€B\Í…å%v“Q‚ÍW,ÁWüd˜›®ÄW.‹	Õ–ÑÒæÈÄšÝU2]æñÆu#iF¯àØ-K‰
-° À¸3 Ê¥§éD9òßW¿»À;>Þˆý“‡P­~ö¡%‰zÙi¹(€Z"É+ÿ–^í [‚’i}»{7É7Èn\gþ¼ÚnÈ×D`«ØP¶C±mð¾‰«µ?‘ò®¦'çƒ–ßIWÅåY(›Ò#Qiê1/G1//Ùt5¥¨F¹Ècu½¡	à®1Þ$•‰úwX¤¢ÿ¾|iÞƒÊ±Q8”Ñ–ˆ$ûˆ»\ã~KHXqÿ-""¯uñ„C9“¸€ÊjM ­ÖW¼i;Ü‹DC¥gÍ¤f™:Fá1^¯Ð•=´¯ÆMˆÊ ¸((†RÄ¨Q#æƒ·¬0ÑÔÄxÜ‡]4‹ð‹pœq?MîZ\Ò‹m¥{‹ë5ôôL\„Ž7›¦i²Sä1EÝ‘‚_‚ã°œmãå‚Þ‰Úe˜qæ GLâ˜ó¨•µÜf¯Yù³÷Ç»1:V8°Þ£·ò»ï^¿ýËŸþýõ?ýò—?þÏjÁ|bJV>­×¨Ùo9û3}¸t^+¡\ôa
-Í‚¿íýÀËŒv^]\¥øp;ÃÂƒÁÝ)ÓF
-îPå£*=q;_Ÿ¹×ù™|•oQóNªÙ£ZŽY>¹-<¬g@ëÍÏgR:Ü@áòD¯teÀíÄðó›8sføßA?e ¼ÿü€’÷ì~Ã¦¾øó3'µ<ANhæ¹µZÚ2iç-›¤˜™ßGA8«oµ:AŸ3q˜8õ äYž]š›IÌØyÃ|íÞÃêÍ03cÒIVXð‹:qÌG}—|å¯è“ÙçU{}îÀÝq6ï*Ó™£þ¤¨ ),î  ª‘5|ÿ"w€T9ø€§JÚæéröq¤Ú>OP³Nþ˜ÑÁÕ™åÆXßE¶Ÿµ£Ê	‘$e©©=ÒTVûÇ—|W¾[ÅÌÑx’è+6JŒBX%A2Î9W<75"DU.ªíQ=ŒŸMäB¬<oÁß£ê÷² R§OÀP6
-"1)6¹Á99Ë,qx€´˜Á«}yÏž„¶`ÎMÖzQ\ÅßƒðP†©(Ÿ”cFI¯T¸cb*„CòSñ/§goÁ÷ûôÝ2á¸R²Î±É¤7Í_n—Çæ/÷Å[æ?ð<HœëYŽ‚pæ6 ¨ ÔÂXoe ¡N[(Ë#¬Þÿz`•®î×1 ðm€LLn†¦ÕLùZ8/¨Ç™“38ƒ¤SN=qµ':6Ô”|W‰Õ§˜Ë_l9¸(iÖÆµÔÄYPægSg¸ =“=3`a Ð¦Œ|×v´Ù2·wë®çrÜQÀ‹M:èÚwÀË——¤’tùÔFøoÊ/¿¥Áò»ðÏWéêëzþQåX¾²Ìî‘tÀÐxb)Q§%ãÊpu4 lqq—”»ñíSj½!fBLér®…wt0uq'A¬[¤\÷ù".Y}k\CùY ‹k—3WàŽ*ê<#}ÓwAK5&Â(4Jè~¿Ç=ÞÎägƒ– Ðœ—ûÇrÌ&è§g¾©_L:Ug£Ý²t@PuøSš8ñ€»
-$±Óí°8:hÕxÌ×£ô?£ð7µ@¾/èœµä„&>ˆŒ¹ÆÓÝ­[ú‰ã±+Ô‘ú‚À&´Ñ€&ð×;aŒDóZgjÌ*‘ •kbè¸rÓÛ%B0høÌŠH¥)ÜÜKMœ¡j­¹÷R5ÒxRt4zƒKZL”¦Á'Æ½žì“k’S¼›ÒÅ¸Ë·{âœ¸ú0¬)ÐÈÌItM¨ÆÆƒnË»¬b
-;6X½%üØÓP°8ø‘”˜âuGÒ#L¯"˜•H²%Q¬\q­QAçxW­kÅ5TAMœlª'ìÚ8êÌ&áÊÌ¯ezT²Ò&%ÏüŠfµÚ¡-Îa'Ë¤º®V²_Æ¬`æ&K…`,„a Ô¡»‹^à¯u¶ÄQ¿+Uª£„<î0^©¼©ŠO¶/7‹­wÓñ¶è±ûìÍå;aÆ5®ð`RöQùcz•Ia•oR`ÃvØ‰¤Ø‰WÐëxÉ\
-…æN5Rø¬ýëé„’
-´X«BUÇ'ð>IMm6¥‹mÆpmÆìym, ]ªM¼µå’>âT:¤ì~QÕçÅÍùA‰1¿ÒÓ¼‚
-Ì÷›ïf%˜¿ªÿÙbœ}½éù$@HºŽS<ÏXŠìÁ\-†q­¾¿&µ£&&PT¯Î#tx”¡‚áL_KÕÛ¦£?u~cõÖ”'zH… Ù~?ãÛ@E!µ¬®bƒøïÓ‹6Qõð;ØÆüëËLÿÊ–×4Â÷+vºB˜
-YÅ™RŸÄ1C…€Ð)}"!|í’¦Žè\c¸­_˜Ëg”Kí1Ê‘ab6Šœ”UÒ2 °¶•JÚFma³Ù8#âevèx1æyÎ&pŽÄË¥HS³ëIþ0=÷¤†›‹²èjãMtœŸ¸.©€’ŽékÙZõDaUJ®ŸáÞªœi‰’­JZ|[­ Á«¡ØWK¹[ä!x9”h3N‰ž®QÃóüt“Bž¾K¡ï=Y¥vÃ~-8A|%"ÞÙÃ5…Qä‚zD5¬M¹:©´©RG"þ»é³&€@|ƒÏd¢è˜ë@­×*±EÊîÛ:Ë’åh-…¸t¡‡~˜‹Ô
-â®²ãEí¥óÿ_p!E‘çBŠ¦KŽ¼†›ÂØƒžB…1žùä>J¼€BQÆI|¹`t«ÕÔc“e²ùC§‘URaŒc~ºVIEœ³ÀUÐÂ¢)rèJT…Y¥UÁœ TŸ:iÿ±<çTK4 ÉRís5²ð(`+ UîŠD§4¥q;c‚<Ep\ã†‚	b÷AÁD1Õ¯µþ°¥¸BQ>£³òs,®x÷<íÕ»ê¶T­¬ÔP¸Säo¶kü¶Î_xPj(•F­Tëj‰E;ƒÂ;ŸH/yñ%)!òú bÖFKÈóž‹=Îás±Ç–bÕ†ú¤s34•eZÖÅÑC‰P'JcÄŒŸj"³jªä~"›˜u³Îw´`oŸ·K+fµ+'þ%ndýý>}O{ž‡;!Îò¦'#2Š3™é¥p< ƒÏ$7ÿMöèì×®óé©E’|hKi~.Êjz¾‹àÜÕsð¨Ô/Äo²ÖãŸ€ï_uÊ¦UXQÞ2ëÍ¬í8V¯û¹ë	Š°Ú²òZC•X¬W‰µ£ «ƒ$ŽR‡…füx?ÎÃ±7EùÇ‘	}šÈ[îº˜.€l{]ÓúùÌXŒ¨Â–hçDµ"0ÌÐÄújö
-aê 6ÒÚh^"Pþwç4£õ
-ª
-ÑL8ùÔsg$°Áv5ù»ëB–qŸæ‚­ø²ÊBm2¹ASÏkÀ}u²ÄŽ”Ðz÷¥Cq´Û ¼ßs?d}=ï7D¢¯ÓÁo3&Ñ)Gxq¨•¤¢ë8m&éVSj5sÔ7“s`kJ"ÚÀ^4OdµºŒLnrNTP÷RG4'„—ö‚	m¸|rñ¥©Ì|tJŸSMOBA^?›T²£LŽÛDv/£z]ê/jÚ+®ÊúQ"¥¸yOÒ6V®›©%`%YÎ‘dÔ•:›mœ ÞßÉ!?£¤aU×iZÚm-düåPÑæ ~£Ñ­'ëyí˜ÞEåÜkë™œôä¯Â( ¼D2°6e‡	“t‹@Æ]hÆ—ˆúoJÿ|X«5ÜƒS°¸†Ä¦µ”™*É¢©Ý×^ Öá“½@Ïa%€ï"	|B´rj@/XæIôëB•!\ÂYP}bV1ýKWU‡ûü‹Ò€#îìÍGÜ•‹‰Y}j‹¡
-D›ß—æÊ‘ö:Û¥)½1Ä´®»Ç>ÞH¥ù£SºéBMúZ7&rvxG´»ªÁUÕŠúþŠó7J†Ýt(aÒ› Ç7î´U29Õv[õ+Fž¸Žßc¸ðÝ&ø[7š–K0-¤ƒäñE×žWµ×T¯¼­é°'Kñ)™¾’tßIÏUX7ãžú …mÚ«ÖEkgà6Ä™WÏ‹‡ºb‹òÕk.™š>‰»ƒòÖ£Sº²V§äà¹RaE»ÚëÒ"ù6©9«¼c­±ÚÃ%Ú¬Å$ Î™ˆ§=0w‹jÏ¿ˆ¢7·3£ÓgrVØ'´'kQ•­rT§PmšF³îl#ï[] ÐÖí©èÚÂ0A`/äpä¤{tXP~bF_Ë«A„…b¨QÜ%ïë–@‹‹^¬u•jR<ŸAïµ¡ÏIºWÖ¶nªê@ƒ9{2l¨˜³”ä—œ¡õœ’ß„™c9ŽyîíœÄCR¼vÌcÍ ´ÎLä£ÂÓó•ž¯Œk#0—KÐÝü[ÐÄL¤þ=Ÿ+Ú97”JàW!EŒ_)á‘ûúü—	úðT(ú>”Mù7G@§æ·.ãÅX)JÑê´ô0Zj˜³X$“ïÑyÀjuÀb!®òeÕëEÇÎ\è¦È*E>¤ÍÅë4—Ê’ÿ]Jù.snTsr\‰’_•_¾]ÜàtÔÔØâ¨YóÍnàÀY>¢L:X©©¥¨2ðÁjŽžG …`ÆJ¦øœ¢~(EásŠú–ÔYƒ¤¨‹p„× ¤`Ê õïWš¤.fÞ‡mA¨ì9Iý<(>'©o£´6þ#çRÔ ­ý¿IS7ÈQÕºp™’’){¥4õ¨–ÕQ}$Q·²û,ÎèpÝ3:vf™w6‡r9Ëibü¸™±âÍ){®vÐM’²x?))S>ý¨’¯”ÈOÇÁ=®´]ÀûÑÓþI‡ÌÒ$UŸt$sU?“S²W\öÀà+O5€Ùu˜ólëœ.~8ü†#)êÌ!9êä–éãkQfH5‘Žwq„[ð[ð–	sµ3r>uxçØ‚ÕsIze!;»‚¶È×S¾Ài`<´Sc·Ùš¿üI›Õ­à8VqÔ¾à½“Ls€÷¼ˆ»"—‹;|öÏÆƒfF)!\¾H?Ï>YÎübu
-‚ºÞ«SŠ|¿ñÛå:<q?_§GòU¾EŠÓÂ£R}¹’Wï[ž8`!à :â
-@yÿ¹%ïØýê†âv@ Éèÿö>t¦‘ÆdÖúQãÎoÛVD!çÇÃ©{µÂv±þc¡è¶-$’0ŽÄ‰s|ÓvµXìˆxúN;ÔÍâT[ÊTÇAnÛ0€p>à‰«45GaÊkÅ7M–0U&ÐBnrg˜:2œ@–QtAµ©Ûs®¡Më\O*ž/T]UcQØ\Ÿ¬ƒéù‘qU±9V­Cs’ä>F2m®–ÔÍ¿\SðkƒîøÁxIÓY;ž·ýž¢ãäZR×F%OWÜ˜µX+Lldýx¤U²=S¯­WÞæ@É"¶Ød!B§’¿±ÈäÃ–”ú-6žU$1g)¿^.V”ë"ÎxD»2O#ÅtLb»ÑÊ…Þ¹£)Ï•ïòRO¯h¡Äº"øy–$m‹Ó’pÊÙ4ÇR¦Üšó‹3} |žMŸŠáä`ã’ú£™w^k=x;ƒ{f­ñ'È!Ù–˜˜¹ŽTeÀÈÉM²€
-j[í˜6<"T8[Ï%]ðÇªŸÈÝ£\òÈÓÇˆ4ç%'Ë¢Šç`Ž{ªéßP†ý”µ3é‘®¾[TÕFz…Z‡Ãûr(AÐÆÆÜºk‰¶8žâq»ü~$Õ˜pvèÚ‘|Š[f¯éCGÕŸæX%½Vû~èÃg\Ï7ÎêÜY&ZÒ58+l£µRZB˜É½ª³Ó{¦QªóOÞàë>…hÐ¢#Ð}&šÁËåqþÆÊñÜ›eÀ¡ñ7%ØceìxE¹Ö½{ŠÞÅ¤ÎÉØÝFím=ËZ¡nG¢œ¸±Yx jár~äh¥5¦
-œc×Ïá!åE²ØjßÔpz¶n*úŸÚ#Nf°)cÿ£ÅG†u„SÌñãE]³†µq“ x9*_u^o´f•Ñžé	_ÈÓÅe¨â°F{½€0ïW{þiÇ¼u|YÉÓÿ6‰ïÇíž¬måmçˆêÎ•}mä"ŽéF¢Y¢Ä÷òÇ´¶ŽíâdêDB¥&›Îl@yì¬´8B‡NÉHŽ°¡´üŠ…œŸÎ•ß5ÜQ.°èÑ¨äw±HÄÇq"—­|
-ßâ©_+Ü6÷9Ìñ»œ‰BÞUÔwµ«Ü’¸;ºÕ&ïQnºëÕ¾°öªk†ÎÓJ¤Ð6ÖÈ9mÈ °YDŽ[‡Uq¢ Ù¯—#¼¾°¢éÇ¨ˆÏ2”+aÂÍ™]¹þ…Ï5Dæ‹tÔ€z¶*‚Éq
-=Z–D/Çô¤´„ä|?:Â* CBº`\§P“W
-]ÓHõ­õ}tmÈL¤§›ßRÒõ“u•Ék‰L’y@OfmÀŠ(Ž@Zé/Î­7©­A/˜5ôÜÀÂ y¬-™¸ß‘¨Ç2œ[uàÂý¯×õÀ^·Í3ì3[„§ûºCâYWÂ“¡
-!ãFOÓµÈhCWO0QÁÓ}mŸ»­ŽÊÖƒ&«¼V¨W0ñï
-Ž–&Ù`LU„YW0501†.áÆÒÑv¼;Z‚¢¨02N	ŽTòù­x?J¸Ç"}ƒ«5âúÝÇŽ·ÝÇr;”O-¸dòzîºµ¼¨}ë¦0(ÃûiRéÆx~èü³ò)Ï1füÔî`ÑÀ©0l’êþ…Z3 RÏæLÅ#``C²PVÏ•XâÎ1%”s÷GÛ2žŒpxÉD“Sx¹“Y|ÎÓxˆOôËÍô÷õ¨õ)Ã«IQˆÌ>K±òÜ±º þa¼™^m´d<VÍb™šPð<QbýÆ¬Ž”¿Su—,™^NŒÞ*à¯R•{á"J¢™g®Íþ\q÷HU 7Í&;2P• Tº^\*‚Üÿsˆ0¡˜Ü«¼Ý2#ÃvbÒD‡Ìõ¯Ìh¨‹ºÅž’œí‘ðƒå‰¹}·óûìÍ‰¯²vÁ×¼Üjtt<nÌãÆõFZ8¯:LôGXÓv»e÷a~½ã&€Í³*8v2Æ“1	cÛ:í'3[’Á{&ôè’Þ	iŠ>ñ`¼Éb=/`÷™G™nÍ$*¯L±n"f¤Ž$@Ü…4°
-,DÝ^Î}«i¯QRV’ìÀRñÉÚ6ü?ñ®¸Þ
+xœí][7r~×¯hyÇ²ÚÖP¼³;Ñ:±eØ XoÙ<x;H#ífvÑþû»›l²XÅ¾3’Vcšsk6»ÈºU|ùÝÝýÿÞüz}ß|ÿóë'ÿ×ˆ†7¼¹ôç]sýöå5o®ÿÒp&¸è-wm8ã}ÇU/åðRá¬iþrýn¸ømc…lxs;üF¹ÃÝ>ùŸ'7OþóÉ?¿~ùËŸ}÷êÕËŸ_ÿî‡†ûí÷?øû+;Œ¡l£s¶égRûi¼çÍB.áÒ8õ®¯4LÛôznºNú;°nœÿðjžþ“ïß4¼ys÷òf˜Á››”¼yóö¿žÿžsþ{ÎÅôW¶&|¤¦¿zúkZ%Ãw6ü|úëÂoÛÿ~óoO~|ƒ<–,ËpÎ”•¦éf½2é£uÆ¯ˆn8ÓvøÏù•‘ÊÈ^™?›h3«Žz2ðTãÓ\ÿÞÿ¾¿ã•7É7ã¿wíe7ÝMØVˆðÚµR?O~Ç%§)¤
+	&;ÓôÚ0¿¤ç!ÐMN9’ë®•jz)Áò_.>òôWµ—Â>Ç‡áýt9­‰´à¯¡é§Kú	Ã¤ð;LYfú³í0ö¿Êö	W<Ý=J´‚¯Ü%§£Š)¨2	"Þ1«SŠØAšã_ŽdðÔ±£t9E¼ÜÅr3	f¶K>KY/¼ÃXðžð×f×›ä·7É7w­˜¯)EzÏ¸~¹à¼§EºÊ—Œ»dl“ñ>GÝé.›Å`™m‹ð­nç‡)nîÉ>š¶ÏØ<*{’„ÞïVQ7®ú´ý“'Ý«“0Õ»¥;ÅqÒUé,ã3Ì¿ÈG¿¿Gž Žþ†µÄWŸ˜w~‡ÈªJ`OwK2Zë¦[(Y<fÔMJÕ†Ç–„––]o˜ëÏ$rþUÛQ¨É|-èÕŽ‚¸”)\él%L+¢9CòlÎ1Ê®Û/ÓoÐks	wÓðy¶g>l$ZÔ2é¸keÐ+ãõO—¸+H¾@»”î	]$>(ÍfY”íÜ§ùÔãþ—óïswUl‚'¦©\!â*ò‡°	=ÂÍ¾HfþRËwÒ¶‹b.jc]%œ£g¾‹³UÉò¤¢*W(5¦åj(Òör|º/â¡›yg¥„ÛŽ0Ž0dý¹LÈ¹–(ht#ß—Ü³«w‹Ã…ôwíåtûß,ªÂyuÑ‰&œV\o°ù4oÄø0ª|ü‹Rð\´rr à†víeÏú¾ïm?>Ê€÷ù²pÍy?[eÈÓç‡¹H/\¼IlDZfpªÇž•zZ’t¢
+i:31¿J(¿ßø¦BG	ÇïúÞK&P;¡àÊ°Ù¡m/íN=6;ð¡™œ_k1‰O)ÍTŸ™hNæ(Ðß‘ aC.ø;t<^ºe5bï(.(µvÄ†°¨<›ùo¥ vIÓÖ9nÌô¨„ÑzŠ…tÇô™ŒöÂ0§÷k¶aRi5…´å¾Ê?wxÜï®ïÿúëí›?¼¿õÓ?ý$9—ßOÍÙ	¦õ0ïqÜ«öÍ=ýÈßÛü÷mûæûoÞ3Ým¸y§ÃïƒRvò ­Ø»0”ïé«EG2üQÑzîñu«Ã£–ý¦ÕA ª(”^ìe`z£NítÑ³Þ™pÕsºÀU–§_»v"ÐU"¨00’¯^½|ó·?ÿáå¿ÿú·?ýõžx`×+ædöÀãó5¤+†4Fç_ºN+¡\H]Í|xýmÃËŒv2:yÀ›ëFæ/ôY©˜6RXÿ•^ªâ×Ãëñ’[ÿz¾f~5ÿDw/UC"%3½:^r$VPëõ/gR:í£½þå(þ¼$”~wh'š_^ÿGÃ™3Íÿ7ºùy&ÊÛ(óšÝ®XÔ'¿`|óKr¤œÐ¬ãÖjÑhË¤mœLIa‡TÓ{A$©ÊtN§òwŠ©¼©!åqv1™PŠ‰Þo	åŠféå4jøÏo!îù"hxc˜v#I¦ZÌ/Â·~¥UÇ´ß—~¥µ`º·Òx ëýoâEáƒñÒkðþ6¾÷ú¾s¦OFœõ&Þi|w=]8¾»ï3~ÀçqÂlw°NÃùÔLC5Ž36à½@®·Ÿ¹â«Û¥M€3d™÷Êäìã¹äw	Ÿ¬rƒ$ó:ÀaÜ´”´
+¡µÙ"K­€ÉËä*(;9[%BÍîQ¼Úµ1¹'eE­kJpXÇº<	¼Å‚5MDt©à4J<)õ éÑÔpLë¥ßÞ¡WÎ9§gÈêÄ¢Hm¶;Ã	9Ø°™UL$Nw¼T˜2¾™Ï’Ü2øßåwÌÌÿ0÷0Fâ®f!‘»l$à|ªƒY‡1Mk³QÛË¼Ž`~E‡{òðæq5šUHƒ¯EÀ5£nX¿¯ìwCíw­ßçðâ¨ÆÚ¶ÐJJÿçœ+éÙ@¤nA3ç" D@Ö®{
+>” ‹	’åEv3úíûÔy¯Xïg$'ƒ¹Çm®×Úgµ6W¬¦¡²¬³Bz ê™òxƒxMø ¨Šüým|µJlRNÓ}R—cT¹T' ÆvV†‘átM•*´:ªÈË„ªèÝ@K­Y×å.ë´í8sr ¦WmÊ’Ú¢È¿ zX Ö”íeÅ“2±OQ[HîF&,7ÓŽ©¡¦ŽIúq6…‹fÅòõüòIýÆ`+†.fóË—ÙÝ’ˆOåqóñË‹ùå7Aw”!´¥—££´ˆŒ+ÃÕ^h“gd1¢Ý4„±Ð)•‘H ¦tò`är–j[}¸$×PÑ–	›'û‰¯NVŸ2ç~®Ä÷Á”óÉ1; N(x±"4Þæ93üBàFW	Î%ÎFTL¬ä&u±a ¼‰ØÀÁ)¡»œâpÞ1‘«³&ërÆ,¶,Èòä)É¸Š€•ðeŽ*¸Ï”wLèýUª-ËWõìîÓV1šäÛ Jk`…@fÙïUP=À Py%c`€€®0@ÄdwºÀÖ¥¤àâ
+ æz3‘´®¬LËqa“åêßÐ 9®ùÕPø‚0$l×1ÞéÞ>¸!!%!fÐ)} C¢H)Cô»2ÈçtßÂèf;6ËlËëmÖqP´—(| p:0LSèŒˆ¥ (/*A
+BJ1ÄÕªYÇÍŸ¬¼Jàc•–U¶ä°db÷VdŒ¢Ú&÷‡x—j0ófFË —ÜmíBüMäÛš£”ÕP÷z;ì*ø1J?A«#˜Lr%×Ï:Šr
+(sp•Àƒ…uMI%*¬1Lì¯VÛ¯'ÅVå„>ˆ–<]AHMcîpë²†å•ó’hVT1ïLk-a*Ù)làw@T %(ör½AÏ+µIäš‚•ùW5 Æb9K¶œkØ²ç$âs%¼oÔÄOçŸC€õF³Â]2_;©×Š±Ûjé‹;Ï'+t†ÔÜÃ€xeÎò8q‹¾k/^k±:.RÚÔ“¼Ý]ÆñâÁÛµn"#ÀÆZ²ø	ŽHÒ`€õà©FC1'S‘§EÙº’„øEŒQ¬•aÂ2C6 °ýð·æì î\Õe¨™Ž2¤„A³‡1:Jþ”z4R³!-®ÈKnÔBÈmv,´I¿7Ê·¼Š&”ï@„1 ¹<\;{¼¼«‡iŽ/¡¨H0m™Ó"U^ jR€ÐÈüz/§"p¨<œå=Sêlá³¢ê•Ü†NŠ²1™Š±4˜Ã:\<­ha^.âÀÊ{#%c'bTH›\¯‚1SÕ {bž\:S$¡Õb áü¾Ú2«‹ùnHX¬ºôÖ',Óõ0ö –€„¤@&ôa,|§C,ã*cxe'LÌªºÈ»g\PŽ9Uáh¾+k¡3N æaT;ÒÕâ4ë¶GV€ô:àæ4Æ‚ÃD~ãôåŒËâŒÈžæ ÕY¼¦÷Z>(*·fœeêl)üZ`’#¡ViÜvm+‰õ¶ŠH¸v“f9©íº†`[R‰4ª§I¼‘^ì„,þ9Ûp€¼Úâô%FN"²æøÆbYg­}P¨ÊÃšÞ(<4Ææ‰1üÿæy,.,ôÍœúõ?òc7º÷U…F)¯V†šB‰×**ãf|ûCÞçžì	ë
+-ÞÞ Rž~·¯4ÁÖu]cŒÊ÷”•†Ú2®Bé\Ï¸±ÞÞfxZ9>è÷üým|?WÎ…ÁF}¸ÏCÖ& <RgøÉë`q‚*³ÇÂô#1µcZ¥Êð7E9ØýTuAôB9q¹¡²”Lúðž«Ü0/¬+ÑHÁ,rx`¥ˆð/ÅKÊ³2Î"…¬è).yWŽ®€sŠŸ§×G—7ÏßÜ,€ûU <7Š“D¥l3>wþÛtä"°"¼ ³\LH¬>(&Dq89µW**e¸e:ë´ôXxxÂÂÃ¡çp.X÷ð±ðp…nï¨ÂCÃ“ýÇ^x¸rHå˜ìüº ,æ9Ìt=0¥GÛeG«‘ôžýhjÅ,l=aAë	ZOXØzb,vžîó€<FÐpà2=µòû¡›9nøLÖ[u|ä:Êfe¦Uj1‘³d´nhÌ$Ãyxé?ÄÜÖ©c§VMZŒHBHÅpISiª´áRŽ'üÊñžuÿð…Àeãç4¹TVwh5ð–râÊrPõ;ºSLë‡O*j*Ã€Lè#ƒíïËÙÇ5|øOÀ¾§¬Àž”Ëç1Îó‚æ˜ø"í;»ºßå‘ö¹S³ÀÔ<Çö ÿE7¥R5÷«+`‘Ñ!ÉŠÑ_à ³¹kö`TiXeU*B*¸ÑŽ3Óë3õÕ5a«ª÷ÿ<›>¡Ö?çDÞŠ…9€ÊÊcgfÂQÝd1¯ nÉÊu$©IåßüA¥Xgs»ñBó¥WàÉeÈ¦x¥„Ù–óËÇDSéHñÙQŽ¦R
+Úp¦û .©"dBD]~\ÝÏˆó_Â›“[n.(ß[¡„irÈu“ª%»$œ¬×Æ1"o¶tIF3äë›±€Š¢\4ºu7*"ˆªÿñn”Õ†Ëóð|µuHv¦Ä¨¿¿ŒJüD•3³f	dÔ!­.Ëßj.o«Ê§l\ÚXdœ24WËU­.·4Š%ODº<E%u*³ùóƒ3,*C%.´pÌhÝw¯µ©tJ§ì…“R…lÓµ5ìÚø¦ÜõÔatQÎ
+w ROW­DNæ§aq`…X~fÌ~ˆ-‚* §ˆe ¦´‚ªëÈ›½õ¬»ÎÃX  ’ºÚ-¸‡ Ïo2f3‚ìýÅ²M•Íh®™=“!þ"ìÜu^ZÃQÖ‹eñi¨²Õé2ð âÓP…è”^|Þ/VÁ-U½U1þÉ-Ÿ- u7*µ1ƒ|Ñê1váÏbÄx@±GŒzdæÄl‰Çô¦ü›Æ;ñzdÐ[gÙÀñ¢†sõ&9kDp¡wfŠCO+ÿ®O6ß±@d#A°Ûs'-‹ŠŒ¢’Ê	æÎ•4È5Rh¾;AoAÂO×‹–=‚¶ûB/ðÃE‹]‹‡öRZ¨Xgy¤¦^2-£AìLóŽ!í³Y¥ECœ‘¼®"æ&£½NàÜ³…†d‰k “¤+Úm‚¾+ãÏÍÈO!J0d%hù³,ÈiõX&PÈÿ9aåXÇ;ooÕ²ÑŽuÆXÓ(ÙUð^á†Šî+-wç©ÈxwÏ‚:‚hµp!5ç¾oèëe<¾älµ~}Ì´û8ë\ç<´G*¦Tråð6€lÒwÃžUjÆâÄAF”Î4üC‚ª©øÈ	tòdªg<µd®¯ÓM9ÖÞ<«˜•Ø_IÃ,?¦«ÃýCØjÓ‰9)œžÏOÀ¹/©…“}h ÿ,–røóð‡ öÁª‰g>ê-P}táþ¹õÝæç]&–Kö^TÔ*.­¸`ây"çT˜ú¯b^ùQ@ýR^É mëÂGrÂÚì0jÜ*I²1«@‡ü êÓÝo‘”Ù*ð0{¡öRf\£/Ùúl„„pûJ±ÌIajrÉ¬-?aÀ½ñÇy× e´GÈý1*>‚î×0º7ÝDPŒÝþ1`÷¶»WÜ0aú#i“Oz¿4ŸWo^€ïWV…BßK×±ŽŸ'n¶¡”•<ÈR~+ýfÎå¡Ëù·¯ZEuV†Yˆ…tÃAÏD¢“œ°Ì`öë\à]ÖA£Í eO„Æ±ç÷Ý
+
+¹Â‹ZØ{ie¸,Oþ 5T×ê£Š&rÚ:Büò¨v¾”X'fØ´‘¾qdù
+oS'šKkXoÎ†ÓC6€žÖ +{’åAƒ^‚v'­uH¢k\PGT;*ßý›ºEÍÆê5tºìÔgÙUÄIm§ŒÄ¼N6ª¨ç‰T
+‚L¥ÆÜpƒÆ¯ÛŽ È²ÒŽž¸ÑH&9àFž`W—S&jˆ¾ˆfF)!Üü"~=½}v4­…õÀ˜®SÞxóï¥\O¯ý·ÃëxÉüjþ‰ãXx<’g÷›®Øárà¤Ú“‡
+Dyû±e^±ÛÅE;ç dH>uoU%•žþ{çžl™{B—kÃt–Oü&ÏXÛŠ šùP$è º/‡ºœ¸ý2TÑœX’ ó›%ÅZP/Ac_,ŸîT$–I´(òÉñ ñJØAeŠýžìîˆC6œH‹™­P‡á-*Î\8ÁY]ßíì5u\ŠÁ'VŽŠÚ©1ê:ÑœeI!£$“æ|G©Á}¶äÎ §î ­3³.ÁuðwÞˆCAGëV‹‹W[,D{àƒåêuË•ŸÇR¸%”Ú‹yÀ–NŸ)²É‹¿*[mÍ™…„©»ÍU¯]á;:’OEÏ4?ß!OûÚS¥:ˆ«Ç)†q‚¿îO‰ÚFæ¢k0÷Õ‚ìeI´Pî¶$ºH7™å¾ÿÜý¸ç¬Ò*ýÜg÷³s[ }Ý–LÔÌÉÇ	3§=`HkÝtÖ“OtÓÖt£÷bï¥§–è{z:K{À ó(lö^<N +¼WfL„êï°G:¥b7÷¢9kXéÙ¯¯´ØŸÝ‹Ìy:ó%®@ø$Ïº‡ŸóTŠ¹,/ÆøõŠ:æ5Ä’Ýö¤ VšÐ¹·˜r‰´e ¶j¹4ºßÐlœ¤KN¨âç
+g
+RØt–éó…ÖqÛ…ÑQÇ,6W‡OÓª§"j•`­¬y§ø2C»-ûà´ÂU%kT§;ü¶•jÓæÓÀò‘rÛq®‰yY±„|]þdáÀ›õö§ƒ&Ñ*Ö/&î±Z?ú)+¼,I^vêÆv/Ã:ÇJë‘ô››u‡”­©:–5\EÒ5êˆ«!,‚ÛBJu0×gêt@J=:×#ÇzLÞ†–3ÝÞ[ÜÛpd®DÅÌy¼—e¦dä\ÞªÐ¤!j}½ÖÉ@RÚcÞ°'y DG½N¦Ø«­+UÎßR¾Å7­žï’Jï™ƒ}<'-žZ»+Ç;l.Ø'‰4å^‚ª†„Ð§oŽc-üŒGþø×™Q
+³/¥ú¦f•{OÓ¯®0 ™ÚsÜù"­&\N;Î{¯µ½±DÞwßñ*ŒŠÊgš8·âÓ®ŠKCÔÝiœ
+˜ÓDÏòÝ”Ð­ÃO$J|ÝÍJ[ñ<ï8R¡¡cHÍ»KºÍ£µ*Â§Y¸Ò–á]¸4W_ð¡~Å|¶quHªG7S,s
+Où‹|O¤	ä˜î•î!ÄLÀ÷Ž°u;RA‰žqnøyÌ]X¹W„ÐAøg>£
+-Mö×øãûVÊZ_^æ°ÆŽFò½dE¥1¥¿¡›<L¥s{—»XíôÞ+UD>W,A4¯/Œ<°È¸_«c¶uñM'Àó,™>T_ï]¾ÆxQéØÜ,EyK·ã¤ á–‰sZºaŽáon»^¥G€lRÎ3(,yûi©ŒÂ›·CøÞokûí{ÿO’*÷kq,_å´çu]h—Na¦*k (ânKk¢ÍÆ“ë‰å¶Nåk—F!‘8N³ªÓ Êä]¹¸½;u‰«00™öêS\÷ý¹0A´üZÿÀÀsËáÂy5Ú-ëŒ÷ÛáþtëpsGü‹Ž—K•´½J<hI¦î Ô£w‘É	è’¹NI®ÄG·ÓB©zï;Üµè%Pœ*kbNx¨g¢±8ï KŽŸ¶­Ö#¾'¬6/}.jZ½:•ÕBµ—ýó•>E‡dœeªGÉóhéEPÀÍšž¯Jùôœ§+ÃÃ»¢†rì¹®1ß!˜½™”‰–ík+gmP8n³§³}~>ÎCg+Põ‰/IXÎ
+³J–XÎ”9_ÉN½‹máß¯À}m*º@xòf[PûE+G™$Â²½ž¦?„cÊÏWC+æË˜“«ùåÍÞ1á¶.nï½­ñv!ZÖ»8!!h‹¸8ºÅõÝ‘h¾$ó[Úùüòùâb‹2–Ö@5­z ê×åGF´—Ój]ìªê9(6Ž‡<›ŸªSÃí`™(ì¼$^úáYM¡[±ª—"¿¶2Ë&’Ä*óýRJKø)ÀkŽkû;¡_ >
 endstream
 endobj
-345 0 obj
-<</Length 4692/Filter/FlateDecode>>
+386 0 obj
+<</Length 5118/Filter/FlateDecode>>
 stream
-xœí][sÝ¶~×¯ /‰ÍÔ‚p8uÒÄ—Þ¦îLÇz«ûkªi;²’ž¨Óäßw  vq!ÏM–kùÁâ9‡ °»ø¾]ðì»ÍÍ?/¿¿¸é^¼yyòïŽu´£Ý©ûÃ(µÝÅ‡³Ú]üÔQÂ(45Vw”ÐÁR1pî/%cF«î§‹k_øC§ïhwåÿúZ®BuW'ÿ8¹<ùËÉë7/ÏÂ“Ÿ??;ÿåÇ¿Ÿýéû_~øÏÍ7ß¼x"1º´&Ã šÃýƒo‚ošuß
-ÿON­a’h®ºí4QÒX¡dro ÝEÇÆ]^u\©8Óî‘±Ä…¿‹\¹ë¹Ì|5ß"üÆ¢ÂË&­3-‹\DV/ßv”pn¤¢ƒQúKf´4¬{ûòÏ%Fuÿíd÷f–É‡»'“yÈ®VŒéÉÛI~oüþúùó³7/ÿðª£Al|”›!Ó”)ÝIM¸îi	ÜÉïgÚ½ú¡PË$o…—¼2ÄÊt–TYË…[3v\3þj^2'/Î;ÚoÎ.iÇxw~™.AÚøëÓw”Òw”Kÿ÷rú¤¦¿ºÿÛùO^ŸZÉk­”‚¨´‘Ú·Q)w)”[Wnzèq¦ØJÖFRŽš'Æ¿ÌLŸÙôwü|ãÿïÿßL¿ÐäJ5(7u^È´D¼g|Öuú[x®˜îa¶‹šžñÐöñž÷=£O“6lò;cïL©7±|ZfêàõáµáâŒp·ºvšUN×¬‡ÃÆtÏåS8TÂ‹êaèùÜ»pe°*ÐXÓd\¦êÞ½ïãsø
-ŠQ®ÑÔ¢¨z%»­•ª”3N¬énáZñ*“:É3/nis(È`F£Ãˆ1ƒÖ–%Wáw§ý„""(XaˆÜ
-áîˆ`\%¥Â7cÙôù*~Ö„*Oª3dPñIþÃÅTÌ¸Jžâ¿ s%¡­;Ø¢‚ ½-Ònº2'@É”¶š{³í.ŒÔØI}øt$¯®–Ç¿hŸdA”z%'êiÚQb¸¦ÓÛÂp%*°0DUAÔ\;a)SÖŸNëþA¢²)§»­-¥	³\V—[\Êpy1ï±¾ýòˆ6Þ¸r¾‘ÕÆú¡’‚hiÒI¾	ƒ?_ÅÏq¼çêÆI3=éö–WI†~I'+&œc,ì¼Øüw¼µÂ>aí½ÂT.MMƒ4ñ³~sÁœÌ¤¿tßan±ÄÞQÁzÆÉ0ƒT4¢î;J)4|'j†Tõ:xÐŠFO¨º¡óí‚ˆ—ÝÀ¡jg§Pt–ðz×%ð`©˜´‹P=›¼€É9wRß­Gé‡Çé}ÁúÂý÷%¼
-¿9Ÿf·jL]’¦â©Ùa Ì·é¢NnRû~·ÊGqr(CYvÔâ€÷çÿ*·Æf­T±5ÛhËm¼I¼æàv1ÇõŸL2,q8òÈ)œqlBýÁçÞfpEœD”f*L5ØªX7l3eföJy¥ ÈóùÙarÇEëÿþºç“»·îïìb¿æï˜éOÃJw.y¸Nû
-ï	ßU´|ìXè7‰§/¶‘âÞ#++åÇú7Q¤±]œÅmËu2"hfÄR´?eQÿª^D½»éDÀÙ,îP—àñrË¦ÕNPæ"*w¡ûÓyœuºóe¤½Ä#R×aCMkXM¬:ŠÚÀN¥Ö)”^Þ¹&OÈžYÔñÊ”\Zö"Ÿ:°U…!ƒçoù*ŒÜV…•/.OÙT³üt`õág´fÃ´vÎám1Æjó1kÏáÌØìF%Ÿæ×%š—…eUdk†¹u	3p¦]®Õusê.¤•_gyèW£ÏÙÖxýL[É”„6—S®#ÃÊ
-vy¼ïWëEò¼"/ˆé¤üñÓcÑ¤ˆ¥p'TAK‡áž‰*>ySzNÙœ°y'þ Ø÷lzBËj_—‡+¾i1…‚òåâ_¾l¯-x%Èp¬õ^æ	P®
-w<ÂÊÓ@£ùÎúS>oæâ,À#gQ\v‹®ÉÒâ‡JÍN®só–<ª±a‘RÙ¬x[VQqkHëÞqZõmkÏ´g:4Wy¸-9‡÷9Ý‰ä2äueY1Ý[ñV¸E“.!êÀUÅR¤šæ×³Ÿ3U
-DuO•fJZ ®”1¢©‘œO\©¥±RO–²
-Y*k®&gý=YÖhØOöí²aT­•Ô8 šŠã0¦‘î‚6õ}¢ÁSŸ eý]Ø™Ü Oeƒ4M°È`7™j¬IBïKvSnQ¦^Ñf¡ÎpTBe¯(X‘ËÅèÄf†ADç%xó€ê{jt Ù|ÏãVåÁä>šþ¢<¥B}=‹Æú¨¾ð—=7p|b1Ä£bÞy¶‰Î˜éÊ¬5VkBæ{Ð1¼½ÏxØCñ¼;™F¦-Ñ¶3ÏWó=§»ŸïyÝ5¬Ëif¸—§UÄ°»Lì‚~ä„ƒ4ŠtP±š&s$&©«à®Íí;à‘BÈ tË4ÿø››ôŠ¾mHt¨iq-ˆÐ·ÆqZÙ›çí9ØæŠ2l'ƒûmxjo|÷Ây£À¼,èúp #pnŠ@ÛJt T2¶Áí›f¯
-mG;ùõB²`8Kî¿y¯£‡ýÁ„Z†'â@kØ8‡¢š\FH3výŽ1']iu‘øB±å„™EÞˆ"­!óFQ¢Øqºö.‚¤-¯ÇG%lŠ­GÛh½Êé]AWÐJ¼sl„ó‘ß};ÆLÔæo©I›ÂßUìÒì<u°Ê"™ªß.8Ãq½q&bÌš—œÙ”bCPxD”_™Æ@^HQÏè£&(žÇ”vKl'gð”8;ñÙˆ
-šçÆÄ˜Îý-Ãñ…YˆáìíHpoK½ƒ"ÕŸªu:­múdMu0CÔqüàÒÐd‚‚¶¥óµ62Ü:¡|	`h«ÄÖ‚ë=HLä¢å…ƒÇûeÍÿ)Îæé^ô‰$¬LŸ0¿/¤½}–ì	Ô={’©™RˆC’\íttB§#Ö‹îg^¦MxÚÕVåæóÌoÐÌ0«EÂjC‰åÇ`Lž •ˆQÎC°ÜršÚOMTKéI¬0qXº•ŽC!].	õ!¹V-Æôì?Y\×7¸“ŒÇa¨-â‚ÛÚÌ‘–(©¨<u©„`k8°9~Ò†%ŠM¬Æ…ìÆq®	9BÄIšP‡ëê»Ž|KÒ‚ÙEØBE§•BËôž
-ÙC‚÷<È„çh7§ÂSD˜O…9J.&v`\vZ¹vªÿäE‹ùj)e s*¡ÖRë57„ò[GD-L1oÏ§—Ruðù„Ç(HÍPØ"-âüÖùí jS…Îž]ÂÀJèŠ©ñs|hžk€$0¯§Ùöƒ-7ÜYW#Ó-¥E\1ËƒÞÀ_Âg„Ð‹DÐ‰U¹63P„Õñß4«¤F¡ñ.Õ÷uÔGm HÔ°cÍ¤3ŒÐK=,”ÅÆâÝZzËq°ð=b0ÖT†_!Í94$ûš×²NÕ(þþÙ"B¤§f$hý:X®1ûj“j„Þ~¢©P•Õ·ç`K¡Û†.Cë ØD?/qb ­‚ã¡þ”ñž±Çà¯×Ê¥š$]H`ÐÛ0$ýiDe×åôÔ
-ÊÖwež]ÏRPG: üq€ÃnÖÊA;ýh/[!Îá×6Â³Ì/Pñ9Ã×@@÷ðu¦î5
-þçlŠúWR‘é€4Q¯EVš§Ã×HÃ¬é ð' ´axkà¤’†>úH§§…m2Ê¢MRÈ9‹/¡#`<YÇ3daÍà|³ ¦Ví•†j¼?Çc‚ïí³ÙjšŠ+|pÊ¡Àj€<×O‰‰N†Øõ”™Ýd!ˆ:%x¾"îAäý„x#¯:'-Ç_™0^ž\k?Yæ§4ŒP­ì×8çŽÌ´-øûÛC"É/b­…"**ˆºý8DYÃ’òöÜæAMíÁ¾>o¯uøDhØ¦…RUN_zXÞe/M½	†Ú)} C¨$>$u”¢ô[<Fúm\i¿[3<ËÈõAQÔ›\šN± ²cÔxC9Õ"å@]FØqi¥]â×[@¥¬åNKC‰²ô#ðvR×\jÒÝÊbZZHµèð&ÞŒµÄê|–úñud¯ÙÜP±+NÚ*E»¢ÐøŒLµ$‡
-=2NÿßÃÒÕpx¨“†¢NOƒ3`!‚u¦dòN¶< ¦q´JŒR2åN%ãŒN<Ž½5jÐ˜¼NáB‘·Hk(*SÓ
-ÊÃ‡áHšwÇ|¹eê©D,åib[Kxø|Á€Ð”’[j
-gsäÃ1ÃU ,U:qq‹3²v4K“==£ž9	˜øª®Drh¤ÖŠCGªe;åµ4º3Ù
-ÏF…Û˜Ñƒw´sž\CmÔŽØ•Ò²q¬ œØ¸U¶G£75,SrIŒý9zª–p^lÒÁdÌŽ>bIÕï¼ŸÁÝ
-W|eß;G†¨lº@(oVúiH±e¹vµ8±mŽ+ešœ.´_EÑ ›%q×lµúÉ›»yƒØCMLo¦¨çQÉbäúB±uj9ì•”Ç}ˆkIQŸÑ“¾îk~ù˜‡Ãûœil,®{&;3/1ÙQL¹#Ÿ-,#”s>RÚ²Li«ž,N„=ŸÍZ*q[&!×T4Xñˆ†5…ý2dÈa}SÂ›¬°e
-FU…6¥\,:U™ˆ°Il¤©Ú«²„q¯nÛc×âç²Â‚mÐ3:¸I&(cöû³"-’Ñý!ðâ)*7'7]xõ¢ÒçÌ¢¤<I†ö$º—¨Äª÷«Á³Q¸šð¹„k,ò×…„G‚ŠÏ
-xŸÉ­Mé«Zt¥PÎõ<
-¥Nú›îûþ«<W¬ô’µC½-ÖS!0ÇßÁT·0 GB°dô"P•»%¦q!	:¡E¾ïÃ
-öâ}XÁª—CÞ%¬—§ÒD8ñúG¨Ò+Ÿ8TqÙ	eˆŽwT_Ê=£Ll´LãÎ6•¥””©†%¿¡rVÆu5~E<i…'àP††èkBHÂåí#,5+oÏG‹ÝÏ!ä.ìÄw»ßýµH~nŠành³%ßZYA2&¨©î@¶žåa­xÂÍä0ïŒC¡¾à¹ár«Ï?ZÆqòW~•¹ØÎˆÚãí.mðf·—E©ÚÛ¢gDëm˜ÄO!«†èÝF_ÏÞbúÌsSÂ»åâ1le(õa¸¿¬ÃVPºö6*AáínÅ`êÚ±—Å&lÖÃÎâhÍð.0°H6ƒâöÈZÛê¿
-¿[Úy;ñûž½‹eœå±á­ì¾ùd»ƒÓ(ø–ZnÙ’·¨©úúæìš+IŒQ0k´E¹µÞnúð¾Çë~ºˆ»…¨…9¡Ã-›4Ñe:ƒ»4sÔÇøòJ¤ŠïÖN‰ðAÎt×=‘­&üVM,µjvâ38s|5ãkyT™ÏÐ5ü“3w
-Ï‘^Ì#L
-RÍ¦GWb2PÞÞä>(ù\‘2B2&ÀhM(ø(­õq%šÎ/‰¼I´.ÈŽ²†£­k‘´œ*BÅhÍ2³‘+ øÎP}"5Ø<öàñ¡¾ÉbÀá¤'×Ý,£öºv*"³‚HqÔ?Ð;º©ÑwtrÜŒ8Àiëvº²†ü7ûý™ü}=QÈÑ-iØlUÇ¬ÌQÒOW„»¦à{²µØá×»c‡[™H¦]þ>|ÃŸ‡õ•<°ïÅêßñg¥`Â|ÖiþPZ÷îD¶˜#4Ì)±‚RcÇtãÜ	!å ;&Ñ£Ö¢VÈËM×¡<Š/Ë¶I:*µ'³£ Žx¯D5„ïñ¾Ì¤õ w¡OóƒNM³ˆ²63ŸGS×À¦†˜0¡‰vÌÙáÝ„gåáÁìlôCK¶Ð0ö¦v cÊ¿;O©;kî¥µŸÖ7á£xÖlú=(þ¸3bl€2ŒrÕŸN<ëåxî¨9:ÙÙës®­)` Æ©båèc¦Í?’ÇÐ[_x-€—z×ä ”Aªâ±Üò¾ÒýtÔë
+xœí][“Ü¶±~×¯ å•mÊZ÷KÊ¹X’“ãœ8U§¬·£<X[Ù:'µZ'Ê¦ŽòïO$.Ý 8ÎÌJ²FÚá	‚t£ñ}ÝÍ§ß¾½ûßëŸ®î†g?<ðt Ã¥ÿÃ(µÃÕ›§Wt¸úç@	£Ìij¬(¡ÎRá8%cF«áŸW·áâ7ƒf| ÃMøZ¹‰ÍÝ<øŸ×þëÁw?<ïüÍ7O_þûï}ú§Ÿþýó¿î~ó›g/@G$#FNkâè76¡¡kÖ+Â?9÷†I¢¹ÞtÐDIc…’Å§t®¦ˆ0þãÍÀ‘Š3íÏå¥"]q>O—ÜøÏùšü)Ÿ"Â¦KEMÙfyuºäê(²zþã@	çF*ê¼€ø4ˆ2|dFKÃ†Ÿÿy Ä¨áÿ9üeòæÃ“I²›cúàÇY~?þý§Ûo¾yúÃóï_4ŠOr3Ä1M™ÒƒÔ„ëÁIK¨à^~ïèðâçF¬’¼AòJ¥U9MUÖrá•ÆNJ>eyðìå@‡—oŸ^Óñáåu©ƒtxùæ¿¿zE)}E¹¯ç#5ÿÕã_^þñÁw/÷›)Œ)â¨s…K W¡k(“×6%å³Z)"Í¤UœHÅ¸dùCü5®!VÍÓ‡k¬ÑÓ¸
+Q\§‹®ÀQ˜tB–Hgr¹F‰S±ùéàj¾h:ºÉíO_ÐÜJìákŠ-¨˜Èb³¬(qð‘†E	½ùÐ%”>Ýìë¦ªñ† Ý$@e	öÜå`Þž›`¡„ÿÔÒ6¢–eVÊüßGåÁPYÊ¾ŠžNKFXÙQÆÔÑBùUÈ+ˆžìª]åƒ[è(åH—Åô—™ù8ôùåÓñ]øÿuøÿíü-~¡TƒëfK!dyE:gº×mù[¼¯˜Ïaö‹š‘ñØ÷éœ×#£_}x[Ÿ™žÎ´ž&]_^3?àýá’½ábÆ+àFìu¡;`_ÏýL£4rŸ‘—³Œ&Óœ.ÿF‘Jø{ò(ú©ÁWwcº“?P.ŒRŽ7HßsôWwÎ3›ÖÎ8±fp\Ce	Õp]A.ãÚÕDb£7"4±šqo,…#‚q•¯‰_DoÒq2w©±ÉÆûÜãºÒ_XUt°‰^|’)m5Ë²ÿ`äÂªòÑHêÀõE5©ƒ ™%yÊQbx¥7ÚÂ„¥Zì³¾<œõéMTdÊÇË¤õB•æŒ³mª¥4a–«†ryÝRÖ!¯mZ=÷õÕ„%Ì·ùÆï#˜ÓaÎHA´?%]¿ˆ#oÒqìÔØ<gæûÜ§vµ$ôKzI1áa³®…ïø’‚},Â:PÁt-KMgYV*fÃ6œ·-|ôßEQîåÁ	=2NœsN;•VPÿ_]ß‰Þ*ªG|,AËõnè;¦ÞUkG´3\Ž{÷Omõ½ŸÎûÏý®àÉÂè‘ÅÕŸ*à_äOÁY…¿=^L¿_lmƒõi;šu’0o<4A½Ø¤ÿ¦Ã'ir(BÙvÐ¢xØøòoíÞ¸ª7N5{³ß€.¸‹Þüþ²)|ò×@Æ¯[žÚ¸ì®pÖãàG§ß ¿³c>¹ãÅÔ1õ4š§ìÎ]££<ùŸ³ªÁ›'›ï’~š·¿yr‰‹§ÿu¹ˆÏQ|ÇÇËI¡/F>kvùhùg ô°“¯‘! í‘úÍòoWÊiëhÁ³nÁ´PIdi—7T%1 ±ž¯¹/Y2¡rÉt²ò&LœeiNí<Ìƒ¾º·µÙˆÛÉ_e“ÌÆË¹«pã™7Äù™Ë§*%Þ7<ŒötÝ2"ÕI”Ý©>èw@ZP3Ûf=œñÙÈ,|äÖTëMÂ»zb”Ý¨õuùktfÙºù>å/-½Šh=@ÒÇø7ÂB.Œp€µš¡î}qa¼7ãªþsyÑµÄ§”5j–|­EÀºõt,ÎÔd˜SÊì1¢;g4BÅYºJ°T„²ÌŠ§¸ÆºX¯8•½Oê<ƒ.@U Kš#Ñ}V­°ßŽ³\2†&ÝU6G;]U<>'°®Yâ‰PhÞ7é%ºWµ<™?œö8J4|«[KIî”<0ay–'[Q¶xÝ^içÙ¸´nˆžKKN¥Ä­áý¬+a,;æ%ä;ûP—|ZñfÇ4ž5ÑfìrºšŒàdäñz} ðõò†½;h]Z­Ãu·aeÒV+í'>(¸ÎlñG–< éŠÛÚ*£”ö¯õ„À§ÇòJPpÃÖõVÙ½ˆfËÃ~¶PêIÅJŒ—4„ÙO™“¢:sò•é•ˆ”gŒhj$ç3)o©!Rê°SÇ:¬¼êy…žå'¢å;kÒõFZ^åg‹ÇÇÎ¤üf¡)ù®¦Õ.c6È9±Í÷MÉ3ÓShÊ‰Ð§!å'Çµ\=+ßò-À!òÚÎâ;ú'zSàÛØúuƒ1†àà¼ÇAÞ1b‹çVË^öÛ¿VüÈJz‹5Ã²O§sŸcA$ÆŸµœø¸- @¼a8ç¢@ï£óùyþùQÛðÆöF–Ü4]Á#7p|ÒePUhCXK`=ÔÛK”=I\Â—É±[…Š™¬˜þcEl[ê´%ÚÆ¤ÊçÍò;Ç¬X k&ˆDi‘ŒRñ‰`Œ8ÇUKÅÎˆð9°&ô³&a¸žÒl)Ú/#z€×Ì„4>fØùIÄˆc§ŠxÕáêúøq80`ê/ÿ]Mà˜fè€ÆxúŽV^,È‘÷ü(¥üfå¾ÞÃ†ëþFâL |¹ÛåáAØaR;ï Ô±hª°æn@¶…¦^×„,ÔÑ5ˆ'(¯±!°Žˆ-,ßV£Ö½‡Q;Ññ¹Ë¸ÿp¾L3o™.¬éþòW÷­Î¶\ö™IÆFGö”\rb¨s§Ñó¥	ÛaÝ*Žµ5÷Né•šXIèÄÀ‹vÔŠZjRjkxZ6œÍî9Ò½™Zõç¨ã%],©Ïø!Ó§s6ÖñRaZ²ÀÞ®ˆÝƒX®Ÿã¥®èä¨ÇËHÏâ…/Ý» -\2ƒ7èêéïÅâ>­Â>@@•ZŠ9ZäÝžË’Q×è]ïíh•Ìúçðk'¢ÄJíàI¸3¾›žòSçÿœhÚ=ÞVàIŒiSq¡o2›µ¤ŠÄY¡Òk£c'–üä+¢€ èébß¥½}Ôw|vÍéÝñ-·ï¡TÓ‚˜ôHyŽI¨á~r/ÑF‹+ÏªèçNDre@[¡±iºT³´œ•3;.¾ëF˜Ÿ¡­#Šµã3"w\AëŸdxÔ9<£Zq2«åˆ¯íá[¤!LZBƒèÞñv\wçYG¨•p[uÄ‚	Q5,•àWUÃm-Z]•!µ/:1ãÂŽP5áÂŠEK\8~QZx|“Ž3.› ÞxŸûdªZ<$Bã£‘Õº¨1tÆÄ,KJ,;E°ÆçUØÀÝå\t ˆèTð¼’2‘—²Äx™ É(tÑî×ZÍOõñ%x²¸ûÍäˆ˜µÕbÈ¨Æ Q0”Žê@7d]¢$U%2òœò×`hDÊ?D!ðùiŽÄ 5(Æ–bÀ	®9‘â¥àÑ#´pÄÊ“_à`ˆ·É“2(¦_ÇÑDÁÄëÒãÑf;¾ØDf‡àRøFtTK˜µšZ¥*Öw`bÛJé¡bÐÒ"==‡tl–ß9¤cÅ:Y“sœŠI””hC©üÀC:ÀÓÔ,„4šXÇ¸´„™_‡,š2[B ›í˜Qö`{íË„ð{‡íE¶¯ûóæ	B´7±ŠîÂš’n³[-b9ÜìùÏÐÄ[“‹ÕBñ}Û&³^w)Ì»v6ïuKg²¡€X\Ÿ<…ßÕx\øý»n›ö€Üßç_l)½v&©WúžÖMèT£‰ÛzlÌ/z0¼¦‚8s"en¥¯ô¹N²l•øµÀÊ§T–¨~å¼íB±€7‚q˜³Ù?«p‡ªˆ3d'þðìb•©cIÙ¨ÝžçëyfÑWVøºV÷¾`õÊ¦Ôý9ÞÿjmôKÉ®4’J3Ý°‹Î²RŽ[ÌÄÞ+sXXÔ)‚% •»K,š?Lá™•¡ œµ>^š¶^w3äÛWÄlƒp«èQwVïOêûìzöuÖiïþÃ˜… 0ÏèØDX° ‰âS&t€€Î„NU=ÁælN´U>p|*~-ÚtŽìá³J	Â< p
+2§è–·/eÔÚí6ðJRâ“”¥8ODóM(G(Ÿ’K%#Ò±ÿá0EþG!g@Ú‰‰ÌHÌÔü}bV-±Bî|à:ª’’ØRNT’8Ž°ªã¥à¦½uýB¯˜Ç§vd¯È¶†q¢*Û¬ÁÑà¢\s©R?[™¤ˆªóN1Ç· °eP8»™¦N"r7iÛÐS²OË5¼{E¼Ä©í‹Œ¤_úiAÉmg[ÓŠ¶­CBíÅ9Òˆ3‰²Y~geÅÊTcåL˜ J&‰±ƒ"k˜]F¨ÖFŠÂ­‚É‡Tßý)ïD¥ˆ™öjqHG‰»ÿz¾Òv©º?÷WÑw1â=äÁÅÔ^8_@õÀÝN|ìe½ZštÃ¶¼Ãšž)0`˜±Â†qÀs?;äxÂ‹R³þ¸k<v8Ç„æÀ]k%)î~¶`zz ´4–PKé‰‰Óýráñ}E{VTâŒsöÞ©b=é¶ºô$7ïPš~ÖÁA³1Ç¨]±±‹‚ë=íæ²ilÔÊ¬r,p†ífGv9Â…ÿ	¯n&ãá</ÓÈ÷ƒÖi1Õe)-be6ëb±Ï$ˆÆ£Äaœ«ÍÃ¬=½82w˜YL¡yÚ˜eM`Ëþ¹à§WšZJEØ©ü¤mò‹œk“QÅâ+ÓŸ &@Zåš$®´+P§¨Âk]Ï¶LóF¥ý=j,ïm¯wLcôRËv9„"`¤gå*H«WB WC|}‘†oËhf‰ÍqÅ‹,ð¦¡2Œw9ìë~¯h‰œp‹
+ð³¨5Œ;¾>Vx„ê†’qÂÞƒï¤z®ús4é>9QüÚFoÛ/†LPxîì+¿îºÙ·»«YÃ^µ}¦_¡KõŠ ÄÕÉ¶X<}¨›ø\<M×SÛí÷ x®Î‹¶øcå.2|ì´R™»Êtû…"{Nqïi
+­Ž!ü¼i<¿÷< ÇŠ}ÊQ@Vç(‹jyÐ(ÊÂ'+Åk!#’ói¡x'Ûáª¼
+Ë==ŒÊU/à‚5·#‚ÑÊÑlòæFÎ´_`Z„¥yš[4LÐÍÛªâ=5 O%a‰"²¿÷¯(OŒF/@ShK”;À¥Z"±P¹Ü³Øç§û—RA¿?iÂ%¡ÍËôü—l*óó¸U89]\ÐßÌU´×Åõ¤º×Ð[tÅª—UÃ*Û€FÇ8!ï€<§ãÒòÕÈk´³–r[æ½U/!^HI,;ažb|ôTë­J)l¿²úXošf;È¾p^/˜N)=Àë…8””Dº­b®„¹A(Q«ò™}?D„g~7¯s}0¦„TDL)ŒºQWsüÇå ¤%LªCX›å$FÈÒBŽ
+îóÒ‹™ºÅ×aöACå*ÔÆÝ0½á^`N¿l2øÍS¿_{/^pFŒ}ô’îaPÍ.½—$’r³ÚDªenKýØT¯Gu­)†z‹wýt-›{×A0Â_cŸ{rWÆ“Ày²Û6WG¬ XÑ|<æÍ(ÊF±/$ßÝh~qr›À\…„lçÉv"1û¿˜W÷êë
+j‰“§bñ1ñ™ö£™ÜýÊ¾ é=¥a'Ùé=VnÊepó2[Ú¶ZEè^Z?·–X‰_,p/Ë\/³¿Ù¥£ÍîGMÒº•LÝ©2:nÍ–â¾6®yû½ˆ¾Šo)'°˜ÖÿAÕ¥G2Å¯°-½Õ×‡Þi¯V,·Ú§¯±¦ƒ sÉ}vÐT@pæ¡|!Â¹w#›¡Ûqþ ¨kå /Uy\¸ÈÈ^(9gšPƒž1½•©ÒO´7ÜéO™TÀâ:ó
+•6YÄ+hb©UNØ™X`Îø²GfÊãTmbA÷PHN5q\:w"bÁŒ— /j¶º18¸]á9n=
+­4;
+RZzØ+Jò®xYqÚ) 5 XÚGµIÄuù}í}Siz!¢ÌùŒ4,Çeª°ÌÙÄ ;ØœÁGœ×åˆ•ÃHxÄKG¾ ¨3˜Þ²  ^þ13Œ0±}-YÄÏ!.Mó„½í—ÔƒÈ7ªô—`s«3“ëUü"t~ˆŸ·4Ok¬I_tÍúwÜúø¢ƒ°÷ñ-P,¡×yÏ6y{-’LQb-šë4 ìJû÷úÉI®áýëÓkÔ>ézX^g§¢ÒçÔúVJ*CïTé³qçDD)¾Óm¿Âô‚ô˜
+q"¿â‹öŠ‹ËÈNZÿevø¥Îãƒø=7NÃ˜IôÂ…Ç>á|¡¥¼<ÓÃB˜º”Ûmð’»ð¤+SÖñâ#Jp´^
+#XZôuï1©"Nþò} ùAü"MÆ<?Ð]ê$ª|…1QÑ*ôh¼LOé##æ¹”Í³Vm‰xË…QmÀÆÛeª®Bs‡¼ÑÆ.yqÃQ¼^¦Ü|à¥} F	B¦ÇâaåÇ]žÄ3 âÿŽ¨"
 endstream
 endobj
-346 0 obj
+387 0 obj
 <</Length 314/N 3/Range[0 1 0 1 0 1]/Filter/FlateDecode>>
 stream
 xœ}¿KqÆ?×U–X94%MQKS†Nø#Ô¦óüQ vÝ÷BšË¡©hˆFk	¢ÙÆú‚ !
@@ -1337,7 +1433,7 @@ xœ}¿KqÆ?×U–X94%MQKS†Nø#Ô¦óüQ vÝ÷BšË¡©hˆFk	¢ÙÆú‚ !
  ô’0l+Ï½ß£Èy7½®Ó;¯×«É¥º;QŽ?V.ø_îtFÀà3LËEÆK¶)y	ðëz”80eÅIPö¤Ÿkñ‰äT‹/%[Ñp ” å:8ÕÁ…ü¶¼+%¿÷dŠ±ÐŒ"ÂÿG¦·™	`d_¿{Ù¹ÙÖ–gzžçm\‡Ð8rœÏSÇiœúµ­öþfæë ´½Ô1\íÃÈCÛóU`¨ÕS·ô¦¥]Ù¨ŸÃ@†oÁ½öãâ_±
 endstream
 endobj
-347 0 obj
+388 0 obj
 <</Length 5181/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíÝy|Uåð_nBaÈ"U¨ bPË8ÈX*™ˆ@A Š±*WYÌØÎgšZ”¶–E¬0¤("‚e°PAdQÙ‘$$²ÜÜ;Ÿ˜FÈ~—sÎóžó>ß¿úçó¾OŠçžó."šˆhgBÒä9­z'kWö'rrrr<>ŸÏç)ÿ_'¾ÈÞ•õÎªEçLJJ¸³}8:-$®gâ´WVlùôœ× ï¹¿oY±pÚC=ãÐù)8®N	S~žy Ð¢Ëû3_2¸“=ò[‡„”Œ—}†*>¸ÚÏÿ,¨­Q|rºÑÍWý+XžÒ·1z”TW‰K÷—ú,PòIÆ„xþ÷@!±ÃlÉ÷YêRÖ¼¡±èq“HlBÚŽb„ç`F ENÛ[æƒ*Ë~ePz´ÿÜÆ+>%þyÖíèÙÐKDß´Ã>¥ÏHä?Öh5>³À§ ‚µãZ¢çÆñâ’×ƒžöüáÙ‘Ò=CvÃŒ¿€÷æÙ:­5zž©qÒúŸ-x²’ùjÀX®¡o…ü%ÇJ…«†ð¡a:¤óÙÎÉ´NèysWÂjK^ë¯,+©zöìîûNùlìÔüÎè´±ÈQYÊ?ï7¤ló¨Hô<ÚS÷9Ÿ#œ›Û=—öÓm‰"o÷peÉ­èù´—~ïØþþªÊÖÝžSÛp%îò9ÐÞäôÌÚAì3Ç}ulfSôìª®ùK¹>Ëy±z†U“šãs¸‹nþÔ!jòŸ.¤ry-¢fœöiâÔt®ª¦QòQŸF¾Já_ÀuÂÇÛð_hŽŽãf²J÷û4th(zÞÕpËŸ|šZû}ôÜãÅ¸¯ú´U’®ùAW²?ùêv!EçÇ€{w£ço¯¶†n~=÷Jð¾u“h("ÕAøCS8[¿/ƒ=?FÏºJþöÑJc·MörX¥4=Fôq¿b»wUp4A4ÑòwÅ§ïÒ¢ƒÄ“è™VÕ™dq¼öëÐ³¬²L§oøzŠÕva„8Xãtôüªo¹sü€ý~ø¬—8RXŠÂ'·¨¤ÔíÄ³¾·=¯öñAGqš‘Ñ“j'yÿ*ŽûôŒÚÍo´UèÖOÑÓi?‡s¦èH‹çv†KyîvØ^n«xÓœ°6,n3zíkëbw½»›Û
@@ -1357,8 +1453,8 @@ R¬¼»Yßäs`ùsßr'¾í÷KïèÉÇûkÑWXò)ŸÖNŽ±ÝÆ>c5qk|yÀ•´XôüãuZãÓ“÷mûœè`ª{?òiho?ô¼+Ã5F»
 –f§'µDŸDbÜ-þL³aî ¾ÜUHX÷ñKö•XQ}ñ¾ÅãnÓ|×¦¢"â“Ó³L<h:GFJ_Íj±Ÿ	);òm¾èàjwR<ßéÛFXÇ_Y³/ä7Ey{W/œØ¿#z8¤æ=~4eþòÍÎôCÑsæÀæeó¦<ßŸâjÛcàÈ‰ÏÍÿõÊÌ¬íÙ‡æäää|ûÃ±(''çâÑÃÙÛ³2W¾6ï¹‰ìÑVŸÇ»ÿ:fL‡
 endstream
 endobj
-348 0 obj
-<</Length 127498/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace 297 0 R/BitsPerComponent 8/SMask 347 0 R>>
+389 0 obj
+<</Length 127498/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace 338 0 R/BitsPerComponent 8/SMask 388 0 R>>
 stream
 xœì½{x•å•>ì¯_Ö¡ð°‘ciÃ!%	„P’Ð(T@Z98E,C)u¨¬¶Vœz¨~íÔj«m­íL;Z{šNÏíLë´jm=;¢x€|×»ï;wÖó¼Ï~“½Ãæð>×såÚ{gÞýî½ïµÖ½îµÖ1Ç¤+]‡åê8dV±ÏDºÒ•®t«ã0_Å>éJWºÒu¨¯Ž£lû|§+]éJWÑV±ø[Åþ@Ò•®t¥«OV±Áõð[ÅþÄÒ•®t¥«—«Øðy¤­bžéJWºÒZÅÆÈ£eûsNWºÒ•®höUìÏ?]éJ×ÑµŠyéò¯b/Ò•®t±«Øð–®¤«Øß”t¥+]GÂ*6’¥+ßUìoPºÒ•®Ãl´ÒUøUìïTºÒ•®Cz¢Òu0V±¿eéJWº¡Ul@JWqV±¿wéJWºŠ¶Š?é:TV±¿‰éJWºÒ*6Ø¤ëÐ]Åþn¦+]éê«UltI×á±Šý=MWºÒU°Ul8I×áºŠýÍMWºÒÕûÕq¤¯}¯¿þô“üéä¡û¿òÿÝ~ÛÍ×ßpõW]þÑK×­øp{ëòÖÙgŸ>£eæä9S+ê&Žžüþ'9»ôÄwê.üÿò_“ßbCõûgžZÞ2sòÙ§ÏXÒ2óÃí­—®[qÕå½áê+þé3×Ýs÷m?øµŸþøñ§Ÿüãûöué«Øßât¥+]=XGÖzéÅ~õóŸ>òÐýwÞòé¼bóÆ/;ûô³kN©=°ôÄwŽøæÞõ–ðq›—Ííú¯ñ#Ì<µüÌyuwÁ’¿ôö[>ýðƒ_ûÕÏúòK/vY«Øßët¥+]¡Õq˜¯×öþï/~ñƒû¿r÷õ;ÿáâ´/œU3ùý'æÄöžîð3ØWÌwÁ?¼'¾oPKã”õ+ÏþÔU»çîÛ~òÃÇ^yååŽÃ|û;ž®t¥Ë®ŽÃp½õÖÏ=û‡ßüú_¿õðçn»õ’]Ö²taySuÉÄQýÆ¾÷Ø0D«[Þü`øoBs€=uÜ°e­³®ØüwwßvóO~øØk{÷v†«Øß÷t¥+]Ñê8|Ö¾}{Ÿ~êW¿ùÕ·û÷ÏÿËýW~ñ®u·~îüÝ»ÏþäÎæõÖ®^>aQcY}åàœ	0¨«þ¼{!'ÿ€q×Ð$ùðÚÿ]¼ü¾þŸY5­:çæÝWÿÛwyåå—:ŸUìï~ºÒu”®ŽÃaíßÿö_ŸùïŸþä›_àÆÛ>¿áÖÏ­øâÖrßú¹óoýÜùŸÝ~æÖ-sV/ŸÐùX—±w~/ž˜ÿ¾ÀcpWë&ŽÞðáe·~æÚ>öÝ7Þx£ãpXÅþ5¤+]GËê8´×›oîûí¯xÿ½7]³såÅ7sëÆª­[æ|rgóîÝgßú¹óùáüïº¬eËº:ÿ
 þcß{ìÄQý°èNÂç„]zÞí£­±€î‘ƒ5ð#-ýPã5WïxüÑïî;äµFÅþe¤+]Gòê8T×Ûo¿õÄÿè¡{?{Ó'.X³¢zõò	ÜÿùÁülÝ2gÓŠuþ	û“ÊM;{Rù Iåƒp{ÅÈ.AdÐ;ÃÃZ ¾Æù8´WÌÇ_\Ð]1âø¶æÆkv~ü}ï­·Þê8TW±%éJ×‘¶:Éõòþé<ø/m¿öš³·n™³ucÕ¦5
@@ -1876,7 +1972,7 @@ d¥[ŽM§&zçý×‚ÁÖb:÷•‘6üËõ¿4VŒ-¢÷ò?Ü&**ÂÎÎ<´ð´?ôn"2q_–Œ ÙºúI°ëìl_kd¸
 ?NZlß÷ÍÜ>1|ùÃ@ó»ýÿ{ççã»¡ÿ×÷ýÕÙu}8ËÌök6!ç€ŸùÅób$D¾?ºÐÝð7'o¦Ç»33?§çF²‹á*zéëZQ”ß€Uí¬äsÙd,Îõý]Ã÷nt^ð·6ýråó‡—>ÿÉ÷ñý¯êÚOÔ´{§óä¾Oííiª	|ónàâý_íá=|F[ö]«h«Ÿh«Ýi\èñÅ4ÍÜ=3}çÌLç©ÙûßÌ?ºtÄ‡»ã£÷“~[áã³¹¥„÷=9ÏŽé«XQ”§Ç´~(•Šé+WQ”ßÓr¢T¦¯SEQž¦ÕEñ.¦¯MEQ6	Ób£xÓW¢¢(Æ0-?ŠL_wŠ¢xÓ‚¤l¦¯2EQ<i‰R~L_SŠ¢T¦EKyVL_AŠ¢T¦•LyRL_)Š¢T-¦åMqÇôu¡(ÊÖÂ´æmuLÿýEQlLkáVÁôßYQe#Lkdµaúï©(Šò”˜–ÏÊÃô_LQåyaZ_=‡é?ˆ¢(Š¬­„é_¶¢(J`U8¦Š¢(UˆåLÿ&å)ù4Sþ
 endstream
 endobj
-349 0 obj
+390 0 obj
 <</Length 3297/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 361/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíÝ{^ãÀñßîæ²‰&,AKŠ ª)Š4ãa¦]ãV*£LŒ´:I+%Ñmm]ªIe\‡jU!îÖe™ .M-MJÜbå&—Íîþ:ˆv×î»ç9Ï9ç}ŸË÷û¯yŸËû‰lö=Ï{Žj¤}EL»FhQ‰Íi¬á?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þqViÿ–ÿüýî«/8íð‘#wªß²®ˆô«T?ü€cOŸtÅM.ZŸótø;ã¿îéç>¬ªçI«‡tê”[äöÇ 'üß¹ýœ‘½géµ[ÃÅúWã_qÿ–G'ì&V>îò'×e›ÿÊú·Üwòf’¥¾N|dƒýüøWÒÿ¥ñƒ$‡êN¾c•å
@@ -1884,8 +1980,8 @@ xœíÝ{^ãÀñßîæ²‰&,AKŠ ª)Š4ãa¦]ãV*£LŒ´:I+%Ñmm]ªIe\‡jU!îÖe™ .M-MJÜbå&—Íî
 8ˆ¿?þ:ÎjSzZþù·šû@ü=ò×eÃm¶Ñç¯¥‚¿OþújÍ>¶(ýœlü½ò×yV—‚vmv×aãºÚtœvíê±¿Î›F­wÖ¿ü÷ÿH|ø·Ëþ:Al:£ÄBð÷Í¿m¬Ø4½û…àï›¿®ÚK,ª¾»Û…àï¿¾µ­äv ÿüµ±¿äu ýõŽ*±hïnâï£¿^,6Ýõ@ þ^ú·Ÿ"6ße ü½ô×õ£L7ÑóŽð÷Ó_—í,õzèÃàï©¿¾²™X4ð¥Î£àï«¿>ØK,Úá½Nƒàï­¿^'6°¶ãøûë¯ãÅ¦:Zâï±ë±ij‡!ð÷Ø_Wî)UÝòÿð÷Ù_ßÜJ,ê3ïàïµ¿>Û?Û@üýö×ÙV—‚výhãËñ÷Ü_/›Ùx ßýÛO›¾ÿÙ«ñ÷Ý_×î/6]ñé‹ñ÷Þ_?ØI¬âï¿¿¾¼©XÔïüÃð×¹V—‚¶Y‚þú±iïÕø‡á¯g‹MGÎ4½©þnû·#…†¿Ûþºb)2ü÷×7Káïº¿Îï+Å…¿óþz»Õ¥ ³ðwß_'Kaáïû‰RTø{à¯k¾!…¿þúÎ0)&ü½ð×…¥ð÷Ã_ï¯‘"Âß.E„¿/þú) ü½ño-ù‡¿7þºbwÉ=üýñ×7¶”¼Ãß#}"÷KAøûä¯7JÎáï•¿N’|Ãß/ÿvÓÃß/]³¯äþžùëÒí$Çð÷Í_Ÿ·z`h‰ð÷Î_çäx)ÿüušäþúëY’Wøûèßr˜äþ>úë‡y=]/ýõõA’Køûé¯[=0´Kø{ê¯×Káï«¿ž/9„¿·þmÇIöð÷Ö_?ÞG2‡¿¿þúöPÉþûës™/áï³¿ÞY-ÙÂßk½D²…¿ßþ:N2…¿çþ-‡J–ð÷Ü_——áï»¿¾Z'öáï½¿ÎËp)ÿýu–X‡ þ:AlÃ?ÿ¶±bþ!øëÊ½Ä.üíü[§u›é›uÆ´j³Øûâ!bþvþë¤¸Zl6ßhõÀPüCñ×;¬î(þz±Í\øãß~²Å\øã¯ëG¹ãÿÚì.]`:Î&³»ïÞŽËº³ëßÑt‚3»¾öù üuÙÎÎø_*ù·mÇeÕæ;ö¹!øë+›¥ÿüõ´Å?(½.å\ø‡å¯ãÓÍ…`þ­cRÍ…`þºrÏ4sáš¿¾¹UŠ¹ðÎ_ŸIq)ÿðüu¶ù¥ üô×‹ŒçÂ?Dÿö“LçÂ?D]»¿á\øé¯Ô›Í…˜þúò¦Fsá¨¿Î5º„¨þúk“¹ðÖ_Ï1˜ÿpý[IžÿpýuÅ‰sá°¿¾18i.üCö×ùIÅ?h½=áRþaûkÂ©{ü÷o?±Ç¹ðÜ_×ì×Ó\ø‡î¯ïëa.üƒ÷×…KÏ…øþzé†â¿N/9þ–þuÅ•¿©»DWÕåeïËˆŽË’ïØó¹ÿ—«µ<üðß_ljjjZÜÜÜÜ¼Üô¥¹ÝÿÁÂôÏþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá?þøãgøã?þøÇþøã?þq†?þøãœá/Ÿøÿ8Zˆ›
 endstream
 endobj
-350 0 obj
-<</Length 7285/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 361/ColorSpace 297 0 R/BitsPerComponent 8/SMask 349 0 R>>
+391 0 obj
+<</Length 7285/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 361/ColorSpace 338 0 R/BitsPerComponent 8/SMask 390 0 R>>
 stream
 xœíÁŽÛÆÒFù?ì5äÂ«ló,~…ì²‚‹L<”õ>~	ï‚,&#ŠcÜdãG™¤FŠbÑnqX]Õ]}>„]ìêÃE±—»õ  ênSÙ¥níÏ xB¤-Í« Ðÿƒ'DÚÒ¼
  ð?xB¤-Í« Ðÿƒ'DÚÒ¼
@@ -1977,7 +2073,7 @@ géIéP‘Á^r býŸæ–Áøÿ<øßØÿI~RAEe:·ÂD†zÉJö‚[ãÿóàÿÚÎÿš?zš}–ÖÕSô¢S‹ÚPKö‚[ãÿóà
  ð?x¢’Èÿ&öhµ
 endstream
 endobj
-351 0 obj
+392 0 obj
 <</Length 10261/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíwx”UöÇß™Tz“Þ[f2™ôžL¤ªˆX`AW@Rh¡,}Jz¡ÔUtÕuÁŽ?]×XQ±¢ØP@ARæþžI É÷M™™·ÜóùW}sï;÷´ï9G‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚P+ö}BÂÃ‚»·õÒj5×üZO///OO:þ™ ñòñmÑ¢…¯·§Ö=ÿÃ„3i­6jÄðaC‡>bä¨‡Féútò­uÏšQãÒ[¬æ%é÷Ž©ëÖ¢öíkZþÊ¾Óeö‹Üù|þŒ1Á$øˆ&£¹.qøS\LttttLlœ)!éúa#®7EîèëYù/´5oÅòeK—,Y²dé²å+V,NO™8¤o{ßÊßºÖøôovv™ò3¿x~Yb¯öRÿ]DÃhŸ4$6"48(0000((8$,<2:Ö”xýðQC#wñ:ÌX±äæÍKOOOŸ7oþ‚…‹/]n¶,ž4"¨£V0ícuql{ö„þd”@xRTˆÑà¯×ëtz½Þß`0‡†GÅÄ'^?lhRÌŒŒÅésfÍL«dæ¬Y³çÌMŸ¿pÑ’¥Ë—ÌŸ1î³:¯Ÿ1f?{ä½Œ„~ÞRÿyÆgHt°AçWNïo
@@ -2027,8 +2123,8 @@ A³OÑa&?J¶GùH}¬JAë'¢øš„š}2ä8àõh:zŒH§¯î†<Ðìc}U~Í>ÅOûSÆ§Á´S|­@EßGd—÷µ™ÜVê3UÞáØ
 C€Q?¨_Ïv¾—£ôÈ©3S/9)©©©i3§O¼)ªOåºv×N{·Ÿúr‹yun)–zô¬×êÛ«[§¶-¼¯üÙztMštïŒ”Ô´Ô”ä÷N›4&Þ¿[»K‚V7üç×ÓÊíÌ^~ñì©ã?m-¸;ª?]¾ºðê:8(*&*Ô0 {›kßôë’¦-ÎÌÉX”r{\òó	‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ ‚ âjþÄ^x1
 endstream
 endobj
-352 0 obj
-<</Length 33283/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace 297 0 R/BitsPerComponent 8/SMask 351 0 R>>
+393 0 obj
+<</Length 33283/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace 338 0 R/BitsPerComponent 8/SMask 392 0 R>>
 stream
 xœì½w|[åÙÿï¾Ïï)#ÆS¶t†ì„QJKûÐ–>íÓ¦ì°i©™@ Cv'8&Ç–-K–día-Ë–<%g“EB	$„L ƒ„IöŽ·ô{ÝçÈÎ v”øëýºÿh)±cÕçºÎ}Ï'!                                                                                                          €H"''áù¡ÿýÔC·>ô·[†þõÿ=ôàÿ{ø/·<ô·Ûþ¿AÃºå‰'^=!÷ŠºùoAQè»PTBnnðPT54ø7ûekîŽ¤(¬29$EÑéîE_Ÿ>   À/H:ô¿zë£ÿwËÿôäã‰O?‘øü°Ä=‰ÎóÃŸ~bÐ“öÐ 'þyËc»õ±‡~õôãÿõÄCIþíöI1"”o‘2fdrÞ›iùï¦MÈMÿNúøwR'¼—>adÚ„wÓ'¾—šÿ~Ú”Q)SF§Œ+eÂiÔd¬²2”/Kº¨L•©úXTI	UÅ"åtú|,RMVR"U±P],Ôu’LÅt¡ºD¤—õ²`   1ÁÐþû¡¿'>ýHÊ‹O'½‘“4üåäw_O=üÒy÷õ¤7^MþbÒ«/Üñú‹wä<“øÜS‰Ï<:èÉ‡o}êáÛ†ôøßoúÑ„œÇ†EçJ'ŒHšðVj^núäQécÓÆ	>ž˜9=/sz~æô<Áô<ÁÇÓÆ¥ŽMÿpLúäQ‚Iï§Oz/=ï½Ôñï¥ä¿Gi~â„ä/ßá)J ¤2ÓE•Å˜¦×—áÆrÜTN˜dÌÁM2ôOR\_†éJ1M	¦.U‹*§+‹E:I†Q&ÒQ¤†JðzÃú  D ‰C‡Þöè?_|:iä«)cF¦ŒK+ÊK§&§K
 .jr:5>­(/mÚ„Ô)cRóßMõVrîð¤‘¯&½šsÇKÏ%þû)tGxâŸ·>ùÐ¯ž|ôöGÿqëc¡ÚNBBâ¨×R'ŒLÿp”`zž°üC¡âc‘†BG[|é ò±H9]¨øX(+”MP“ODaÊé“>H›ô^úï§O5¨2I™rJ¨žŽëK	³œ°)IG%Y­&]š«OµšpVvaUU„YŽ›Êq½ÓJDêbQ%%Ò‹è;‚À¦„2  ñCâÓ¥æ<“üþ;iÓ&¤…:i†Fži•fZ¥B‡FèÐdZUÌÍÐÈÑÿª“
@@ -2167,7 +2263,7 @@ I[ô¼+_xK$Ûß. €™ƒÉ©{>õgk½çShß]âÝÆÉõŒ»S*ßíçC†çSöóÿØ|fòsŠÉ— ò ˜sÞÚKLß¾l<ê'
 RÎ3ø­Z˜¤ûA•Rƒ¢A!ÚÎÇ$Ú&‰ÉN!©,NµCÉ                                                                                              8]þ??6"ð
 endstream
 endobj
-353 0 obj
+394 0 obj
 <</Length 2782/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 345/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíÚ•UÇñïy~Ü’há 5›üÒ°B”`4¦˜±QQgúAF…ÌT”L‘NM4šÎ¢eX–†X‹	&K* ”°ˆÄ&¬÷Þç>çÛÜÝ-~]ˆ?Î·{Î~?¯÷Ÿ3çýœÏ³—è½¯ºcé³›wìl¬W·o\}ß—F‘¡°ê{Í‚_¬kiô|î|ù¹§îùì°ÿ1ŸM]v”=²û›†üD4õ±{dÇ™æ3¦é[Ø/–;õõ	ˆiÊóì›ÒÔŸÏˆ.~Šýc¹õzŠ)<Æô{(gµÏ©7Ÿ1}ê [öåÊ(¡ÐD4âEöÔï˜“·€„¾Ñáeþ»„âÀÎ€˜Æìðv>yë{):a¸	Íó7?³½ŸR
@@ -2182,8 +2278,8 @@ AL“ö0¡Ì?é>Qo<Àp-·¼í¸WV¥4çHº¹»ÿwÊAwWSŸ 
 µOçÍlæjý¨yr¯ÊOóå4³m?þHJ§IâÅM5ògaŸ%“$DÞÝ‘‡ðÅ“Tøù›{Q’xÿK¿E)g¿aƒ{ ÊütE^}¥Tl¢[Ú¬?/Qg¥ÌO!ÔwÂ˜hfí*Œ›/¨}Pp‰Ã‘óÞÑ!üV5½s5t(ó­µ§\14‰ë|	ôTÆ¿9Ëß%Coˆ3ƒ­ð$¬~·]ÌPå§£¿[††¬åPâž®(ýûóÅÿLl~äý8ý]3t%ûóÓ„3©ò“ïÂöïš¡‘‡ø‰zç‡ÿïŸƒþ®ºhC€2Ïlôdõ@†=FÿOkôdõ@†,ã@‰?Šíß9CïXFÿ·øJ\ÿCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝÐ_7ô×ýuCÝ·$Œþ%¾ý3tîâ0ú—ù2ôwÎPñ[\itÛ³`«å&ô—p3—Ù9ÿm™FÏUÏÑ¸ ÖÆË ¿{††¶pÎÞ+óí¨/ÀÐ9Ø lÆãpüK0ôá úWù×ƒ°ýK04ðWþ¿–øãž¨žÊÐD®XöZÆÄò—a¨×÷<´Õ£ã‘_Š¡!òû(óg=I=™¡¦]\eo•ù®"–¿ Ccü} l™öA~Q††ý‘3//6ã¯¤žŸÏPŸù¶šûöX[åÍ=9JŒXÎ¹µÖ—g 6”œ÷}¹O£çE3|ÑîÎÿXtnýÍ3ú6zRT1Å¦Û—¬Ù¹ÿp{ƒ½Ùºåw§Œpíû3Qœ¤—$1þÝ       äµ=g¶
 endstream
 endobj
-354 0 obj
-<</Length 2500/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 345/ColorSpace 297 0 R/BitsPerComponent 8/SMask 353 0 R>>
+395 0 obj
+<</Length 2500/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 345/ColorSpace 338 0 R/BitsPerComponent 8/SMask 394 0 R>>
 stream
 xœíÝÑnÛ6 @ÑüÿG»fTPeÙqj«´xÏy†vM3¼¤$Ûùúú_¿].—åŸ|šëHýd`áË,âmÂ{èz7Nçò?Áz?£#Ö»™0Ç!Á.À3¬÷	\.—××»™0[ ,óÄÝ9¼²ÞÅJ¶ v]g…òÏê/&ƒ“À”–mý°–p2{sûÑ©Oü§ç*€…ø<¹äM†[ ËJwÒëx<Ä¿ÀëB¹²ä;¯÷õCþÇYï5–¼Éd(³ä³ngAúŸ%þM»KÞdò Ì’3Ðÿ¦Ñ“Ž;òþÖãú®ÏAbç½²{ý÷2à²A)b ýÏº÷Ñp£¿/ð Iÿ¹}@“þ×,‡@jîùF_£ÿ5ú§ÿ,?#Lÿk|Úsœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿè–þÇé?úŸ¥ÿqúþgéœþ£ÿYú§ÿ\û¿;˜Û²éSsoÉ;déþÇížÿmMúŸ²Œ»õtïü?úûbýOYFœ¸Í¬ IÿSô?n¹¸ž”Ù:ô?n÷æ)Q¦ÿëá¦Iÿùö’)Yéq»'½å·¼$ Ë%@W~f=~³Ïò[¶€ ï.°Æã¯q×†qîMì:ÄÊ_ömÿÉòY»±5^öÌÒÞL§…[À”®ƒ+þeÏ/êÍƒ`[@Ð:œÚf@‰ØíöósÆÃ¸u1N‡ØŒ£…÷ÓÉcæ°97Ö*ÞãÞðYÂ)Ëp¿r!¿ù
 ÷þ">ÇÛ§Ðú‰ §°ûB¾wÍÑœ?ÜŽïú×_¿‹»üqç‡ÓyeÈîýY†?™š#žßÝ~Y>ÖÑ;õî©ƒeŒRzlwû5ýÿ1`½ßûšÚò9Ž¸û·ûeú'XÂî¥ßã¯ùGü¼Åí:µl§wèk¶GÏhî2LoŸ`¼Ñî0mž½bèS/¶Þ2¦ëÁ]þÝb?…–}Na31n_ÒyœÝ²~=·åIÊ3Y¯nñçýóÙ,s» ë3z¶oæ­|ìò¹¯Pàó½ÙµžÀ¬¼›[â~,â.Øý `zž°=”‡r¨ìö‡ûŒžÀ¿£ÿ\é?Ôx€ìC“þ£ÿÐäþnþ@“w¡ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4é?úMúþC“þ£ÿÐ¤ÿè?4-kŸ2ý‡ ëªwøÓÒÿ²eÜõÊF§ˆ‘ôš<@ÿ¡Iÿ=1ô?ÎáÊl5ë'þúeúŸ5zêãy!h“Ã?à ÃËþ[@Êèé|ôÇÁ¹4«ËåâðlØ
@@ -2191,7 +2287,7 @@ xœíÝÑnÛ6 @ÑüÿG»fTPeÙqj«´xÏy†vM3¼¤$Ûùúú_¿].—åŸ|šëHýd`áË,âmÂ{èz7Nçò?Áz?£
 8ñŸÃèyœÒÒ{Áž>ÀéíößŽðáFÏ`*£“Æ7FO            ¾Žð5÷OW
 endstream
 endobj
-355 0 obj
+396 0 obj
 <</Length 3213/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíuÛLEAÁÁj5ƒ˜AÊÀeà2C0AØïØIsš~MâIófß½ìýyogfÕ4                                                                               ðm×õ/tmcEÛ­^þøªkiûíóá4–?9ûÝzÕTN·Þî§w|<ÏÛÞf¬¶û÷ÿÿý`»¾©“¶ÞOù÷óÿ°­~ö·›ý'#ðÆ°©nWì¶ŸÅþmì7õîmÍ¼r¬i
@@ -2218,8 +2314,8 @@ h¨þðÒOÉG`&oR½ßVÈýH| jÞv Nö¯©¨?Ù*Ð)< ¤ïW[þªU`¨dÙðK-Ý$Ðƒ¥`j	?Ñå¯|L>’Lùh.e
 „ö·®8Qôé,8ü½¯)ù·Ö€8ëjPÂo=¿õ üÖ€ð[O Âo=Ö³\üd¡›á*øÄ­_ÚÉ“A|åÝù*p$áë|éó5ö#º?'Ý$/„¿´l>Nd{gÀ¸CöûÎ ¢ï<†-Ñ¯…þÖû ñÀg]ª¢ÛÜÐ!ÄÒ¯‘ns¸"14~½ôÛÏæÀxØ²íWO×o÷Ãñ}àO‡ývÍEm·ê/t>                                                                              @jþO­
 endstream
 endobj
-356 0 obj
-<</Length 6882/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace 297 0 R/BitsPerComponent 8/SMask 355 0 R>>
+397 0 obj
+<</Length 6882/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace 338 0 R/BitsPerComponent 8/SMask 396 0 R>>
 stream
 xœíÝ}ˆeå'ðÒt’ªº¶vp@V22ã0BÂ4Ù²ôlFp2»ÆYL 0Â„	»aYì^GâBæLÈ’­—FEÔ•‰´cÆ¶5c2IµÓÆJÙãŠ!Æ•8í7×…ÀLÒUw¸u»+U·ëåÖ­sÎï9ÏóùðEæ…ØÆºõ=÷<Ïï<gl                                                                                                                      €»{×ÛýÌ\´Fúÿ¯èF¨F÷ÀX÷ñ±î“KÈÒÿrÕ/ù©‰S3SÓ“§—rjèœžéœžíœšš<5»óíéŽ‹IëUúÁ¥<¶”åÿaÈôÿ³—þ>¢ÿËÀH¦;½ÂŸ=[ø§ªÍLçôÔä©™‹\Hæ»ýÊÎ¯6ý¿ó“Ñÿ=aCwïê}?_êüæ2Ó9=Ý9i±ˆ†ÕÛùÇ}É8»†ß©þ{¾é~Ûo¾ön
 ‹þwAÙ–j?²ó×IïBýï†Ü$QûkÆÒÍJáÿæq;@U_øÃKÞí 	˜îœlAó¯Èlç”« Ù6ÿy:Ì\ôvx™œ™Iyó»
@@ -2248,7 +2344,7 @@ u÷®·÷OZRþ@‰¦Lé Hwïzû[Š‰Ç¾€`3°ÜxìüIø›÷¾Ý‡Å%úgÐ3Ý9î,ˆãË?'Ý`¢Ú ¿q÷
 \:ìx€òv¤3@ykAó?ôµ`-¯òØØ³csG¢»ºòXíÒRmfp/0ï$g€Ò®‡MxvÐü ¥]žÓü õ82v4Á¡Ãc/;ýï é¼VÞ~€ÀÁáÆ¿í«}€t;úÜØüá:;ß"@âŒ¿Ö¿üã…/-øü³ÝRÛ÷×vž÷è@ûÝ½ëí¹ÞzÑÜ‘±£™›ë'úŸ                                                                                                                       Úçß €Æe†
 endstream
 endobj
-357 0 obj
+398 0 obj
 <</Length 7884/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 617/Height 612/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíÝitUÚð{«:I'!BŒB Œ
@@ -2278,8 +2374,8 @@ u¥`f®aÏà®ztÞŽ A¶ûœ¶q1hCUêRÁÄœüËã¿CÐ x›Û¡–ß#h´²ßø5†æv‚A[éÏÇ§J£4Ö¹N~7hì
 —«ÂUq‘Ó­¼¬ÔQ|îLAþ±ìŸöíúnë†Õ,˜ùÔÃÃöéÒ19¡iŒ=B–ðu"È%‰qÙÂ¨({l\³f		—_žœ’šÖ¾ãÕ®½î†Þ}úüºwïÞ7ôº¾GîÝ»]Û­[—«¯l×¦ebB|\LŒ=2Â&ËŸ¾Y þ=–_
 endstream
 endobj
-358 0 obj
-<</Length 95630/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 617/Height 612/ColorSpace 297 0 R/BitsPerComponent 8/SMask 357 0 R>>
+399 0 obj
+<</Length 95630/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 617/Height 612/ColorSpace 338 0 R/BitsPerComponent 8/SMask 398 0 R>>
 stream
 xœìÝw%Ç'öy hvWºÐ)B(¤‹P(B§Ý=bfÚ?ï½ý^{ï}ÅÀc`´»Ü]­v¥ÕIºÐñöH$Aï–$Hb€ fzzÚ{ï½+E–ÍªÊ¬ÊzÝƒ •ñŽæÌ 9ïƒï/³ò9£/}éë—Aù÷ÞwæÌýgÎ<`tÿÜ`øŒ=|Ó7þ$R±‘ª;r„nÔöRÿ»Žè¸5tÇ•˜1úMÛ¶è”Ñ+PF8_/i¡â5Tžýžâ5{tøŒáÓgÎ<pæÌý^ô5ú‹ƒüwÿö!ÔO@_úÒ—¾ô¥¯SY°Œ´ƒ†ÏÓ‡¾:*ÚBåº~™çúÍyç«g¿>çúÝYÇ/Î»ÿåœë§ç\?=kÿñƒ¶µÿò¬ýW9î7sÜožw½yÎùúyç›ç]7rÜ8ï~;×ó~Žû½\ÏÍ\Ï­<O_ž·ŸÎ:·éoÿ ×ó^®ç½÷;¹žwsÜÈõÜÈu¿‘çyÄûZ®ç×yžßæz^Ï÷½–çýmQèÍ¢à«ÆÐ«–ØŒá×-‰¬ÉÛ‰6Ê–^0þì\àÝÿ)ÿŸé_…Ž¬¾ô¥/}éë—á¿ÿ7×þí_ü}¡éÍ³¯þeÞ·4¾rÞþÓóŽŸœwþì¼ã9Î×r\¯åºßÈq½‘øû Ï×Ÿï,Ž…ÆL‘IslÊ’˜²&§l©){zÊžqd¦%SŽ’igé´£tÚY6ã,gãª˜E¤’ÿdÎÍÅU1ç®˜sWÎƒT0Yp—/ºË]e‹Î’%{ñ‚5¹hŽÍ›"ÓE¡‰¢Ð$‰ÂÀP¾ïí\×oó<oä8™ïýM÷7…ÞßúoæºÞÏ±¿C7YÝS}éK_úÒ—ê2œ1Üï/Èuýø¬õ›gmß:k{é¼ã§çì?Ïqþê¬íWgí¯w¾ë~?ß×o˜"cæè˜%>jMŽÚRc\ÆmÅã¶ô¸==nÏLØ3“ö’I{É”£tÊQ6í(›v–M9ÁÇig¹(.öFO&³ÜG@§dÎ]%ÄS=/ÎH/“j6à{«ø,º+\å®ÒEGzÁ–Z´ÄL‘é|ÿ<ïÏ»ãþ—ó®_äz~‘çû—<ÿ¯Ï{þ¥Àÿ^žóç9®—è¢ª/}éK_úúD-0ný7ñœÁð©ó·
 œ?9oå¼ý{¹ÎŸç8™ëú}Žûý\÷Í|o_QpØ7ÇÆ¬É1kj˜HÇZLž¦“·e&ì%\2|&%q”LÒM“f”Ž³´NVÒ2Q÷”ÄU.é¡tådêgÕ¼$€Qæcõ<,)>ô«]ðÖ.‚Ô,zª=•KîŠeWÙŠ#³lM®˜bK±_ï"ÿÏkEwó}oå8~h0<ðç…/è-U_úÒ—¾>.‹Û”4<`‰üæ¼óŸ³|óAûwÎÙ¾ÿ õ§çì¿8ïz;Ïs3ß{Û6…G,±kb”Òš‹ù°bÒŸ0Õr‚ù$ÂZI—M&æ#àrZš²&œ›³ÒpP²©a‡´—îjBDV.Ò(ÉXÉ¢Y»ä­]òÕ-yùÔòYöÖ.ûêV|5+žŠWéª-¹lŠÎGòýoåù?Èñ¾vÞó›óž_çºîËè[¨úÒ—¾ôõ‘ZÀJ‡ï÷QZ¾ÖúÝ³Öž·ÿâ¼óõ·ŒáQStÄ§¡L±PZR#†KY,,¦ã €Î	[ñ„•‹-=É&3Å„ÙÐ¤ÝœJÎVÎ2q–ñJÎ	©âª˜wUÂY P
@@ -2661,7 +2757,7 @@ y/œ¶aúßïä>Þ%úFIÇBZúŸ÷@ãä·¿h™Š~ØÝµœßöua×ÊîÞåòA(\ªÁíBå#P†’þ—eƒ‹%ƒ¯Ê†ñœ»H
 ãÿˆñ
 endstream
 endobj
-359 0 obj
+400 0 obj
 <</Length 8557/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíyœWUùÇÏ—aP6qaQqJIÄùfŠJþJY(MAÉç×«2é÷«ÆÊ\[°\ 3¥RK—TÈ4MpA‘(SYdq˜íþ^ÈÌ÷;ßåžÏóœóÜ3÷yÿSÂ|ï¹w¾—{ÏyÎûycEQEQEQEQEQEQEQB£òØóôÇ7Þ:Rú<ïT¿dÎKÑÖC?^ÿ!§¥x óˆê…Û¢Vlùù˜åó¢µ¯›:¢’ågôž¼ 6ÊeëgÈÇ-»mÇ‘VÜóý‰Ue,§ªpÓïŠç¢¼ÔžI>væš–Ãm_6wæ}!$Œá÷6æÿö£(ª?‡~ü+³Y×|ìÁqâ
@@ -2730,14 +2826,14 @@ ou°¦kFP[>Ï€×ý;a0™Qs¹Â¯ß4¾DBJèˆV[ä6FºOŽüÝÿûöóRûÆ·êTã®w$…3ÁËÔ-¹nr•à¹'‘¼
 º>”÷ë_ÚEúÄ?TÜ›çë_«©i.óAÐý;ÊnÕ©ªiÕÉu³¤OH‘4Bþ åRÇô–!ÏCÝ”°9÷C#dÝÒ§¢H0vgÛ >)}"Š'îht¾ôi(Ró^ý@ú$9†¼5_§þiæà½¤Ï@QEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQEQ”]ü?Š—ÄR
 endstream
 endobj
-360 0 obj
-<</Length 5354/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace 297 0 R/BitsPerComponent 8/SMask 359 0 R>>
+401 0 obj
+<</Length 5354/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 512/ColorSpace 338 0 R/BitsPerComponent 8/SMask 400 0 R>>
 stream
 xœíÕQ–$Ç‘CQìÓ˜òh$ŠbUWg& ‹wWàöÜÂC                               à¯ü?¤Ï øÐƒõpl xÓ›ïp{: xí³ì‘|Ô° žì%Ïþ±Wñ±ƒxˆW?ü×^B" ¸çEÏüý× ÎxÕƒöœG2 xÇSö„‡ŽD v½õ{ÂûF+ ‹\@û(`‹khé ¬pí# €~®¤}îÎ  ”‹iŸ›¤c èânÚç>é$ *¸žö¹U:€0×Ó>K·äzÚçzéB 2\Oû\/]@†ëiŸë¥Èp=ís½t! ®§}^Ž Àõt‚ë¥p=àzéB \O'¸^º€ ×Ó	®—. Àõt‚ë¥H?<_Ó	®—. Àõt‚ë¥ðís½t! ^ }®—. À´ÏõÒ… d¸žö¹^º€×Ó>×KázÚçzéB 2\Oû\/]@†ëiŸë¥Èp=ís½t! ®§}®—. Ãõ´ÏõÒ… d¸žö¹^º€×Ó	®—. Àõt‚ë¥p=àzéB \O'¸^º€ ×Ó	®—. Àõt‚ë¥p=àzéB \O'¸^º€ ×Ó	®—. À´ÏõÒ… xö¹^º€×Ó>×KázÚçzéB 2\Oû\/]@†ëiŸë¥Èp=ís½t! ®§}®—. Ãõ´ÏõÒ… d¸žNp·t ®§Ü-@†ëé×Kàz:ÁõÒ… ¸žNp½t! ®§\/]@€ëé×Kàz:ÁõÒ… ¸žNp½t! ®§\/]@€ëé×KàÚçzéB ¼@û\/]@€hŸë¥Èp=ís½t! ®§}®—. Ãõ´ÏõÒ… d¸žö¹^º€×Ó	î–Î Ãõt‚»¥ó Èp=àné< 2\O'¸[:€×Ó	®—. Àõt‚ë¥p=àzéB \O'¸^º€ ×Ó	®—. Àõt‚ë¥p=àzéB \O'¸^º€ ×Ó	®—. Àõt‚ë¥ðís½t! ^ }®—. Ãõ´ÏõÒ… d¸žö¹^º€×Ó	î–Î Ãõt‚»¥ó Èp=àné<À¶ÝïÈõt‚»¥ó «Ö¿#×Ó	î–Îì¹ñ¹žNp·t`É¥ïÈõt‚ë¥íN~D®§\/]èuø#r=àzéB@£ó‘ëé×Kº<ä#r=àzéB@…§}D®§\/]{æGäz:ÁõÒ…€˜'D®§\/]à#r=àzéBÀçð½;Åé×K>è“A^Eû\/]x/>¢T–ß§}®—.¼QIŸÓ>×K^Œ¨6Ô¯Ò	î–Î¼ÑD®ïÓ	î–Î¼ Ñ\´ïÐ	î–ÎüÐ&×Ó	î–Îü„ËhëéwKç~+iëéwKç¾ËÅ4Èõt‚»¥ó _s=r=àzéBÀ\Oƒ\O'¸^ºð×Ó ×Ó	®—.|Áõ4Èõt‚ë¥_p=r=àzéBÀ\Oƒ\O'¸^ºð×Ó ×Ó	®—.|Áõ4Èõt‚ë¥_p=r=àzéBÀ\Oƒ\O'¸^ºð×Ó ×Ó	®—.|Áõ4Èt‚»¥ó _p=òàné<À\O›\O'¸[:ð×Ó&×Ó	î–Î|Áõ´Éõt‚»¥ó _p=mr=àné<À¼@ƒ\O'¸[:ð/Ð ×Ó	î–Î|Á4Èõt‚»¥ó _ðr=àzéBÀ\Oƒ\O'¸^ºð×Ó ×Ó	î–Î|Íõ4Èõt‚‹¥Û ßâzäz:Á­Òa€ïr=r=àJé*À/p=r=à>é$À¯q=r=à2éÀ/s=r=à&éÀO¸ž¹ž®p‡tà‡\Oƒ\OW¸@ºðs®§A^ ÒdÄc¹žyN !‚l‚ëi“ëéâó.-CâÓù5Úäz:zø¤{ûàzÚäz:tøŒ«+ázÚäz:nx·Û[áäz:hxŸ',†hëéŠáåµ^ A®§È…zæz¸ž¹žN ^âÉâzäz:PøM,‰ëiëé*áÇØ“—wxr=@"ü «òÖ/§A®§èƒïc[>œåU4ÈõtqÜ“ãzäz:2øü†Û×Ó ×ÓdÁãðÚ¸ž¹ž® 	Þ·OØ×Ó ×ÓÁË—áQËãzäzº‚pÍr=r=]AŠ'sÍr=ò@„grÍr=mr=@§q%Ír=mr=ððñÅÅ4Ëõ´ÉõtÂ“g×Ó,×Ó&×Ó	üQ\O³¼@ƒ\O'<sê§q=Íòr=ðÀ‘Èõ4Ë4ÈõtÂÓæ}&×Ó2×Ó ×Ó	ö±\OË\Oƒ\O'<gÒ's=-s=r=ð1Îõ´Ìõ4ÈõtÂf„ëi™ëiëé„ó‚¯éÝ\Oƒ\O'Üžp=-s=r=]qx4üÁõ´Ìõ4ÈõtÅÕ¹ð/®§e®§A®§+N…çzZæzäzºâÞDø/Ð,×Ó ×ÓÇÆÁóÍr=r=]qiü-/Ð,×Ó ×K¾Ë4Ëõ4ÈÒ‘€oñÍr=mr½t!à»\O³\O›\/]ø.×Ó,×Ó&×K¾Ëõ4Ë4ÈõÒ…€ïr=Íòr½t!à»\O³¼@ƒ\/]ø.×Ó2×Ó ×KÂGMß¸ëi™ëië¥áCÜ¸ëi™ëië¥áíÎÜ¸ëi™ëië¥áŽÝ¸ëi™ëië¥á-NÞ¸ëi™ëië¥áÅß¸ëi™ëië¥áeÎ_ºëi™ëië¥áw=çÒ]OË\Oƒ\/]?÷´K÷Ír=r½t!üÄ3/Ý4Ëõ4ÈõÒ…ðkž|é^ Y®§A®—.„ïâÒ½@³\Oƒ\/]_ãÒßÔá4Ëõ4ÈÒ‘ð?qãŸ	òBšåzÚäzéBøÜøç³¼„f¹ž6¹^ºþ7žó›4Ëõ´ÉõÒ…ð'n¼'Ñi–hë¥áÓK¢Y®—.ôs^ A®—.ôhÜx®_¢e®§A®—.ôPÜøV´oÒ2×Ó ×Kzœô…ß¸ëi™ëië¥=…kh–ëi™ëië¥Ýç2šåzZæzäzéB—¹’f¹ž–¹ž¹^ºÐM.¦Y®§e®§A®—.t»i–ëi™ëië¥]ãÚäzZæzäzéB×x6¹ž–¹ž¹^ºÐ5^ M^ Y®§A®—.th“h–ëië¥äzÚäšåzäzéB¹ž6yf¹ž¹^ºÐA®§Y®§Y®§A®—.tëi–ëi–ëi“ë¥]ãzšåzšåzÚäzéB×¸žf¹žf¹ž6¹^ºÐ5®§Y®§Y^ A®—.tëi–ëi–hë¥]ãzšåzZæzäzéB×¸žf¹ž–¹ž¹^ºÐ5®§Y®§e®§A®—.tëi–ëi™ëië¥]ãzšåzZæzäzéB×¸žf¹ž–¹ž¹^ºÐ5®§Y®§e®§A®—.tëi–ëi™ëië¥]ãÚäzZæzäzéB×x6yf¹ž¹^ºÐ5^ M^ Y®§A®—.th“h–ëië¥äzÚäšåzäzéB¹žf¹žf¹ž¹^ºÐA®§Y®§Y®§A®—.tëi–ëi–ëi“ë¥]ãzšåzšåzÚäzéB×¸žf¹žf¹ž6¹›útžêû\O³\O³¼@ƒ\LejöK\O³\O³¼@ƒÜJMšÏö«\O³\OË\Oƒ\I5Ê÷®§Y®§e®§Aî£ý'ü×Ó,×Ó2×Ó —Q‰Cþ˜ëi–ëi™ëi›¬ÔÐ2×Ó,×Ó2×Ó ×ê e®§Y®§e®§Aî°U@Ë\O³\OË\Oƒ\`nv-s=Ír=-s=zf´Å3¿Šh“h–ëiÐÓŠ»­À»i“h–ëiÐsrM¾¶Ã›h“h–ëiÐZ­Ÿ¿¿ÆËi“h–ëiÐíPFØÊò*šåzšåztµÒ)Fãü>Ír=Ír=º—èÌ ë‰~‡f¹žf¹ž]êsi–3¡~F³\O³\OƒnÄùØŸçÝ\O³\O³\O›¦Ë|àðžè\O³\O³\O›v³¼ûä‘¡>Àõ4Ëõ4Ë4h1È[Ïœë3\O³\OË\Oƒ¶j¸ƒ–¹žf¹ž–¹ž­¤p-s=Ír=-s=êïà>ZæzšåzZæzÔÁ­´Ìõ4Ëõ´Ìõ4¨³€»i™ëi–ëi™ëiPÛø^ e®§Y®§e®§A=³{‡–¹žf¹ž–¹ž5î5Zæzšåšåz”Ú›´Ì´É4Ëõ4(5²—i™h“h–ëiÐççõ>-ómòÍr=úð°¾B³¼@³\O³\Oƒ>6©oÑ2×Ó,×Ó,×Ó Œé‹´Ìõ4Ëõ4Ëõ4è­3ú.-s=Ír=Ír=zß€>MË\O³\O³\OƒÞ1@Ë\O³\O³\O›^8šCË\O³\O³\O›^2—FË\O³\O³¼@ƒ~"?–¹žf¹ž–¹žýÎ8~*-s=Ír=-s=úñ,~0-s=Ír=-s=úÁ ïZGË\O³\OË\Oƒ~iŠDÔFZæzšåzZæzôýBQi™ëi–ëiY:Þ×4è;çÏ-¥e®§Y®§e®§A_>Z´”–¹žfyf¹žýÃÉÓ9{i™ëi–h–ëiïÿh™h“h–ëé„tÅZæÚäšåzÚ—N¸AË¼@³\O³\OËÒñÆh–h–ëi–ëiVºÜ-s=Ír=Ír=mJg›¤e®§Y®§Y®§5é`Ã´Ìõ4Ëõ4Ëõ4%]k›–¹žf¹žf¹žF¤;] e®§Y®§Y®§éHGh™ëi–ëi–ë©^ºÐZæzšåzšå*–nsŠ–¹žf¹ž–¹ž*¥«¤e®§Y®§e®§>é$7i™ëi–ëi™ë©LºÇYZæzšåzZæzª‘.qœ–¹žf¹ž–¹ž:¤3Ü§e®§Y®§e®§é e®§Y^ Y®—.4è-s=ÍòÍr=ú<„–¹žfyf¹eBË¼@›¼@³\,¡e^ Y®§Y®G“‡Ð2/Ð,×Ó,×#Èsh–h–ëi–ëQã9´Ìõ4Ëõ4ËõHñZæzšåzšåztx-s=Ír=Ír="<‡–¹žf¹žf¹žCË\O³\O³\ïáã?Š–¹žf¹žf¹Þ“g-s=Ír=-s½gNý@ZæzšåzZæzù™´Ìõ4Ëõ´Ìõž6ïci™ëi–ëi™ë=jØ'Ó2×Ó,×Ó2×{Î¤§e¤»Úö;´Ìõ2&´Œ>ÓmŸf¹ÞfÄôGôŽKt¹í;h–ëÐ²'Ïþn^ Y®w{:ü‹–=jØÏs=Ír½Ã£áßiÙíéâ\O³\ïê\ø-»7Q×Ó,×;9þ›–Ý˜¢–ëi–ë
 ëŽ\O³\ïÞDø_Þ³ã˜çzšåzÇÆÁ?xÛšc›ëi–ë]šÿì›Ža®§Y®wiü³wn:†¹žf¹Þ™Að¥7/;V¹žf¹Û)ðMo^v¬r=Ír«#àW½sÓ1Ìõ´ÌeÖÏ{Ï‚cžëi™kL¿ïÛ\OË\`úðx•—î5îp=-KÇãýÇŸ^º×¸Ãõ´l´[ðØx“×-5NñÍÍ96ÞêëŒƒ¼@³C}øÌÚœäzšµ˜ècgÆ'½pCpŒëiÖ\œ¯Ý\âzš5WæÝFÊËWg¸^ºÐÏm5yßi÷Ž…Á®§Y[5ÞqZ”xßÚ`ëiÖP‡×mÞº<˜æzš5TàUGE¡ìv¹žf­ÌþŠ[B—Ïlp=ÍZ™úuw…°O®np=ÍZù¥×…€/.q=Íšö7†ùü¶à×Ó¬‰1ßvox—Ôªà$×Ó¬‰ß|{x™ìžà*×Ó²òÑ>u‡ø¡ô‚à>×Ó²ò¡>{“ø®ô^àA\OËÊ'úøeâŸ¤×OäzZV>KèJñÿÒ+€§óÍ*!z«–¾yàO^ Yå‡O_ìã¤/ø®—.tVúb!}ÉÀ\/]è¬ôÅž•¾Xà¸^ºÐYé‹½&}ŸÀO¸^ºÐeé»—¾@àw¹^ºÐeé»”¾4à•\/]è²ôÝÎH_ð.®—.t\úz{¥oø×Kº/}ÃEÒW|šë¥=‚,ÝHr½t¡Gð“¤cE\/]èA|Tº+ÐËõÒ…ÇûÒ	®—.ôPž’®¬r½t¡§sŸtà×KÂŸ¸zà×KÂ?á~i®—. gyA: œåzéB p–ë¥ÀY®—. g¹^º œåzéB p–ë¥ÀY®—. g¹^º œåzéB p–ë¥ÀY®—. g¹^º œåzéB p–ë¥ÀY®—. g¹[: \æVé0 pŸû¤“ Àƒ¸I: <‹;¤3 À¥ß~ ˆáñ€Çâñ€Çâñ€Çâý€Çâñ€Çâñ€Çâñ€Çâñ€Çâý€Çâñ€Çâñ€Çâñ€Çâñ€Çâñ€'ãý€Çâñ€Çâñ€Çâñ€Çâñ€Çâñ€Çâý€Çâñ                                                                                                                   Ôú?Â±Q¼
 endstream
 endobj
-361 0 obj
+402 0 obj
 <</Length 4554/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 454/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíÝgxÕEð¹!‰$»Ø(
@@ -2762,8 +2858,8 @@ C-µ_ssíô_sGYi¿æ>QÇ šûðhg!ÐÜ‡ÈèÄÛ¯¹OÜ1@7é’T.ú'Ü~Í}¢Ž4÷aÓ)ÑþkîCgb‚íOsŸ˜c Í
 ¼7ùp«“wNõˆ´Þ âËÉ/ï)ðqÔÏšd<t0ˆ|QN<Ö ÙÙ–‰y´ƒ2¨Æš`wã¥]Ad~óºK¿D&OM‘khO~Ÿmå)pÝAy÷ƒÈ-Æ[·‚È}œOU¶0ÞZk!Ç%P´¸ØxìŽKÙDü;ù­«‚iR6ö#|ÊôTãµ~ —ÖDf•¯•|"}èž2?ÄxîPK¥eàéÉo©i r×#vèh¼×D¬qˆL6¦€Èõö âÁuïÌÖÜƒHéÝRJ)eDüý*
 endstream
 endobj
-362 0 obj
-<</Length 3840/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 454/ColorSpace 297 0 R/BitsPerComponent 8/SMask 361 0 R>>
+403 0 obj
+<</Length 3840/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 454/ColorSpace 338 0 R/BitsPerComponent 8/SMask 402 0 R>>
 stream
 xœíÚY’ì¸EAîÓ”IjSzCÉ<À}iˆS—?u]Àîû® ïvÿGý+ Æß' àäý÷	 8süí?À±ûï pæøÛ€3Çß' `oöà@¿Ÿ €“÷ß' àÌñ·ÿ gŽ¿O ÀNì?À>;þ> {°ÿ úÚøû ;þ> ë²ÿ úþøû ¬ÈþèUãï pìøû ¬Âþè‰ñ÷	 ˜Ïþè¹ñ÷	 8vüí?À±ûï pæøû LcÿôÎñ÷	 8vüí?À±ûï pæøÛ€c÷ß' àÌñÿ¯ú ŽsÏP?Àqî1ê— 8È=Iý ¹‡©ßà÷<õ“ ì¯^úŸª`s÷`õÛ lëž­~€mÝãÕ/°¡{õ#ìæ^GýT [¹—R¿À&îÕÔ°‰{Aõ›,ï^Sýl k»WV?ÀÂî•Õ°ª{}õ¬çÞEý ‹¹wQ?$ÀJî½ÔÏ	°Œ{/õs¬áÞQý¨ ÓÝ›ªß`º{_õÓÌuï®~`€¡îÝÕ0Ñ}†ú™f¹Q¿4À,÷IêÇ˜â>LýÞ SÜç©Ÿ wŸª~x€Ò}°úíJ÷ÙêçhÔëÛ«/ Ð¨×w„ú ïVïî õ) Þ§^ÜYêk ¼O½¸ãÔx‡zk'ªoðõÖUŸàYõÊÎU_àAõÄNWßà)õ¾. >ÀëÕËº†úJ ¯W/ë2êC¼R½©+©oð2õ ®§¾ÀkÔkºžúb /POéªê»|W½£«Oðuõ‚®­¾ÀÕó¹ƒú† _Qoçê|Z=œû¨/	ð9õjî£¾$À'Ô“¹›úž Råžê«ü^½”{ª¯
 ðõLî¬¾-À¯Ô¹³ú¶ ?Uäþêü@=§¨ïðOõ.ž¢¾3ÀßÔ£x–úÚ ªñ,õµþPÏá‰ê›ÿF}v ûŸ©/­žÀÓÕ÷ÎUïßéêû‡ªÇ«+ ŽSÏ¨C ŽSÏª[ RSç ¤<þ©.8B=uüXÝ°¹zäø©:`sõÈñ+uÀ¶êyã7ê@€mÕóÆïÕ ª‡©3vS¯ŸPÇl¥ž4>§îØD=f|Z°‰zÌøŠº`yõŒñEu8ÀÚêã[ê|€…ÕÆwÕKª§‹¨#–TO¯Qw,¦-^¦N	XI½X¼X°Œz®x±:(`õVñˆ:+`õPñ”º,`´z¢xP0W½O<®Nª'W'LT/oR‡ŒSÏoR‡ÌRooUçLQ¯::`„zŠÔÑ½z‡ÈÔé±z„ÈÔé¥zˆÕz{èÕz{¡Îx·zu¤Žx«zr¤ŽxŸzo§Nx‡zi˜¨®x‡zi˜¨®x“zl˜¥îxŸzo¤Žx·zu˜¢.x·zu¡ÎhÔÛC¯nÈÔóC©®(ÕD¦NèÕ;D£îèÕ;D Ž˜¢^#Þ­.¤$Þ§n˜¥Þ$Þ¤˜¨^&Þ¡®˜¨^&W'ÌUïªãF«'ŠÕqÓÕ+Å#ê¬€5Ô[ÅëÕMk¨·Š«ƒVR//S§,¦-^¦N	XO½[¼@°ªz½ø®º `Uõzñ-u>ÀÚêã‹êp€åÕ3ÆÕá ;¨—ŒO«“6QŸS÷l¥ž4>¡ŽØM½j|H	°¡zØø:`Oõ¶ñu À¶êyãWê:€ÍÕ#ÇOÕi û«wŽ¨£ ŽPO?PGœ¢^;þ¦Î8H=xü©n8N={ü¡8N={ü[]p¨züNWß8Z=G«­žÀsÕ—ð	hÔg°ÿúæ ¨çð,õµþ¦ÅƒÔ§ø›zOQßàêi<B}d€¨§qõ…~ªÈÕ·ø•z#wVßà7ê™ÜS}U€©Çr7õ=>ªÞËÝÔ÷ø„z2÷Q_àsêÕÜG}I€O«‡sõ¾¨žÏµÕ×øºzA×V_à[ê]U}7€ïªwtUõÝ ^ žÒõÔxzMSŸà•êM]I}+€«guõ• ^¯^ÖÔ'xJ½¯ÓÕ÷xJ½¯£ÕÇxV½²sÕ—x\=´Õ7x‡zkÇ©ð>õâÎR_à}êÅ¤>À»Õ»;E}€w«ww„ú ûlõó”îƒÕoPºOU?<@ï>Oýä #Üç©Ÿ`Šû$õcÌR¯òûÔ/0Ë}†ú™&ºwW?0ÀP÷îê˜ëÞWý´ £ÝûªŸ`º{Gõ£¬áÞKýœ Ë¸÷R?'ÀJî]Ô	°˜{õ+,é^_ý„ «ºWV?ÀÂî•Õ°¶{Mõ³,ï^Pýf ›¸WS?À&î¥Ô¯°•{õSìæ^AýH ºÇ«_`[÷lõó lë¬~€ÍÝ#Õ¯p„{žúI ŽpS¿ÀAîIêÇ 8È=Fý Ç¹¨ß àPõüÛ€†ñ8–ý8“ñ8–ñ8“ý8–ñ8–ñ8“ý8–ñ8“ý8–ñ8–ñ8“ý8–ñ8“ý8–ñ8“ñ8–ý8–ñ8“ñ8–ý8“ñ8–ý8–ñ8“ñ8–ý8“ñ8–ý8“ñ8–ñ8–ý8“ñ8–ñ8“ý‡ýú? ÓÔ›ÄûÔ­³Ô›Ä›Ô¡ÕËÄ;Ô•1…ø«z™x\ƒH‚¨÷‰Õq1ˆ0ø¡nŸxV]ShƒŸ)–‰ÇÕY1ˆ<ø…bŸxVÝS(„_{ï2ñ¸:(	¿õÞ}âYuML¡>â]ËÄãê”D*|Ð»ö‰gÕ1…Zø¸ç—‰ÇÕ1ˆ`ø”ç÷‰gÕ1…fø¬'—‰ÇÕù0ˆlø‚'÷‰Õá0ˆxø²gö‰gÕÕ0…~øŽW/«“a	ñM¯Þ'žU÷Â*âû^·L<®Ž…A„ÄK¼nŸxV]
@@ -2774,7 +2870,7 @@ Q1¼+^®®ƒADÅÌ¢xNÝSÈ‰Eñ¨º‘¯òŠqâêR˜BH¼Ê‹Æ‰ÇÕ¥0ˆø¾×ïP÷Ââû^:N<®î…AôÃw<°O<®
 ñ®qâêš˜B$|ÄÇ‰ÇÕ51ˆHøµ÷ŽïP7Åòà×Þ>N<®nŠA´ÁÏDûÄãê²DüP·O<«.‹ATÁÿK÷‰ÇÕ}1ˆ$ø‡zŸxVÝƒè¿ªÇ‰w¨+Æ©g‰÷©[f©7‰÷©[cŠºD    ®GýÊ+]
 endstream
 endobj
-363 0 obj
+404 0 obj
 <</Length 4213/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 95/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœí{œMUÇ×™33.“;cÐ4”ð¯[r'E!’Þ"R>¡TD‰‘[}jÑEQš”Ê5B“[Ä'Ôën3æÂœ9Ïû1sö>g=ë²÷^ûœOo¿?yÖeöwfïµÖsY„ü£¿¢šJœ÷íö#®3YYYº2Ò6=oÊ¨þÍ+Z5@t| "ä»©Ié&>¾œÞ(6^J±•ÊŠO \¼¼jW~Œµ¨Ü$Ô6’>:wìzÃ»Š Ñ¹íŸŽéXž˜U™“”¾Ÿ“ïg#u’CôF ­üŒ§öçOà10¦¬ý«ßÖ"’×ývjã£BÏ¦1}ä—˜Z¼qŒ?ù¢C‹†ÝLÌè9Z·g¢B†‰²V<§†ÿ_º¼bTÍâ_áù#âsÏ˜×»1¨¨ÓÔ.Ç…ÿkÚ;º²2þ à^Ó/,4øGÏÉ–œ{ö¢ž¥ˆ½@ïïœß‡;$øä/¬¯Ž? ¤vŸéñ—ŒÌýBþlP•;‡ô6!$ù¸?ŒSÈ ­e°ù·2ü<ëû0^`TMÀúÊªšürŸ	SÈŠ¦:ƒÉß™Xhfö¿ú¨‰ö49TùlŠSÈ µrðø—ýÆìì÷w"âJÄû¹X)dùÃé;Tò‡½ÕƒÅ¿ÚNó³P”!•.2ú™FB–?ä÷UÉVÿriæçž)±˜Êê(»jèò‡Â^*ùCjD0øG®·`êIâÈª°w™¯…0Èï¬’?¼þ³¬˜ycqd¯±{ºLû†
@@ -2790,8 +2886,8 @@ xœí{œMUÇ×™33.“;cÐ4”ð¯[r'E!’Þ"R>¡TD‰‘[}jÑEQš”Ê5B“[Ä'Ôën3æÂœ9Ïû1sö>g=
 ¹ø‡]¿Í°ÍÜöeÒÄ¡=º´jÖ >¾Yó{†N^Âº*8ÃÛiMãÉ„šË/vˆýZŸÿ?x_„Mü=ñæ*§ãzHßo¸XÜ£æz{M6Ó·äkwÌ¢ V-ÇÁ›Ÿ•ñ¨zØPîæT¿úö¢«,ò¾c±åÊïišæV5æ«åOnÁÞ_yuíáÿ`À ¢ê’YŸ€eÚçít>b‘G/pª6Ô•›×A¯D_ï°ƒ?%Ý¹’D(ø-ÝeÒqBzã°íG’}ÖàÅü#÷c#kürêøßG™ú5”Ð)oˆ'5ß€Ò½k£‹+7Iauƒ °®âúOm°ïíùhõüý6Ì»däé%ìï–—7`¡v< ¿ÖÆÜàcÕõ¿æ‹¾B­ç–þ™,žˆJØ]WEƒÙÞÌÓqlIáæ¸«iºÎ}«bþObCwSÌÿŠ&ôK§Nü=OKÂ.biô&ÆÝêþÃáËñ6àbÕõÿúa#RÊßóžÍ/_©H£-‡ºŒ‡r*èÈK9ƒ")37"¯¨êúŸè•³Tòw32ãHûRz¦¾a¬é¶jÒ¾„ÒØÂé+bDhé@Ÿ³Qÿ8Ì…én¦Ž>;5·n€·FT)ç~V™IRnMm†Ìˆ’8/¢ÞXE	ªëÿ"©9 »ÂUñ?Ø˜ó8j éñLM§†¯…õFlºÜÃ×cöço4çÄ±ökÕüibyH–ñ/Lb…™—Lj’—öIlIIHçeXÀ“¨Ò›Šl(u3e„-¹8Jeýï¦ØN67^ÿTV’©Oí¤K³¤žYhT}Œt‡y’µñ"M=B3eäØÃ9&QXÿ}–P…%ü=ßR‹Ó>ÍÀ£égzYY­ZÏ1º®øIŸó»Üè%.õAo©šZíkùœ uË^¥éÂºv?,–ÞÑxŒ„jo_ý‘z‰“¾Ð»œXù`X­üþ´8ø¹ª–ñ?¾tx=é‡Rzº.ÒÈ½´½DŸÕûÏ•©øtuiÀ è.š¢¼@§PüÊ|—êEös¡,£Ñãy´JÆ¼Ôc|6=Ó)u]Ê»‰C:©ÅQ¬ÆÓ˜´ò–?ÎÍPtŸé«Ð“O®¬R™ò^Âdê.iÚm@Á‘ÿ3Å>š¼ƒz„Ÿ¹fJþ^SL·±ó×ýŽþ:»6±3?Hø[Ùä¾Q3—¬Ûš–árHûaÍG“‡ÜeÁu­„DÔí4`ää¹_®Û”–ær¹\ûÓ¶,KN|¼=#Uì—Ó¼
 endstream
 endobj
-364 0 obj
-<</Length 2418/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 95/ColorSpace 297 0 R/BitsPerComponent 8/SMask 363 0 R>>
+405 0 obj
+<</Length 2418/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 95/ColorSpace 338 0 R/BitsPerComponent 8/SMask 404 0 R>>
 stream
 xœíœ[rc9CµÿMs>R“J¹íDWAðqpqÊJw{­a†ÁÃ±ŠR²òÆMÏ‚³vòBêr2:´Qžáƒ¨Zb½éïÿOxŸµ“R”ã-éáì§Ò“Ê›ª³“ç²´ˆ¯ årœÜ\áÚ¦ÇJBáyÉsY~4W ƒ`9X%Ž3PÛäYÚž”<”UAmjH•ƒ’a:C´-K’Ú3’‡²Zè¬@r &dç{mKËRb¦NdQX,
 å\:„8ßh[	– Uçú†<‘%|Ê„—s#å|¬m…@oF¥Ì%y«Kì
@@ -2807,7 +2903,7 @@ r¡p`üèð/aW4GÖ1Q«H!ÎdYA.ŒåÿÞ›€Ú¤õ|€V"q&@Ô
 ð
 endstream
 endobj
-365 0 obj
+406 0 obj
 <</Length 5435/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 193/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíw|ÅÇ'ÉMAB¤HoJ/¢`¡
@@ -2825,8 +2921,8 @@ xœíw|ÅÇ'ÉMAB¤HoJ/¢`¡
 *@sŸ©Z¿©kh¾^Ú9³»öFÕ†º±yï˜¸Y	mNJÚ“’²/ió‡sFE¶½©AUHÓžƒÇÄ¯JÚžr 5õhÊöMFG47jªñãü“0
 endstream
 endobj
-366 0 obj
-<</Length 3115/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 193/ColorSpace 297 0 R/BitsPerComponent 8/SMask 365 0 R>>
+407 0 obj
+<</Length 3115/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 193/ColorSpace 338 0 R/BitsPerComponent 8/SMask 406 0 R>>
 stream
 xœíÜÁn9CÑúÿŸæ,¼$c·¤YäYg¡Kµ#Ø©¡†bˆ…Ÿæ…#nÁ5C,ü4/q”ÕPl±˜èâžœ ¥†âŒÅ·‡Œ 5y,”Ý/BÔDä±Pv{¼ WñÇBÓíÙ"Ä€[#A·7‹b5ŽJ,ÔÜ,BˆÕ,B±r{­a`U³ÅBÊíµ"„UÍ")·×ŠV5ˆ\,tÜž*B(Õ r±Ðq{ªm TS(ÆBÄí"äRM¡·wŠJ5‚h,DÜÞ)B(Õ¢±q{§y Tútc!âöNò@©ôéÆBÄí"äR‰“Ž…ˆÛ;EÈ¥'·wŠ˜ |J™z,DÜÞ)bð)Yb!âöN€OÉ·wŠ˜ |JÓŒXˆ¸½SÄàSšfÄBÄí"& Ÿ4&"nï1ø”šI±q{§ˆ	À§¤‹…ˆÛ;EL >%eX,DÜÞ)bð)ób!âöN€O‰·wŠ˜ |JÁÔXˆ¸½SÄàSôÇBÄí"& Ÿâ6;"nï1ø·Ù±q{§ˆ	À§ˆ…ˆâ rÎˆ?Ÿbå¢]<vÄ'ð)J&±¡¾Lÿù#NÕ[™Äš±IgEDç·ýZ1±ŠåüþhÌ m!ýŸ÷EÃ*¶-y‹aS4äDÜýÈ¿©8XÅ6W¯›·Ãé¢†ïü«Ø+á‹¦.p®+‚íkÿ#«AŠDÎ?”ñ	|¬Ö(21»ýD]Ä'ð±Ú¡È@ÄøðíŸÀÇj„"Õ{#>U~‘‡ê½ŸÀÇª½È@„IòÆÌˆOàcU]d Â§wWiÄ'ð±ê-2áÓ»«4âøø”þtCDb#ÖÏøÀs±ë "±ëÀgpÚ¹Ø] Â§ô—wñ;ð™WôE"|JÙq·¿Ÿ1!wÍžñ]\æÆäˆOà#}xc¾‡ur™“#>â™	ù6ÖÉenLŽø>Šg&4æ{ØX§ÕøiLÈo<os×ÃÖS<3¡1ßÃÆ:­ÆOcB~ãy›»¶žâ™	ù6Öi5~eø¯¹N,0f·‘QýfOçùyLm\¹Í,0l¥Ä^Ÿ¦–®ÜæŒŽ. 5Nb/‚ˆñ3²÷õmŽáôBË$ö"ˆø7#“_ßæ˜P™%±AÄøÀ¿Yýú6ÇŒÐ³€Ä&‰½"ÆZ…¿ŽÊó6IìE1>Ð*üuÔ˜Úà$±AÄø@«ð×QcFh[€Ä^ãÿfäå®DÍ¡sò5{D84ú„¯DÍ¡sò5{D84~šz¹‹]Fè\€|Ä^Ÿ¦ÞïzW³Fb/‚‡ÆOSïw½+ŒY#±A„Iæo¦Þïz—úÍxN§Øw Â$ó7Sïw½K}„æ<§€Sì;áSêP½Þ¥>BóžSÀ)öˆð)ý²ãzkpšôÍxN§Øw Â*v|ò–4éšðœN±ï@„[oÞÿ ÷<§€Sì;‘ÞIÉë²@¦Hìká–<»wc]È‰}"ÜªgÇn¬Ë™"±¯A„UûøÌ½Y S$öˆ°Êß¸70dŠÄ¾>ŒÌûŸ÷ÿ)±A„Ï³ë5fLaûD˜ì08ítfÈÎ±ï@„É#£z2³@¦ /ÍûÿšÃ óŠšK³@¦0,]ã7–s+6d
 ·Ò1~–I-c³@¦p+]³Ç™QAÒ›2…Ué
@@ -2858,7 +2954,7 @@ xœíÜÁn9CÑúÿŸæ,¼$c·¤YäYg¡Kµ#Ø©¡†bˆ…Ÿæ…#nÁ5C,ü4/q”ÕPl±˜èâžœ ¥†âŒÅ
 0Â–)â§rÑ_D$äN|EùœBZ>þðîÏþ?ZýZ
 endstream
 endobj
-367 0 obj
+408 0 obj
 <</Length 3979/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 283/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœí{œÎUÇ¿3cÌˆ!L¹”[Q[‘¶Y´Rª%¥¬U)T¬•J)—nÚBM,]V7Õªôê¶Új•‘.K¼¶‹ÚèfHRdÃ"ÉóÝ×”dfžËç÷û}ÏsžçœïûoçœÏó¼óÌó{Îù"øýJ˜6	º9h_Â—¥€œÏ0ítsÐ¾N
@@ -2876,8 +2972,8 @@ Cêßÿ¬÷¡ôÌ|
 ^ô§í¨Šà¢_eÛŽªØœþçÚŽª .úù¡NÁ‹þžc;ªb ¸è÷Rþ‚ýïe;ªb øÒ%:ý¿ô§§í¨ŠnAõ¿·oARÅ»éßÃvTÅ p­¿Å:ý¿óóÛQÜŠêW§¿ƒàw~Ÿn;ªb€bTÿ;:ý¤þ·¨ÿn¶£*˜€ê_d;©b€BxúwµU1ÀDTÿBÛInEýŸb;ªb€;PýoÚNª á6ÔÿI¶£*¸Õ¿ÀvRÅ àéßÙvTÅ “Qý¯ÚNª |5õ‰¶£*¸ÕÿŠí¤ŠÃÓÿÛQÜêŸc;©b€&¥¨ÿN¶£*˜‚êŸe;©b€¦;PÿlGUðª¦í¤ŠšÁÓ¿½í¨Š¦¢ú_´T1@sxú·³U1À£¨þÚNªàÐ þ²ßØŽª`:ýŸ·T1@Kxú·µU1@ÿé cl'U( ÿËÍK
 endstream
 endobj
-368 0 obj
-<</Length 3785/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 283/ColorSpace 297 0 R/BitsPerComponent 8/SMask 367 0 R>>
+409 0 obj
+<</Length 3785/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 283/ColorSpace 338 0 R/BitsPerComponent 8/SMask 408 0 R>>
 stream
 xœíÝAvd9CQîÓìASƒÎLW¤- õî‚€ü1upRHuü~ hé¡Žß m =Ôñû@ ¤‡:~? ´ôPÇï 6êøý  ÐÒC¿ Ú@z¨ã÷€@Huü~ hé¡Žß m =Ôñû@ ¤‡:~? ´ôPÇï 6êøý  ÐÒC¿ Ú@z¨ã÷€@Huü~ hé¡Žß m =Ôñû@ ¤‡:~? ´ôPÇï 6êøý  ÐÒC¿ Ú@z¨ã÷€@Huü~ hé¡Žß m =Ôñû@ ¤‡:~? ´ôPÇï 6êøý  ÐÒC¿ Ú@z¨ã÷€@Huü~ hé¡Žß m =Ôñû@ ¤‡:~? ´ôPÇï 6êøý  ÐÒC¿ Ú@z¨ã÷€@Huü~ hé¡Žß m =Ôñû ßÃþÀ›Ø xû obÿàMì? ¼‰ý€7±ÿ ð&ö ÞÄþÀ›Ø xû obÿàMì? ¼‰ý€7±ÿ ð&ö ÞÄþÀ›Ø xû obÿàMì? ¼‰ý€7±ÿ ð&ö ÞÄþÀ›Ø xû•ÄØü¯¬6Þ|™Ç÷,á¶‘†õ?úàC³/ÅþGßŸß³„ÛFÖÿè¯7à)ÏÔÒË/3âøž%Ü6Õ°þw½_›}#ö?ýþ¬øž%Ü6Õ°þw{¾ô@m ½ÿ2#ŽïYÂmƒëú·gà·f_‡ýgÿÅñ=K¸m°aýOÿéü*ëiÚ@ú”q|Ïn›mXÿëº>ïÂþ„*3âøž%Ü6Û°þ×¿8ÿŠ{”6þ
 eFß³„ÛÆÖðÅ1ö*T™Ç÷,á¶ñ†õ|}Ÿ£œ~ö@=Æ¡aý_ßó²Ù·`ÿC•q|ÏnshXÃžô¬Ð‡hGßa T™Ç÷,á6“†õgüçIš}ö6T™Ç÷,á6“†õg|rÕkrŸ œ{‡™PeFß³„Û|Ö_òÉUï˜íŸýUfÄñ=K¸Í§aý%öˆèòÛÀ¡wUfÄñ=K¸Íªaý1¶Þlóì¿C¨2#ŽïYÂmVëùü¶ÝÒko'Þa2T™Ç÷,á6·†õ÷|~ÛV³³ÿ&¡ÊŒ8¾g	·¹5¬¿ç¯Î[iAámàHÁPeFß³„ÛÖŸô·n2]6ûïªÌˆã{–p›aÃú“þöÂMvTÝNe™
@@ -2894,7 +2990,7 @@ rÃkå´ôPeFß³„Û¢Ö/ËYÓÅ°ÿy¡ÊŒ8¾g	·E7¬?þ^–ƒ¬¥¤‡*3âøž%Ü–Þ°þþ«qŽ˜®„ýUfÄñ=K¸-½
 ã eãÎ°Va
 endstream
 endobj
-369 0 obj
+410 0 obj
 <</Length 10097/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 400/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíw|ÅÚÇçœ$¤ÑA:JW¤	ˆˆ"*WA¬”+""¨Xˆb¹êED¬è½W#"E$"*J± ðŠ"‚"Ð{	5&$9gÞO¨	û›ÙÙ™Ùsr²óý3yvfvs¶Ì<…7¨Ö®çã¯}0}áê-™™Sš•™¹yÕÂi^Ü£MW:4êu:qY6åõ{Ú“]ëDzœí$_–’¾›
@@ -2931,8 +3027,8 @@ o£×êüÀ$¥Î< é/¥9 UA†DüPGŽ ¼FÅØ»ä»i“ÞMŸùÓŸx“×Â²rNÒÝ!Qƒ¶Ü»”nžàøàÓXÕq•áô
 fÀ¤VêÝ4`»k<Åx|D‚\š¡jû±—M·K'BišyöG.JÆÓÒBç<Ê:)ÂÆÛ7bô©-˜?ãŸ%3oþL¤ñc}Ý8/ƒ ¸Kr§ÉþòNGå€ËÞ:I¬vù>TÎ>.Ò‰Òàâ‘W¥€-ÕþéùBŽ‚ùÝ¸†.ÉjUà›ûË½šÅq‚L÷3ßŸðÄäpž©ó€³¿ÜåS^yèúµÝ’j7ï:pôä¥ÎÊy0’gm8MV>Ù™›2Ö¬ÍØ”	“·Ú²¾m¤ÏÛp’Ä±ö_éºI+é³6œ¡‹Æl/"ì¹)Ògl(BåÂyøÄäv-v\.å+Ã©¢®—IxÞÁ§›<Ç^JŒô™0µÓÜÌ1%‹1m9Ñ:XbÖ{‹7¾¢Â¬ìe¼üŠ=¾î¿»¤~Ûøouá)°¨§ùíG­Ò´æN¿:ÒgdpFíá’ž`Ëˆs#}6çø¯™¤aA {RsãV’º§Uz~@Cq§L¯‰ì²à\öLìeüúKþÖÃ~Ìr¦}ÖwC[™Û~	"®Í I„V‡C¾Ø¸ô—DÊ´ëÿúÌ•LwŸ¬3^½§ñë(éTisÃÝ¿ønzú´9sæÌ™–žþÎõí~±}ÖO	'ÿ@Þø˜
 endstream
 endobj
-370 0 obj
-<</Length 6528/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 400/ColorSpace 297 0 R/BitsPerComponent 8/SMask 369 0 R>>
+411 0 obj
+<</Length 6528/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 400/ColorSpace 338 0 R/BitsPerComponent 8/SMask 410 0 R>>
 stream
 xœí›[r\Kkÿ›>óq'
 ?¤î.ÉÌè ‰íë˜9g;O Õ   ãÚó' €!%ÕV  fò´¢Ú @{žæTû hÆ3Žj£  î<£©¶ `Ç³Œjß  õ<‹©v PCõõu¡z €<ª/®#Õ›  ÄR}eÝ©Þ @OõeíDõV  ª¯iWªw ¸¢úˆö¦z= €O¨¾s¨^ àªOæ4ª÷ ø™êK9™êm þIõœOõÂ  ¿S}wQ½6 Àÿyì¡ €œÇš $ðx°¶{Iq XNõå3:}Õ&ŒT Àx¸u- 0îÛ  æÁY{\À¸fŸ4 hGìì@G¸]*Ð àdÉÁ' øÃ¥
@@ -2966,8 +3062,8 @@ a àÂ°•xaÚË `ˆÏq$	Êïœ-'ü} pCrüà‰‰RÅ¶ àÈ°c5Ÿ÷I À«+¡
  †‘Öz7ü Àlª®œí¡C ì¡ðâùÜ½j `!´ Hæ±„Ž  9<MØÐ  ™ê£¸…ê þBõiœOõÂ  ßQ}#gR½* ÀKTËiTï	 ðÕWsÕ |HõùìMõz  ·TßÑ~T/  ¤ú¦ö z% €ª«;Õû  ÄR}e©Þ  ê‹ëBõ  e<+©¶ àÂ³†jÓ  Ž<£©¶ Ð€gÕ. Zò´¥Ú Àž&T{ ˜ÌcFµ €¥pð àœz 8ËøGõÌu
 endstream
 endobj
-371 0 obj
-<</Length 19263/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 1024/Height 1024/ColorSpace 297 0 R/BitsPerComponent 8>>
+412 0 obj
+<</Length 19263/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 1024/Height 1024/ColorSpace 338 0 R/BitsPerComponent 8>>
 stream
 xœìÝÁkUÙÞàýâ¥ï¤´ÖÕÂ÷b [yuP¡pRè(Pt B=!ˆ ¤˜tŠÊ¤,‚¡À€D¬Tu®êö×à@¡Êî§ûå¶uss5'gï³ÖÞk­½?ðAêæž³Ïwo×>Y?“èÿþÿþßÿ                                                                                                                              à
                                                                                     ´àùøÁçÿùÿÑt@õ×ªòxýúõë×¯_¿~ýúõoùøè¯Õæ¹ë×¯_¿~ýúõë×¯„¤ˆ!çëúè×¯_¿~ýúõë×¯ËÇ!äzæ@¿~ýúõë×¯_ò$ý›ÿßŠsÄæo–Û¬¤_¿~ýúõë×¯_¿þAÏ?Î žs¬Û£_¿~ýúõë×¯_¿þ¡=µÎkPO¬kUåãU®‰~ýúõë×¯_¿~ýú«7Ô=ÇX±Ž©_¿~ýúõë×¯_¿þ-Ÿ[ëøƒÎqºÇ¬{=cS¿~ýúõë×¯_¿þþô‡Ï#Ì[?¤A¿~ýúõë×¯_¿~ý\ññ›_eNô˜XçU÷|õë×¯_¿~ýúõëïyÿÐ×­ÒPå|cõ×½núõë×¯_¿~ýúõëßx|-u¯C•ëSå¹±è×¯_¿~ýúõë×¯?î1c]Ãºç«_¿~ýúõë×¯_¿þ¡mµ:=¦ÊÇ©{­ê6è×¯_¿~ýúõë×¯ã1[ôºƒŽYåc]‡ºúõë×¯_¿~ýúõëß|¨ÑÎ7VCÝkUåñúõë×¯_¿~ýúõëôøS÷|«œW]u¯ƒ~ýúõë×¯_¿~ýú«÷Çê9~•s×¯_¿~ýúõë×¯_xÿ ±ŽÙæµÕ¯_¿~ýúõë×¯_ÿ–ýC_å8ƒ®IÈõŒu¾úõë×¯_¿~ýúõë­§Š*m!×P¿~ýúõë×¯_¿~ý#÷m«rŽuÏ·nsÝk¢_¿~ýúõë×¯_¿þí_+ä›èôºMüé×¯_¿~ýúõë×ß“þ‘_EHs•ëë˜úõë×¯_¿~ýúõ÷§?|¦™Yª<·
@@ -2993,7 +3089,7 @@ y-ýúõë×¯_¿~ýú{Ø?ôñƒ:«iéÑ¯_¿~ýúõë×¯_ÿ–=µT9¯A=!ÏE¿~ýúõë×¯_¿~ýqëÖ=_ýúõë×¯_¿~ý
 ÷ÃÏÏÏÏÏÏÏÏÏÏßÿîŒ3jþÌîüüüüüüüüüüü÷æW¾“~~~~~~~~~þCü—Ï÷Ì‰Ú«§Ñùüüüüüüüüüüü±žÖ7HÔ7ËèYüüüüüüüüüüü¾{ù|ÏŽ£»G½Û³/??????????ìüÑï—ž»âçççççççççç_áŸŸÓ³cÏ»+Îâççççççççççÿ|e~þê?ŸiÅÏÏÏÏÏÏÏÏÏÏé¿œ9ºc”3ê,~~~~~~~~~~þou>ßš?ºïê9üüüüüüüüüüü­9÷vé)jfÏ~~~~~~~~~~þ{sVìÛz>ëÞøùùùùùùùùùÏôÏÿkXqŸQwÈÏÏÏÏÏÏÏÏÏÏÿýLø¹£žÑsWß?????????ÿ‹ý!†¨ç£ÞåççççççççççÏ=Ë|óÍ7ß|óÍ7ß|óÍ¯3çœÕ3ùùùùùùùùùùùÿ™°ù›"ê{'ë›ˆŸŸŸŸŸŸŸŸŸÿ¹þyOÔ^3ñóóóóóóóóóó¯Ûkç·ÏŠ³øùùùùùùùùùùcË:—Ÿ¿Büüüüüüüü5ý¹ÿ,²Þ­`àçççççççççßïß³ãÎûä¯s?µ™üüüüüü‡ûOØ‘ŸŸŸŸŸŸ¿àYüüÕfâ?aG~þô³øù«Íäççççç¯ÐÓwäççççççççO'ñ¿ §ïÅÏÏÏÏÏÏÏÏŸNâß<³ÚòóóóóóóóóóŸé¯s'«ï°Züüüüüüüüüé¤ý’$I’”Û;¾­øùùùùùÓIüŠŸÿd¿$I’¤ÜžþMÁÏÏÏÏÏÏÏÏŸNâ—$I’$I’$I’$I’$I’$I’$I’$I’$I‡õ™Îz@
 endstream
 endobj
-372 0 obj
+413 0 obj
 <</Length 6374/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 232/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœíw|ÅöÀç¦z3Â"	jT  -ôb  (‚ ‚€D0>: (¨è)UAÃï!Mª	¡„„Ô{Þ'@’»÷n93»³37ÙïŸÉîÎÌýÞ²;sæB„FÅ˜':"¢F"÷î4†W_Gø´””8kp")¡}Þ?X V‘{2eí²Ywª'vPÃ]­Á©íWT[sÿ8(ÈG­ééÀ…K¿.{²‰°Ëç t#’8îðäâºWb\"&¥€„P"7üü9>¯½ý_’ú‡äÊD¢O€=¤Nÿ—ÍC“Õ?l¯Ddá¦3`ù_t°ulÒú‡!Dj[Ùkãàäõsˆ¸¾»IŒ¶mtûww$20ì'~y›F'±Ø+Ã<@¹“ ‚}ÍížÌþa Ï(Cî$[ÞýRûßBÄ“¢ø2´¬ûwGÑDƒ8Ë•qÿ0ŠˆæÈ¦JeÜÿ‡D4«@$kƒÊ¶ÿmD4ÿ¡Ì+ÛþÑpZôE3ªLû?CD“bÉm[–ý§Ñ€hŽTä:>Ç¿> œÙ\Ççø×„SÐ†çøÿú€xvpŸã_€~Ççø×$`Ç/ Ç¿>PÊ¿ ÿú€ìà7>Ç¿> 7qŸã_‚iÜÆZÍ^SÿXŽó|†ã×9 Q”ÿS#°DÇ´ëÜ÷Á§g­ØCë2)…”ÿã®tû˜ÿdÑøß@J!’ùoºð*ê­\9µð3fpò_H¥¡{ðþ3eÙUŠý÷ÌÌÌ†¼ÌÌ™­!-/œÈ¼ÌÑ?!ŸC¿Z“Ò‡dþ	!½anaNX£	™•µ*òôOH=ttùhRúÕÿ0š¿•üõí‡Ð€¯Ré'¤I6C–	ÿã¡Ç6wDGó.ÄpöOªþŽóŸHäÇÕ°ËcÓ­^¿¹0•ÓÆU^Ø¢‚mþC·èù7V|¿>yçÎíë×®üì½WëÕìz½ÿ7 å‹0æmw½éÐ·rËe”ÿ½Dn*t‹O:ïÛíüß?ú/Îþ]üû›Cù—¸¼kÉ¸Îµ¨ü/„›nƒÕ‡¶‘	0ˆ»2a [æÀð‘ëôf4öMmÆÍôSk0!Ú-öÿ9Ô&G³á92
@@ -3012,8 +3108,8 @@ zSúoÆ³ ËÍß ;üoEôp¨Æ¹}©_}ÿàž¯{§YÇªRçn¤ò_OwNÓ4GiŒ×ÿå1»nQ=5`*ý,Œ€Ÿu–C·Uü
 ‘mú™¿ á“„„øø‰Ï>ÛØô‡þƒ¨%
 endstream
 endobj
-373 0 obj
-<</Length 3704/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 232/ColorSpace 297 0 R/BitsPerComponent 8/SMask 372 0 R>>
+414 0 obj
+<</Length 3704/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 232/ColorSpace 338 0 R/BitsPerComponent 8/SMask 413 0 R>>
 stream
 xœíÝÑnÙ„a¾ÿK3ÀXh%e<Ó}šü‹¬ïÒA¤b‘s_H‰ø@ŽöIVÄ7PÏMÚÙcP×½„½¼èz®Ôüò¿Ö½œ-¼Öznu¹ã0[÷º&ó*ë¹ÛÍÚþÝ«È¬çz×znõ{tïpï®žÞéÑ½oÓ½Ì!¼µz.y¡§—¾S÷Våy_õ\ò6Oo|¹îõ
 ó¦ê¹çm
@@ -3035,7 +3131,7 @@ e©/D:i ëÓ¹’-RP(K}!‚ÐI{€%/RSÈÊRH{€%/RVhÊRH{€RA ¥¬Ð”#¤ö ã¥ˆ@Je¡&§
 ë^™Ù-Ý¨ªî½™™Ðý”êéÞ˜™Ù1Ýª’î]™™Öý¬jèÞ’™ÙyÝ/«€î™™=¥û}Eë^Ž™Ù³º_Y¨îµ˜™Uè~kqºbfV§ûÅ¥èÞƒ™Yƒî§·_÷ÌÌ:åJÝ­›™!ä&Ýe›™±äÝ›™qåPÝ½š™iÈAº»43“úº+43–‚º;33%t—df6V"u·bf¶‹ß|33ó›offñåOýÿ šr~¢
 endstream
 endobj
-374 0 obj
+415 0 obj
 <</Length 6025/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 166/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœí{œÎUÇÏ3ã2ã6•ëH’»A%i1.‘¢„h'!›KMŠ´­2»l••KŠ2¹§¤U«¬Km«ŒPH4•4·ÃÌÙ×ÃŒyžç÷;ßs¾ç{Îï7ÛËûßy~ßó=¿yžßåœÏ÷óeì"ÿç¤ð¼ê~çpß(w˜óá~'qßx‚sþ_¿“¸ˆ_ÄerÎy]¿Ó(>T»¾çðñÓ­Øœ––žžžþUZÚ¦e/|{½hö{äÉà¿Ÿö;b@T£»Æ.Ù™ÃEdo?²C,û}Q1ëÜÜv³âK™K!.12F\·§Öå
@@ -3066,8 +3162,8 @@ aÀxÉ^YD_e³‘2ÀÚö.z¬ÁX8Ö;à¢^í’>¹a§`üá/HUÆÿ†ƒqð(·KnÃ®-jPŸ’¤=¡ÃÔÌAÞ
 ÜOX‰ÉFÔ ‹-Çtèñ#7ËÆvšÞÏdW°ç6ç7:i²§øçÙž.Úgjç)“bòÁtW’xIâEn¹ð¦£äcÛMÙKËT}‹Å‡–Ÿ¥®év#3Å¸Yïå¯Ëô¼ªlè	ITLhô(ØsY'ùØ]¦Î˜ÌPÏ)¡ÜäÄ$#&=‘ÔšªV¨’·¼5<ŠÌ‡žj¾×Yò©tsN$«L¼/tp ¯æMàèÁ“5š“ˆ¯?=[›æýL·_‡;î-/–=Ê‚í„+ý0ÜÑ•=C1v!hbê«ósÞºMá·e¯"/A¥ÏÑÏoœU$Ïñ¹G¨NKÔë±ƒÎnó;YéFÃq’W²—ß¯dmO	? +¶¦´\t ÛÐUX›¯?NÕœò×y=íõE§ù˜Í¨Óá9=U]ãÊÎ²Å+ÁŸFmÉ‡fJ›<bH’Œæpƒt¥îÈ²m¸ìµci‚5,•ûÎØ¡ôØ¿pHcû¥ß9±mF,ýÁýüÝœúPÓ–˜jT¸ù±9ibÙbî®·žèe`'õ"ç‰Mè:tÒü%«×¦íÙ‘–öñ²ÔÉ#z·Öòa2IÔå‰ýF½ôÆÊ-é‡23óø±Œôí›—Ï3°Kcw—ñ‹°þfil˜
 endstream
 endobj
-375 0 obj
-<</Length 3042/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 166/ColorSpace 297 0 R/BitsPerComponent 8/SMask 374 0 R>>
+416 0 obj
+<</Length 3042/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 512/Height 166/ColorSpace 338 0 R/BitsPerComponent 8/SMask 415 0 R>>
 stream
 xœíQndIóþ—~ûÑÀbao·ËU¢T2PÊ9ÀÌÇœBá#žÿa:K!„Ç?ï!ÜCÞÿB¸/þÂ2o3Ý&\Mn2„ž§þ¦‡‹È^Bž,ˆ«_1m",gëíåó±1èçsV:)þËâur·_ˆ~-
 6Ééì¾³x Üí"¤SˆšŠz*„¿±{£œî"¤ÁC3Ö®ÔáÃ¿Ù½QN·Í†‹g)¦Æt±Ã¬ŸIy¹~N¤6øBž°ó¦^d÷LÊ³µtr­ç2ŒìÕF¯³~&ÙÍº:¹PÈs1«B†ß²~)ÍÁFˆ‡uYø+¦¿æ†¥×!BÔ5àË¬<üš–\k„Ð…¨;zÁ÷Y±yø—ŒUz§ö6Öÿ‹\i;SøV+–¿ã’±JïÔ[Åz!Òj¦Xˆ-	^çž±êŽÔ^Ån!Ò^¾X¸-	^çž½Š.ÔÞÃb!ÒFîð—$¯sÕdºÁÃV!Ò:àK.I^çªÉ*.tƒ‡ýBÔuÀ÷\’0¼ÈU«U•µ–°UˆºËøªK†¹jµª²ÖV
@@ -3084,7 +3180,7 @@ QYßvIÂð
 µ#ž¥ÄX#~Î^Lí=†(<8ò,"®šé÷sVc-ð1AgÀ—ÇœX¡_ÎYÍ‡iñ<VÄÌ,ÍrÎ¬Ñø`èé»ŒL„@h–s.`ŸÆ†F„š[y0L›!¼OžwÌš!Ü@Þw*ÞøÂiæ?æñ½n
 endstream
 endobj
-376 0 obj
+417 0 obj
 <</Length 32822/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 395/Height 512/ColorSpace/DeviceGray/BitsPerComponent 8>>
 stream
 xœì]”UÖ®ž@ÎQQ@DÅ°*˜Óš³((‚b#ÔU`–U¨+fD‚ˆˆHR$HòÄ®Ôiz:ÕýÏ}¯Â«îŠ=ƒòƒß9»3Õ]Uï¾pãw9îÿ=úý¹ý•÷CüŽkøF fÇ™÷süƒ“¶Ö ‚ÿ¤Ùßý(û6½ÁA @²âò¿ûiöeœ¼.	
@@ -3224,8 +3320,8 @@ Xv¸±Î™’þR¿ÇbhÓ£¸¦HÄ‹‰æÿÖÐ.Æ4óDÛÓúá*Á¼ÞN‰tBŒlò
 ëaë,øe}õi¿ZD{ó}áÛVŸ÷«Utr›Y"½Î©¯4ô1æ„Kë]§ZÇ£ºiÀëQá wI]?ÔŠÕÚÚ·÷½º~¤+ÉûHþŸwq]?Ñ•‹–yj—Ö·¾þÆ®;tçj}®r=Lp|uWì»TU³.LˆÚ"’s¹)q\zxAL{ì‹;×£¦ð‡{åuø^Œ˜ 0µ®¢Â…éuýÕÿu]zø
 endstream
 endobj
-377 0 obj
-<</Length 10757/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 395/Height 512/ColorSpace 297 0 R/BitsPerComponent 8/SMask 376 0 R>>
+418 0 obj
+<</Length 10757/Type/XObject/Subtype/Image/Filter/FlateDecode/Width 395/Height 512/ColorSpace 338 0 R/BitsPerComponent 8/SMask 417 0 R>>
 stream
 xœíœÙv$9ŽDùÿ?ÍyPŸ•"œÄ÷iZNf:3´Ô¬5ìÿ’-g†áËÕ4wÔ0à·Ó\SÃ0 _MsGÃ ~;Í55òÕ4×Ô0ø·ÓÜQÃ0À^MsMÃ€;Í5ìÕ4×Ô0ø·ÓÜQÃ0À^MsMÃ€;Í5ìÕô›ì†a€c#‘Æ0(lT²ƒ†!ûÄ£æ0¯Âðù¼I\‹ÃÐ›˜Û#¦Ë0m0¼4(÷Fp»aê’uWdõ†¡
 ¹·„a÷¹¦†¡87Ž’a@»õÌ55uA¾µÃàþ`¨p®©a¨B­·¾–ÚaÞö¾WÔ<Ã«^óêú‡aèýv÷p1Cã—ºŸ£ax']ßå®¾†á%¼á~ƒÇaèÇ{ÞÜ÷8†¾°…ÞÙZ†r¼ù=}³÷axÏëYú†y+3iC¿—±Ùû8±C.ó^™|†¡ô«×þí› †!’yãLbÃPèE{á»6¹þûõæWl2æÍ2d’´·i^¨ßLªÃ gÞ#W&ÛaÈ}wæ:3!—yk‚™´‡!òM™÷…ËÄ>gæÉeòïWcÞ%3…aðx#æ¥°b&2óÁ	œ™Ëðf¬Îÿ¼~ÌŒ†bxìçä0“^ÅørÌÈ†÷0G½"3µá%Ì!¯ËÌnhÏœðÒÌø†ÞÌÙnÀqèÊì6Ì‡~Ì‘îÄLshÆéfÌ4‡NÌÕŒ™æÐ‰¹ š1Ó:1T3fšC3æH·aþ¹ú1Gº3Ê¡sªÛ0£ú1§º3Ê¡sªÛ0£ú1§º3Ê¡sªÛ0£ú1§º3Ê¡sª;1£š1T'f”C3æ‚êÄŒrhÆ\P˜QÍ˜ª3Ê¡s¤;1Óš1Gú…ÓœU˜óÜ‰¹ †fÌyîÄ\PC3æ<wb.¨¡sž›1:1ç¹3Ð¡sžû13Ú0'¹sAm˜“Ü¹ †ÌInÉŒuèÁœä—u&; 3Ç¸+3Ù¡:s†3Ãª3g¸1ôáÎ|@úàËÂ¦“—á…Ô=½˜…D]åÃË)ttwqªD—¨s
@@ -3275,403 +3371,444 @@ V€×‚Ä),dafi Žµ@f<“€Ð‰kÜè®ÁRÂ_HÈÂÌÒ •žlúDƒÜ‚«8û­œí³r£KI~Á H²±.m,kŸ¿m!ö…ŠE
 P·”˜a@H¿ÒÃ NÖ‘Òt†¢D^‘½†ahCÀ½Ðb†Þ8Ý&eŸŠÃð*l¯‹kiî¥aþƒÉ•2WÓ0~èo˜¹†apen§a™«idæv†™¹†a@fn§a™Ûidæv†™¹š†a@fn§a™ÛiXæv†™¹ †a@fn§a™Ûidæv†™¹†a@fn§a™Ûidæv–5ÿ¥(ä
 endstream
 endobj
-378 0 obj
-<</Title(Sid Jain Resume)/Keywords(AI product engineer, Applied AI lead, staff full-stack engineer, founding engineer, TypeScript, React Native, Chromium, DNS)/Author(Sid Jain)/Creator(Typst 0.15.0)/ModDate(D:20260728024337Z)/CreationDate(D:20260728024337Z)>>
+419 0 obj
+<</Title(Sid Jain Resume)/Keywords(AI product engineer, Applied AI lead, staff full-stack engineer, founding engineer, TypeScript, React Native, Chromium, DNS)/Author(Sid Jain)/Creator(Typst 0.15.0)/ModDate(D:20260730002847Z)/CreationDate(D:20260730002847Z)>>
 endobj
-379 0 obj
+420 0 obj
 <</Length 4312/Type/Metadata/Subtype/XML>>
 stream
-<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/"  xmlns:pdfaExtension="http://www.aiim.org/pdfa/ns/extension/"  xmlns:pdfaSchema="http://www.aiim.org/pdfa/ns/schema#"  xmlns:pdfaProperty="http://www.aiim.org/pdfa/ns/property#" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Sid Jain Resume</rdf:li></rdf:Alt></dc:title><pdf:Keywords>AI product engineer, Applied AI lead, staff full-stack engineer, founding engineer, TypeScript, React Native, Chromium, DNS</pdf:Keywords><dc:creator><rdf:Seq><rdf:li>Sid Jain</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.15.0</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-07-28T02:43:37+00:00</xmp:ModifyDate><xmp:CreateDate>2026-07-28T02:43:37+00:00</xmp:CreateDate><xmpMM:History><rdf:Seq><rdf:li rdf:parseType="Resource"><stEvt:action>saved</stEvt:action><stEvt:when>2026-07-28T02:43:37+00:00</stEvt:when><stEvt:instanceID>1pqgYi9OeQnXcZy/uQpQCg==_source</stEvt:instanceID></rdf:li><rdf:li rdf:parseType="Resource"><stEvt:action>converted</stEvt:action><stEvt:when>2026-07-28T02:43:37+00:00</stEvt:when><stEvt:softwareAgent>Typst 0.15.0</stEvt:softwareAgent><stEvt:instanceID>1pqgYi9OeQnXcZy/uQpQCg==_source</stEvt:instanceID></rdf:li></rdf:Seq></xmpMM:History><pdfaExtension:schemas><rdf:Bag><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>XMP Media Management schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/xap/1.0/mm/</pdfaSchema:namespaceURI><pdfaSchema:prefix>xmpMM</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>UUID based identifier for specific incarnation of a document</pdfaProperty:description><pdfaProperty:name>InstanceID</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>Adobe PDF schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/pdf/1.3/</pdfaSchema:namespaceURI><pdfaSchema:prefix>pdf</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>external</pdfaProperty:category><pdfaProperty:description>Keywords associated with the document</pdfaProperty:description><pdfaProperty:name>Keywords</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Version of the PDF specification to which the document conforms</pdfaProperty:description><pdfaProperty:name>PDFVersion</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Name of the application that created the PDF document</pdfaProperty:description><pdfaProperty:name>Producer</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Whether the document has been trapped</pdfaProperty:description><pdfaProperty:name>Trapped</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li></rdf:Bag></pdfaExtension:schemas><pdfaid:part>2</pdfaid:part><pdfaid:conformance>U</pdfaid:conformance><xmpTPg:NPages>2</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>1pqgYi9OeQnXcZy/uQpQCg==</xmpMM:InstanceID><xmpMM:DocumentID>8WwkqRF/py529rYo68LIrg==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/"  xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/"  xmlns:pdfaExtension="http://www.aiim.org/pdfa/ns/extension/"  xmlns:pdfaSchema="http://www.aiim.org/pdfa/ns/schema#"  xmlns:pdfaProperty="http://www.aiim.org/pdfa/ns/property#" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Sid Jain Resume</rdf:li></rdf:Alt></dc:title><pdf:Keywords>AI product engineer, Applied AI lead, staff full-stack engineer, founding engineer, TypeScript, React Native, Chromium, DNS</pdf:Keywords><dc:creator><rdf:Seq><rdf:li>Sid Jain</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.15.0</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-07-30T00:28:47+00:00</xmp:ModifyDate><xmp:CreateDate>2026-07-30T00:28:47+00:00</xmp:CreateDate><xmpMM:History><rdf:Seq><rdf:li rdf:parseType="Resource"><stEvt:action>saved</stEvt:action><stEvt:when>2026-07-30T00:28:47+00:00</stEvt:when><stEvt:instanceID>QlBHk5HZQUNKaf3EmcHIpQ==_source</stEvt:instanceID></rdf:li><rdf:li rdf:parseType="Resource"><stEvt:action>converted</stEvt:action><stEvt:when>2026-07-30T00:28:47+00:00</stEvt:when><stEvt:softwareAgent>Typst 0.15.0</stEvt:softwareAgent><stEvt:instanceID>QlBHk5HZQUNKaf3EmcHIpQ==_source</stEvt:instanceID></rdf:li></rdf:Seq></xmpMM:History><pdfaExtension:schemas><rdf:Bag><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>XMP Media Management schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/xap/1.0/mm/</pdfaSchema:namespaceURI><pdfaSchema:prefix>xmpMM</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>UUID based identifier for specific incarnation of a document</pdfaProperty:description><pdfaProperty:name>InstanceID</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li><rdf:li rdf:parseType="Resource"><pdfaSchema:schema>Adobe PDF schema</pdfaSchema:schema><pdfaSchema:namespaceURI>http://ns.adobe.com/pdf/1.3/</pdfaSchema:namespaceURI><pdfaSchema:prefix>pdf</pdfaSchema:prefix><pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource"><pdfaProperty:category>external</pdfaProperty:category><pdfaProperty:description>Keywords associated with the document</pdfaProperty:description><pdfaProperty:name>Keywords</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Version of the PDF specification to which the document conforms</pdfaProperty:description><pdfaProperty:name>PDFVersion</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Name of the application that created the PDF document</pdfaProperty:description><pdfaProperty:name>Producer</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li><rdf:li rdf:parseType="Resource"><pdfaProperty:category>internal</pdfaProperty:category><pdfaProperty:description>Whether the document has been trapped</pdfaProperty:description><pdfaProperty:name>Trapped</pdfaProperty:name><pdfaProperty:valueType>Text</pdfaProperty:valueType></rdf:li></rdf:Seq></pdfaSchema:property></rdf:li></rdf:Bag></pdfaExtension:schemas><pdfaid:part>2</pdfaid:part><pdfaid:conformance>U</pdfaid:conformance><xmpTPg:NPages>2</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>QlBHk5HZQUNKaf3EmcHIpQ==</xmpMM:InstanceID><xmpMM:DocumentID>8WwkqRF/py529rYo68LIrg==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
-380 0 obj
-<</Type/Catalog/Pages 1 0 R/Metadata 379 0 R/OutputIntents 3 0 R/Lang(en)/StructTreeRoot 4 0 R/MarkInfo<</Marked true/Suspects false>>/ViewerPreferences<</Direction/L2R>>>>
+421 0 obj
+<</Type/Catalog/Pages 1 0 R/Metadata 420 0 R/OutputIntents 3 0 R/Lang(en)/StructTreeRoot 4 0 R/MarkInfo<</Marked true/Suspects false>>/ViewerPreferences<</Direction/L2R>>>>
 endobj
 xref
-0 381
+0 422
 0000000000 65535 f
 0000000016 00000 n
 0000000077 00000 n
 0000000240 00000 n
 0000000263 00000 n
 0000000463 00000 n
-0000001094 00000 n
-0000001695 00000 n
-0000001797 00000 n
-0000001857 00000 n
-0000001958 00000 n
-0000002019 00000 n
-0000002125 00000 n
-0000002231 00000 n
-0000002337 00000 n
-0000002411 00000 n
-0000002473 00000 n
-0000002549 00000 n
-0000002658 00000 n
-0000002725 00000 n
-0000002830 00000 n
-0000002892 00000 n
-0000002959 00000 n
-0000003026 00000 n
-0000003129 00000 n
-0000003191 00000 n
-0000003294 00000 n
-0000003356 00000 n
-0000003425 00000 n
-0000003487 00000 n
-0000003590 00000 n
-0000003652 00000 n
-0000003721 00000 n
-0000003824 00000 n
-0000003886 00000 n
+0000001121 00000 n
+0000001762 00000 n
+0000001864 00000 n
+0000001924 00000 n
+0000002025 00000 n
+0000002086 00000 n
+0000002192 00000 n
+0000002298 00000 n
+0000002404 00000 n
+0000002478 00000 n
+0000002540 00000 n
+0000002616 00000 n
+0000002727 00000 n
+0000002795 00000 n
+0000002900 00000 n
+0000002962 00000 n
+0000003065 00000 n
+0000003127 00000 n
+0000003230 00000 n
+0000003292 00000 n
+0000003361 00000 n
+0000003428 00000 n
+0000003531 00000 n
+0000003593 00000 n
+0000003696 00000 n
+0000003758 00000 n
+0000003827 00000 n
+0000003889 00000 n
 0000003992 00000 n
 0000004054 00000 n
 0000004123 00000 n
 0000004226 00000 n
 0000004288 00000 n
-0000004397 00000 n
-0000004459 00000 n
-0000004528 00000 n
-0000004631 00000 n
-0000004693 00000 n
-0000004799 00000 n
-0000004861 00000 n
-0000004930 00000 n
-0000005033 00000 n
-0000005095 00000 n
-0000005204 00000 n
-0000005266 00000 n
-0000005335 00000 n
-0000005439 00000 n
-0000005509 00000 n
-0000005614 00000 n
-0000005676 00000 n
-0000005743 00000 n
-0000005810 00000 n
-0000005913 00000 n
-0000005975 00000 n
-0000006078 00000 n
-0000006140 00000 n
-0000006243 00000 n
-0000006305 00000 n
-0000006381 00000 n
-0000006443 00000 n
-0000006546 00000 n
-0000006608 00000 n
-0000006677 00000 n
-0000006780 00000 n
-0000006842 00000 n
-0000006948 00000 n
-0000007010 00000 n
-0000007079 00000 n
-0000007182 00000 n
-0000007244 00000 n
-0000007353 00000 n
-0000007415 00000 n
-0000007484 00000 n
-0000007587 00000 n
-0000007649 00000 n
-0000007755 00000 n
-0000007817 00000 n
-0000007886 00000 n
-0000007989 00000 n
-0000008051 00000 n
-0000008157 00000 n
-0000008219 00000 n
-0000008288 00000 n
-0000008392 00000 n
-0000008462 00000 n
-0000008567 00000 n
-0000008630 00000 n
-0000008698 00000 n
-0000008766 00000 n
-0000008869 00000 n
-0000008932 00000 n
-0000009035 00000 n
-0000009098 00000 n
-0000009202 00000 n
-0000009266 00000 n
-0000009345 00000 n
-0000009410 00000 n
-0000009515 00000 n
-0000009580 00000 n
-0000009653 00000 n
-0000009725 00000 n
-0000009832 00000 n
-0000009897 00000 n
-0000010011 00000 n
-0000010076 00000 n
-0000010149 00000 n
-0000010256 00000 n
-0000010321 00000 n
-0000010435 00000 n
-0000010500 00000 n
-0000010573 00000 n
-0000010680 00000 n
-0000010745 00000 n
-0000010859 00000 n
-0000010924 00000 n
-0000010997 00000 n
-0000011104 00000 n
-0000011169 00000 n
-0000011283 00000 n
-0000011348 00000 n
-0000011421 00000 n
-0000011528 00000 n
-0000011593 00000 n
-0000011707 00000 n
-0000011772 00000 n
-0000011845 00000 n
-0000011972 00000 n
-0000012044 00000 n
-0000012150 00000 n
-0000012215 00000 n
-0000012283 00000 n
-0000012351 00000 n
-0000012455 00000 n
-0000012520 00000 n
-0000012624 00000 n
-0000012689 00000 n
-0000012793 00000 n
-0000012858 00000 n
-0000012939 00000 n
-0000013004 00000 n
-0000013108 00000 n
-0000013173 00000 n
-0000013246 00000 n
-0000013350 00000 n
-0000013415 00000 n
-0000013521 00000 n
-0000013586 00000 n
-0000013659 00000 n
-0000013764 00000 n
-0000013829 00000 n
-0000013937 00000 n
-0000014002 00000 n
-0000014075 00000 n
-0000014172 00000 n
-0000014245 00000 n
-0000014352 00000 n
-0000014417 00000 n
-0000014486 00000 n
-0000014555 00000 n
-0000014660 00000 n
-0000014725 00000 n
-0000014830 00000 n
-0000014895 00000 n
-0000014968 00000 n
-0000015033 00000 n
-0000015138 00000 n
-0000015203 00000 n
-0000015276 00000 n
-0000015381 00000 n
-0000015446 00000 n
-0000015554 00000 n
-0000015619 00000 n
-0000015692 00000 n
-0000015797 00000 n
-0000015862 00000 n
-0000015970 00000 n
-0000016035 00000 n
-0000016108 00000 n
-0000016205 00000 n
-0000016278 00000 n
-0000016385 00000 n
-0000016450 00000 n
-0000016519 00000 n
-0000016588 00000 n
-0000016693 00000 n
+0000004394 00000 n
+0000004456 00000 n
+0000004525 00000 n
+0000004628 00000 n
+0000004690 00000 n
+0000004796 00000 n
+0000004858 00000 n
+0000004927 00000 n
+0000005030 00000 n
+0000005092 00000 n
+0000005198 00000 n
+0000005260 00000 n
+0000005329 00000 n
+0000005432 00000 n
+0000005494 00000 n
+0000005600 00000 n
+0000005662 00000 n
+0000005731 00000 n
+0000005834 00000 n
+0000005896 00000 n
+0000006002 00000 n
+0000006064 00000 n
+0000006133 00000 n
+0000006244 00000 n
+0000006314 00000 n
+0000006419 00000 n
+0000006482 00000 n
+0000006585 00000 n
+0000006647 00000 n
+0000006750 00000 n
+0000006812 00000 n
+0000006882 00000 n
+0000006950 00000 n
+0000007053 00000 n
+0000007115 00000 n
+0000007218 00000 n
+0000007280 00000 n
+0000007383 00000 n
+0000007445 00000 n
+0000007521 00000 n
+0000007583 00000 n
+0000007686 00000 n
+0000007748 00000 n
+0000007818 00000 n
+0000007921 00000 n
+0000007983 00000 n
+0000008089 00000 n
+0000008151 00000 n
+0000008221 00000 n
+0000008324 00000 n
+0000008386 00000 n
+0000008492 00000 n
+0000008554 00000 n
+0000008624 00000 n
+0000008727 00000 n
+0000008789 00000 n
+0000008895 00000 n
+0000008957 00000 n
+0000009027 00000 n
+0000009130 00000 n
+0000009193 00000 n
+0000009300 00000 n
+0000009364 00000 n
+0000009436 00000 n
+0000009543 00000 n
+0000009615 00000 n
+0000009722 00000 n
+0000009787 00000 n
+0000009892 00000 n
+0000009957 00000 n
+0000010062 00000 n
+0000010127 00000 n
+0000010200 00000 n
+0000010269 00000 n
+0000010374 00000 n
+0000010439 00000 n
+0000010544 00000 n
+0000010609 00000 n
+0000010714 00000 n
+0000010779 00000 n
+0000010860 00000 n
+0000010925 00000 n
+0000011030 00000 n
+0000011095 00000 n
+0000011168 00000 n
+0000011240 00000 n
+0000011347 00000 n
+0000011412 00000 n
+0000011526 00000 n
+0000011591 00000 n
+0000011664 00000 n
+0000011771 00000 n
+0000011836 00000 n
+0000011950 00000 n
+0000012015 00000 n
+0000012088 00000 n
+0000012195 00000 n
+0000012260 00000 n
+0000012371 00000 n
+0000012436 00000 n
+0000012509 00000 n
+0000012616 00000 n
+0000012681 00000 n
+0000012795 00000 n
+0000012860 00000 n
+0000012933 00000 n
+0000013040 00000 n
+0000013105 00000 n
+0000013219 00000 n
+0000013284 00000 n
+0000013357 00000 n
+0000013486 00000 n
+0000013559 00000 n
+0000013665 00000 n
+0000013730 00000 n
+0000013834 00000 n
+0000013899 00000 n
+0000014003 00000 n
+0000014068 00000 n
+0000014141 00000 n
+0000014209 00000 n
+0000014313 00000 n
+0000014378 00000 n
+0000014482 00000 n
+0000014547 00000 n
+0000014651 00000 n
+0000014716 00000 n
+0000014797 00000 n
+0000014862 00000 n
+0000014966 00000 n
+0000015031 00000 n
+0000015104 00000 n
+0000015208 00000 n
+0000015273 00000 n
+0000015380 00000 n
+0000015445 00000 n
+0000015518 00000 n
+0000015623 00000 n
+0000015688 00000 n
+0000015796 00000 n
+0000015861 00000 n
+0000015934 00000 n
+0000016031 00000 n
+0000016104 00000 n
+0000016211 00000 n
+0000016276 00000 n
+0000016381 00000 n
+0000016446 00000 n
+0000016551 00000 n
+0000016616 00000 n
+0000016689 00000 n
 0000016758 00000 n
 0000016863 00000 n
 0000016928 00000 n
-0000017001 00000 n
-0000017066 00000 n
-0000017171 00000 n
-0000017236 00000 n
-0000017309 00000 n
+0000017033 00000 n
+0000017098 00000 n
+0000017203 00000 n
+0000017268 00000 n
+0000017349 00000 n
 0000017414 00000 n
-0000017479 00000 n
-0000017587 00000 n
-0000017652 00000 n
-0000017725 00000 n
-0000017830 00000 n
-0000017895 00000 n
+0000017519 00000 n
+0000017584 00000 n
+0000017657 00000 n
+0000017762 00000 n
+0000017827 00000 n
+0000017935 00000 n
 0000018000 00000 n
-0000018065 00000 n
-0000018138 00000 n
-0000018235 00000 n
-0000018308 00000 n
-0000018415 00000 n
-0000018480 00000 n
-0000018549 00000 n
-0000018618 00000 n
-0000018723 00000 n
-0000018788 00000 n
-0000018893 00000 n
-0000018958 00000 n
-0000019031 00000 n
-0000019096 00000 n
-0000019201 00000 n
-0000019266 00000 n
-0000019339 00000 n
-0000019444 00000 n
-0000019509 00000 n
-0000019617 00000 n
-0000019682 00000 n
-0000019755 00000 n
-0000019860 00000 n
-0000019925 00000 n
-0000020036 00000 n
-0000020101 00000 n
-0000020174 00000 n
-0000020279 00000 n
-0000020344 00000 n
-0000020449 00000 n
-0000020514 00000 n
-0000020587 00000 n
-0000020692 00000 n
-0000020765 00000 n
-0000020872 00000 n
-0000020937 00000 n
-0000021006 00000 n
-0000021075 00000 n
-0000021180 00000 n
-0000021245 00000 n
-0000021350 00000 n
-0000021415 00000 n
-0000021488 00000 n
-0000021553 00000 n
-0000021658 00000 n
-0000021723 00000 n
-0000021796 00000 n
-0000021901 00000 n
-0000021966 00000 n
-0000022074 00000 n
-0000022139 00000 n
-0000022212 00000 n
-0000022317 00000 n
-0000022382 00000 n
-0000022487 00000 n
-0000022552 00000 n
-0000022625 00000 n
-0000022722 00000 n
-0000022795 00000 n
-0000022864 00000 n
-0000022971 00000 n
-0000023036 00000 n
+0000018073 00000 n
+0000018178 00000 n
+0000018243 00000 n
+0000018351 00000 n
+0000018416 00000 n
+0000018489 00000 n
+0000018586 00000 n
+0000018659 00000 n
+0000018766 00000 n
+0000018831 00000 n
+0000018936 00000 n
+0000019001 00000 n
+0000019106 00000 n
+0000019171 00000 n
+0000019244 00000 n
+0000019313 00000 n
+0000019418 00000 n
+0000019483 00000 n
+0000019588 00000 n
+0000019653 00000 n
+0000019726 00000 n
+0000019791 00000 n
+0000019896 00000 n
+0000019961 00000 n
+0000020034 00000 n
+0000020139 00000 n
+0000020204 00000 n
+0000020312 00000 n
+0000020377 00000 n
+0000020450 00000 n
+0000020555 00000 n
+0000020620 00000 n
+0000020725 00000 n
+0000020790 00000 n
+0000020863 00000 n
+0000020960 00000 n
+0000021033 00000 n
+0000021140 00000 n
+0000021205 00000 n
+0000021310 00000 n
+0000021375 00000 n
+0000021480 00000 n
+0000021545 00000 n
+0000021618 00000 n
+0000021687 00000 n
+0000021792 00000 n
+0000021857 00000 n
+0000021962 00000 n
+0000022027 00000 n
+0000022100 00000 n
+0000022165 00000 n
+0000022270 00000 n
+0000022335 00000 n
+0000022408 00000 n
+0000022513 00000 n
+0000022578 00000 n
+0000022686 00000 n
+0000022751 00000 n
+0000022824 00000 n
+0000022929 00000 n
+0000022994 00000 n
 0000023105 00000 n
-0000023174 00000 n
-0000023279 00000 n
-0000023344 00000 n
-0000023409 00000 n
-0000023474 00000 n
-0000023579 00000 n
-0000023644 00000 n
-0000023717 00000 n
-0000023798 00000 n
-0000023871 00000 n
-0000023978 00000 n
-0000024043 00000 n
-0000024112 00000 n
-0000024181 00000 n
-0000024286 00000 n
-0000024351 00000 n
-0000024416 00000 n
-0000024481 00000 n
-0000024586 00000 n
-0000024651 00000 n
-0000024724 00000 n
-0000024805 00000 n
-0000024878 00000 n
-0000025045 00000 n
-0000025254 00000 n
-0000025471 00000 n
-0000025679 00000 n
-0000025716 00000 n
-0000025994 00000 n
-0000026239 00000 n
-0000026381 00000 n
-0000026649 00000 n
-0000026859 00000 n
-0000027005 00000 n
-0000027707 00000 n
-0000027924 00000 n
-0000028069 00000 n
-0000028956 00000 n
-0000029172 00000 n
-0000029314 00000 n
-0000029638 00000 n
-0000029848 00000 n
-0000029990 00000 n
-0000030605 00000 n
-0000030816 00000 n
-0000030956 00000 n
-0000031614 00000 n
-0000031826 00000 n
-0000031968 00000 n
-0000032188 00000 n
-0000032399 00000 n
-0000032557 00000 n
-0000032676 00000 n
-0000032753 00000 n
-0000033218 00000 n
-0000034836 00000 n
-0000034918 00000 n
-0000035576 00000 n
-0000044079 00000 n
-0000044161 00000 n
-0000044904 00000 n
-0000055502 00000 n
-0000055581 00000 n
-0000056073 00000 n
-0000058309 00000 n
-0000058392 00000 n
-0000059014 00000 n
-0000063983 00000 n
-0000064064 00000 n
-0000064700 00000 n
-0000072461 00000 n
-0000072538 00000 n
-0000072969 00000 n
-0000076410 00000 n
-0000082636 00000 n
-0000087399 00000 n
-0000087806 00000 n
-0000093147 00000 n
-0000220818 00000 n
-0000224275 00000 n
-0000231731 00000 n
-0000242153 00000 n
-0000275608 00000 n
-0000278550 00000 n
-0000281221 00000 n
-0000284594 00000 n
-0000291647 00000 n
-0000299691 00000 n
-0000395493 00000 n
-0000404210 00000 n
-0000409735 00000 n
-0000414449 00000 n
-0000418460 00000 n
-0000422832 00000 n
-0000425420 00000 n
-0000431015 00000 n
-0000434301 00000 n
-0000438440 00000 n
-0000442396 00000 n
-0000452654 00000 n
-0000459353 00000 n
-0000478776 00000 n
-0000485310 00000 n
-0000489185 00000 n
-0000495370 00000 n
-0000498583 00000 n
-0000531566 00000 n
-0000542495 00000 n
-0000542772 00000 n
-0000547162 00000 n
+0000023170 00000 n
+0000023243 00000 n
+0000023348 00000 n
+0000023413 00000 n
+0000023518 00000 n
+0000023583 00000 n
+0000023656 00000 n
+0000023761 00000 n
+0000023834 00000 n
+0000023941 00000 n
+0000024006 00000 n
+0000024111 00000 n
+0000024176 00000 n
+0000024241 00000 n
+0000024310 00000 n
+0000024415 00000 n
+0000024480 00000 n
+0000024585 00000 n
+0000024650 00000 n
+0000024723 00000 n
+0000024788 00000 n
+0000024893 00000 n
+0000024958 00000 n
+0000025031 00000 n
+0000025136 00000 n
+0000025201 00000 n
+0000025309 00000 n
+0000025374 00000 n
+0000025447 00000 n
+0000025552 00000 n
+0000025617 00000 n
+0000025722 00000 n
+0000025787 00000 n
+0000025860 00000 n
+0000025957 00000 n
+0000026030 00000 n
+0000026099 00000 n
+0000026206 00000 n
+0000026271 00000 n
+0000026376 00000 n
+0000026441 00000 n
+0000026506 00000 n
+0000026575 00000 n
+0000026680 00000 n
+0000026745 00000 n
+0000026810 00000 n
+0000026875 00000 n
+0000026980 00000 n
+0000027045 00000 n
+0000027118 00000 n
+0000027199 00000 n
+0000027272 00000 n
+0000027379 00000 n
+0000027444 00000 n
+0000027549 00000 n
+0000027614 00000 n
+0000027679 00000 n
+0000027748 00000 n
+0000027853 00000 n
+0000027918 00000 n
+0000027983 00000 n
+0000028048 00000 n
+0000028153 00000 n
+0000028218 00000 n
+0000028291 00000 n
+0000028372 00000 n
+0000028445 00000 n
+0000028613 00000 n
+0000028822 00000 n
+0000029039 00000 n
+0000029247 00000 n
+0000029284 00000 n
+0000029562 00000 n
+0000029807 00000 n
+0000029949 00000 n
+0000030217 00000 n
+0000030427 00000 n
+0000030573 00000 n
+0000031305 00000 n
+0000031522 00000 n
+0000031667 00000 n
+0000032584 00000 n
+0000032800 00000 n
+0000032942 00000 n
+0000033266 00000 n
+0000033476 00000 n
+0000033618 00000 n
+0000034233 00000 n
+0000034444 00000 n
+0000034584 00000 n
+0000035242 00000 n
+0000035454 00000 n
+0000035596 00000 n
+0000035816 00000 n
+0000036027 00000 n
+0000036185 00000 n
+0000036304 00000 n
+0000036381 00000 n
+0000036846 00000 n
+0000038464 00000 n
+0000038544 00000 n
+0000039218 00000 n
+0000048004 00000 n
+0000048085 00000 n
+0000048846 00000 n
+0000059519 00000 n
+0000059598 00000 n
+0000060090 00000 n
+0000062326 00000 n
+0000062409 00000 n
+0000063031 00000 n
+0000068000 00000 n
+0000068081 00000 n
+0000068717 00000 n
+0000076478 00000 n
+0000076555 00000 n
+0000076986 00000 n
+0000080427 00000 n
+0000087110 00000 n
+0000092299 00000 n
+0000092706 00000 n
+0000098047 00000 n
+0000225718 00000 n
+0000229175 00000 n
+0000236631 00000 n
+0000247053 00000 n
+0000280508 00000 n
+0000283450 00000 n
+0000286121 00000 n
+0000289494 00000 n
+0000296547 00000 n
+0000304591 00000 n
+0000400393 00000 n
+0000409110 00000 n
+0000414635 00000 n
+0000419349 00000 n
+0000423360 00000 n
+0000427732 00000 n
+0000430320 00000 n
+0000435915 00000 n
+0000439201 00000 n
+0000443340 00000 n
+0000447296 00000 n
+0000457554 00000 n
+0000464253 00000 n
+0000483676 00000 n
+0000490210 00000 n
+0000494085 00000 n
+0000500270 00000 n
+0000503483 00000 n
+0000536466 00000 n
+0000547395 00000 n
+0000547672 00000 n
+0000552062 00000 n
 trailer
-<</Size 381/Root 380 0 R/Info 378 0 R/ID[(8WwkqRF/py529rYo68LIrg==)(1pqgYi9OeQnXcZy/uQpQCg==)]>>
+<</Size 422/Root 421 0 R/Info 419 0 R/ID[(8WwkqRF/py529rYo68LIrg==)(QlBHk5HZQUNKaf3EmcHIpQ==)]>>
 startxref
-547352
+552252
 %%EOF

--- a/scripts/build-resume-pdf.ts
+++ b/scripts/build-resume-pdf.ts
@@ -2,9 +2,15 @@ import { execFileSync } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { resumeData, resumeRoleMarkerLabels } from "../src/content/resume";
+import {
+  formatResumeLocation,
+  resumeCompanyStageLabels,
+  resumeData,
+  resumeRoleMarkerLabels,
+} from "../src/content/resume";
 import type {
   LogoAsset,
+  ResumeCompanyStage,
   ResumeExperience,
   ResumeRole,
   ResumeRoleMarker,
@@ -65,8 +71,9 @@ const pdfOnly = {
     32 / 3 / (10 * CSS_PX_TO_PT)
   ),
   contactStackHeight: pt(32),
-  companyTaglineGap: pt(-6),
-  experienceItemGap: spacing[4],
+  companyTaglineGap: pt(-3.75),
+  experienceItemGap: spacing[3],
+  markerInsetY: cssPxToPt(4),
   pageMargin: "0.58in",
   profileAvatarSize: fontSize["5xl"],
   roleBodyGap: cssPxToPt(3),
@@ -133,7 +140,7 @@ const roleMarker = (marker: ResumeRoleMarker) => {
   const details = roleMarkerDetails[marker];
 
   return `#box(
-  inset: (x: ${pt(4)}, y: ${pt(1.5)}),
+  inset: (x: ${pt(4)}, y: ${pdfOnly.markerInsetY}),
   radius: ${pt(8)},
   fill: rgb(${quote(details.fill)}),
   stroke: ${pt(0.75)} + rgb(${quote(details.stroke)}),
@@ -143,6 +150,17 @@ const roleMarker = (marker: ResumeRoleMarker) => {
     weight: "medium",
   })}]`;
 };
+
+const companyStageMarker = (stage: ResumeCompanyStage) => `#box(
+  inset: (x: ${pt(4)}, y: ${pdfOnly.markerInsetY}),
+  radius: ${pt(8)},
+  fill: rgb("#242220"),
+  stroke: ${pt(0.75)} + rgb("#57534e"),
+)[${text(resumeCompanyStageLabels[stage], {
+  fill: `rgb(${quote("#c7c2bd")})`,
+  size: fontSize.marker,
+  weight: "medium",
+})}]`;
 
 const sizeFromClass = (
   className: string | undefined,
@@ -268,9 +286,17 @@ const bulletContent = (bullet: NonNullable<ResumeRole["bullets"]>[number]) => {
 const stack = (items: string[], gap = spacing[0.5]) =>
   items.join(`\n#v(${gap})\n`);
 
+interface SectionTitleOptions {
+  after?: string;
+  before?: string;
+}
+
 const sectionTitle = (
   title: string,
-  { after = pdfOnly.sectionTitleAfterGap, before = spacing[8] } = {}
+  {
+    after = pdfOnly.sectionTitleAfterGap,
+    before = spacing[8],
+  }: SectionTitleOptions = {}
 ) => `
 #v(${before})
 ${text(title, {
@@ -313,8 +339,28 @@ interface PdfSectionItem {
   pageBreakBefore: boolean;
 }
 
-const experienceItem = (item: ResumeExperience): PdfSectionItem => ({
-  content: `
+const experienceItem = (item: ResumeExperience): PdfSectionItem => {
+  const companyHeadingItems = [
+    text(item.company, {
+      fill: "strong",
+      font: "Literata",
+      kerning: false,
+      size: fontSize.base,
+      weight: "bold",
+    }),
+    ...(item.companyStage === undefined
+      ? []
+      : [companyStageMarker(item.companyStage)]),
+  ];
+  const companyHeading = `#grid(
+  columns: (${companyHeadingItems.map(() => "auto").join(", ")}),
+  gutter: ${pt(5)},
+  align: horizon,
+  ${companyHeadingItems.map((headingItem) => `[${headingItem}]`).join(",\n  ")}
+)`;
+
+  return {
+    content: `
 #block(breakable: false)[
 #grid(
   columns: (${spacing[10]}, 1fr),
@@ -322,13 +368,7 @@ const experienceItem = (item: ResumeExperience): PdfSectionItem => ({
   align: top,
   [${companyLogo(item.logo)}],
   [
-    ${text(item.company, {
-      fill: "strong",
-      font: "Literata",
-      kerning: false,
-      size: fontSize.base,
-      weight: "bold",
-    })}
+    ${companyHeading}
     #v(${pdfOnly.companyTaglineGap})
     ${text(item.tagline, { size: fontSize.xs, style: "italic" })}
     ${item.roles.map(roleBlock).join("\n")}
@@ -336,8 +376,9 @@ const experienceItem = (item: ResumeExperience): PdfSectionItem => ({
 )
 ]
 `,
-  pageBreakBefore: item.pdfPageBreakBefore === true,
-});
+    pageBreakBefore: item.pdfPageBreakBefore === true,
+  };
+};
 
 const sectionWithItems = (
   title: string,
@@ -366,9 +407,10 @@ ${remainingItems
 };
 
 const buildTypst = () => {
-  const contactLinks = resumeData.links
-    .map((item) =>
-      link(item.label, item.href, {
+  // Preserve a word boundary for Preview/ATS extractors between the name and first contact link.
+  const contactLines = resumeData.links
+    .map((item, index) =>
+      link(index === 0 ? ` ${item.label}` : item.label, item.href, {
         size: cssPxToPt(10),
         weight: "medium",
       })
@@ -415,7 +457,7 @@ const buildTypst = () => {
   align: top,
   [#profile-photo(${quote(profileAvatar)})],
   [#box(height: ${pdfOnly.profileAvatarSize})[#align(left + horizon)[${text(
-    resumeData.person.name,
+    `${resumeData.person.name} `,
     {
       fill: "strong",
       font: "Literata",
@@ -426,14 +468,18 @@ const buildTypst = () => {
   [#align(right)[#box(height: ${pdfOnly.profileAvatarSize})[#align(right + horizon)[#box(height: ${pdfOnly.contactStackHeight})[
       #set par(leading: ${pdfOnly.contactLinkLeading})
       #align(right)[
-      ${contactLinks}
+      ${contactLines}
       ]
     ]]]]],
 )
   #v(${spacing[1]})
   ${paragraph(resumeData.summary)}
+  #v(${spacing[1]})
+  ${paragraph(formatResumeLocation(resumeData.person))}
 
-  ${sectionWithItems("Experience", experience, { before: spacing[4] })}
+  ${sectionWithItems("Experience", experience, {
+    before: spacing[2],
+  })}
 
   ${sectionWithItems("Education", education)}
 ]

--- a/src/app/(blog)/blog/[slug]/page.tsx
+++ b/src/app/(blog)/blog/[slug]/page.tsx
@@ -7,6 +7,7 @@ import AuthorCard from "@/components/blog/AuthorCard";
 import PostCard from "@/components/blog/PostCard";
 import { JsonLd } from "@/components/json-ld";
 import MDXImage from "@/components/mdx/MDXImage";
+import { SiteMain } from "@/components/site-page";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -153,30 +154,32 @@ export default async function BlogPostPage({ params }: { params: PageParams }) {
   } satisfies MDXComponents;
 
   return (
-    <article className="relative">
+    <SiteMain className="relative">
       <JsonLd data={jsonLd} />
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 py-16">
-        <header className="flex flex-col gap-6">
+      <article className="flex flex-col gap-12">
+        <header className="flex max-w-4xl flex-col gap-6">
           {metadata.tags !== undefined && metadata.tags.length > 0 ? (
             <div className="flex flex-wrap gap-2">
               {metadata.tags.map((tag) => (
-                <Badge key={tag} variant="secondary">
+                <Badge key={tag} variant="tag">
                   {tag}
                 </Badge>
               ))}
             </div>
           ) : null}
           <div className="space-y-4">
-            <h1 className="text-balance text-4xl font-semibold tracking-tight md:text-5xl">
+            <h1 className="text-balance max-w-4xl font-serif text-3xl font-bold tracking-tight sm:text-4xl">
               {metadata.title}
             </h1>
-            <p className="max-w-3xl text-base text-muted-foreground md:text-lg">
+            <p className="max-w-3xl text-base text-muted-foreground">
               {metadata.summary}
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
             <span>
-              <time dateTime={date.toISOString()}>{formatDate(date)}</time>
+              <time dateTime={date.toISOString()}>
+                {formatDate(date, siteConfig.language)}
+              </time>
             </span>
             <Separator orientation="vertical" className="h-4" />
             <span>{metadata.author}</span>
@@ -187,26 +190,25 @@ export default async function BlogPostPage({ params }: { params: PageParams }) {
             {updatedAt === undefined ? null : (
               <>
                 <Separator orientation="vertical" className="h-4" />
-                <span>Updated {formatDate(updatedAt)}</span>
+                <span>
+                  Updated {formatDate(updatedAt, siteConfig.language)}
+                </span>
               </>
             )}
           </div>
         </header>
-        <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_280px]">
-          <div className="prose prose-neutral max-w-[70ch] dark:prose-invert prose-headings:scroll-mt-24 prose-h2:text-2xl prose-h3:text-xl prose-lead:text-muted-foreground prose-a:text-foreground/90 prose-strong:text-foreground prose-p:leading-relaxed prose-li:marker:text-muted-foreground/70">
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_240px]">
+          <div className="prose max-w-[70ch] prose-h2:text-2xl prose-h3:text-xl prose-p:leading-relaxed">
             <Content components={mdxComponents} />
           </div>
           <aside className="space-y-6 lg:sticky lg:top-24">
             <AuthorCard />
-            <div className="rounded-xl border border-border/70 bg-muted/40 p-5 text-sm text-muted-foreground">
-              Sid writes about engineering, product, AI, and creative work.
-            </div>
           </aside>
         </div>
         {suggestedPosts.length > 0 ? (
           <section className="space-y-6">
             <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold tracking-tight">
+              <h2 className="font-serif text-xl font-bold tracking-tight">
                 Suggested next posts
               </h2>
             </div>
@@ -217,7 +219,7 @@ export default async function BlogPostPage({ params }: { params: PageParams }) {
             </div>
           </section>
         ) : null}
-      </div>
-    </article>
+      </article>
+    </SiteMain>
   );
 }

--- a/src/app/(blog)/blog/page.tsx
+++ b/src/app/(blog)/blog/page.tsx
@@ -1,9 +1,12 @@
+import { Rss } from "lucide-react";
 import type { Metadata } from "next";
+import Link from "next/link";
 
-import PostCard from "@/components/blog/PostCard";
 import { JsonLd } from "@/components/json-ld";
-import { Separator } from "@/components/ui/separator";
+import { SiteActionLink } from "@/components/site-action-link";
+import { SitePage } from "@/components/site-page";
 import { getBlogPosts } from "@/lib/blog-utils";
+import { formatDate } from "@/lib/date";
 import { publicUrl, siteConfig } from "@/lib/site";
 import { buildBlogCollectionJsonLd } from "@/lib/structured-data";
 
@@ -35,66 +38,46 @@ export const metadata: Metadata = {
 
 export default async function BlogIndexPage() {
   const posts = await getBlogPosts();
-  const [featured, ...rest] = posts;
 
   return (
-    <main className="relative">
+    <>
       <JsonLd data={buildBlogCollectionJsonLd(posts)} />
-      <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,rgba(120,120,120,0.12),transparent_55%)]" />
-      <section className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-6 py-16">
-        <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-end">
-          <div className="space-y-6">
-            <div className="space-y-3">
-              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-muted-foreground">
-                Journal
-              </p>
-              <h1 className="text-balance text-4xl font-semibold tracking-tight md:text-5xl">
-                Writing about craft, experiments, and what I am learning.
-              </h1>
-              <p className="max-w-xl text-base text-muted-foreground md:text-lg">
-                Notes on what {siteConfig.author.name} is building across
-                product design, engineering, and creative development.
-              </p>
-            </div>
-            <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
-              <span>{posts.length} posts</span>
-              <Separator orientation="vertical" className="h-4" />
-              <span>New notes as they land</span>
-              <Separator orientation="vertical" className="h-4" />
-              <span>Deep dives + quick notes</span>
-            </div>
-          </div>
-          {featured === undefined ? (
-            <div className="rounded-xl border border-dashed border-border/70 p-10 text-sm text-muted-foreground">
-              First post coming soon.
-            </div>
-          ) : (
-            <PostCard post={featured} variant="featured" />
-          )}
-        </div>
-      </section>
-      <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 pb-20">
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold tracking-tight">
-            Latest writing
-          </h2>
-        </div>
-        {rest.length > 0 ? (
-          <div className="grid gap-6 md:grid-cols-2">
-            {rest.map((post) => (
-              <PostCard key={post.slug} post={post} />
+      <SitePage
+        title="Blog"
+        action={
+          <SiteActionLink
+            href="/rss.xml"
+            icon={<Rss aria-hidden="true" className="h-3.5 w-3.5" />}
+          >
+            RSS
+          </SiteActionLink>
+        }
+      >
+        {posts.length > 0 ? (
+          <ol className="divide-y divide-border border-y border-border">
+            {posts.map((post) => (
+              <li key={post.slug}>
+                <Link
+                  href={`/blog/${post.slug}`}
+                  className="group flex flex-col gap-1 py-5 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring sm:flex-row sm:items-baseline sm:justify-between sm:gap-6"
+                >
+                  <h2 className="font-serif text-xl font-bold tracking-tight transition-colors group-hover:text-brand-hover">
+                    {post.metadata.title}
+                  </h2>
+                  <time
+                    dateTime={post.date.toISOString()}
+                    className="shrink-0 text-sm text-muted-foreground"
+                  >
+                    {formatDate(post.date, siteConfig.language)}
+                  </time>
+                </Link>
+              </li>
             ))}
-          </div>
-        ) : posts.length > 0 ? (
-          <p className="text-sm text-muted-foreground">
-            More posts are on the way. In the meantime, check back soon.
-          </p>
+          </ol>
         ) : (
-          <p className="text-sm text-muted-foreground">
-            No posts yet. Check back soon.
-          </p>
+          <p className="text-sm text-muted-foreground">No posts yet.</p>
         )}
-      </section>
-    </main>
+      </SitePage>
+    </>
   );
 }

--- a/src/app/(blog)/layout.tsx
+++ b/src/app/(blog)/layout.tsx
@@ -1,39 +1,9 @@
-import Link from "next/link";
-
-import ThemeToggle from "@/components/ThemeToggle";
+import { SiteShell } from "@/components/site-shell";
 
 export default function BlogLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const navLinkClassName =
-    "inline-flex items-center rounded-md px-3 py-1.5 text-xs font-medium text-muted-foreground transition hover:bg-muted/60 hover:text-foreground";
-
-  return (
-    <div className="min-h-screen bg-background text-foreground">
-      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/80 backdrop-blur">
-        <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4">
-          <Link href="/blog" className="group">
-            <div className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground/80">
-              Journal
-            </div>
-            <div className="text-lg font-semibold tracking-tight transition group-hover:text-foreground/80">
-              F0RR0
-            </div>
-          </Link>
-          <div className="flex items-center gap-2">
-            <Link href="/rss.xml" className={navLinkClassName}>
-              RSS
-            </Link>
-            <Link href="/" className={navLinkClassName}>
-              Portfolio
-            </Link>
-            <ThemeToggle />
-          </div>
-        </div>
-      </header>
-      {children}
-    </div>
-  );
+  return <SiteShell activeHref="/blog">{children}</SiteShell>;
 }

--- a/src/app/(portfolio)/page.tsx
+++ b/src/app/(portfolio)/page.tsx
@@ -17,19 +17,19 @@ export const metadata: Metadata = {
     images: [resumeData.person.image],
     locale: siteConfig.locale,
     siteName: siteConfig.name,
-    title: "Sid Jain Resume",
+    title: "Sid Jain Résumé",
     type: "profile",
     url: publicUrl("/"),
   },
-  title: "Resume",
+  title: "Résumé",
   twitter: {
     card: "summary",
     description: resumeDescription,
     images: [resumeData.person.image],
-    title: "Sid Jain Resume",
+    title: "Sid Jain Résumé",
   },
 };
 
 export default function Home() {
-  return <ResumePageContent includeProfileJsonLd={false} showSiteNav={false} />;
+  return <ResumePageContent currentPath="/" includeProfileJsonLd={false} />;
 }

--- a/src/app/(portfolio)/resume/page.tsx
+++ b/src/app/(portfolio)/resume/page.tsx
@@ -1,9 +1,14 @@
 import type { Metadata } from "next";
-import { JetBrains_Mono, Literata, Source_Sans_3 } from "next/font/google";
-import Link from "next/link";
 
 import { JsonLd } from "@/components/json-ld";
-import { resumeData, resumeRoleMarkerLabels } from "@/content/resume";
+import { SitePage } from "@/components/site-page";
+import { SiteShell } from "@/components/site-shell";
+import {
+  formatResumeLocation,
+  resumeCompanyStageLabels,
+  resumeData,
+  resumeRoleMarkerLabels,
+} from "@/content/resume";
 import type {
   LogoAsset,
   ResumeExperience,
@@ -14,32 +19,9 @@ import { buildAskAgentLinks } from "@/lib/resume";
 import { publicUrl, siteConfig } from "@/lib/site";
 import { buildProfilePageJsonLd } from "@/lib/structured-data";
 
-import {
-  ResumeAskAgents,
-  ResumeMobileMenu,
-  ResumePrintButton,
-  ResumeThemeToggle,
-} from "./resume-controls";
+import { ResumeAskAgents, ResumeDownloadButton } from "./resume-controls";
 
 const resumeDescription = siteConfig.description;
-
-const literata = Literata({
-  subsets: ["latin"],
-  variable: "--resume-font-heading",
-  weight: ["400", "700"],
-});
-
-const sourceSans = Source_Sans_3({
-  subsets: ["latin"],
-  variable: "--resume-font-body",
-  weight: ["400", "600", "700"],
-});
-
-const jetBrainsMono = JetBrains_Mono({
-  subsets: ["latin"],
-  variable: "--resume-font-mono",
-  weight: ["400"],
-});
 
 export const metadata: Metadata = {
   alternates: {
@@ -51,35 +33,36 @@ export const metadata: Metadata = {
     images: [resumeData.person.image],
     locale: siteConfig.locale,
     siteName: siteConfig.name,
-    title: "Sid Jain Resume",
+    title: "Sid Jain Résumé",
     type: "profile",
     url: publicUrl("/resume"),
   },
-  title: "Resume",
+  title: "Résumé",
   twitter: {
     card: "summary",
     description: resumeDescription,
     images: [resumeData.person.image],
-    title: "Sid Jain Resume",
+    title: "Sid Jain Résumé",
   },
 };
 
-const { education, experience, links, navItems, summary } = resumeData;
+const { education, experience, links, person, summary } = resumeData;
 const askAgents = buildAskAgentLinks();
 const profileJsonLd = buildProfilePageJsonLd();
 
-const mutedText = "text-[#78716c] dark:text-[#a8a29e]";
+const mutedText = "text-muted-foreground";
+const resumeBodyText = `text-sm font-normal leading-[1.625] ${mutedText}`;
 const accentText =
-  "text-[#b45309] transition-colors hover:text-[#92400e] dark:text-[#d97706] dark:hover:text-[#f59e0b]";
+  "text-primary transition-colors hover:text-brand-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring";
 const roleMarkerDetails = {
   "hands-on": {
     className:
-      "border-[#e4c184] bg-[#f9ebd2] text-[#835018] dark:border-[#6a4b24] dark:bg-[#2b2319] dark:text-[#e8ae58]",
+      "border-hands-on-border bg-hands-on-background text-hands-on-foreground",
     description: "Hands-on engineering",
   },
   leadership: {
     className:
-      "border-[#d6c7cf] bg-[#f0eaee] text-[#66505f] dark:border-[#5b4b55] dark:bg-[#282328] dark:text-[#d8becd]",
+      "border-leadership-border bg-leadership-background text-leadership-foreground",
     description: "People and engineering leadership",
   },
 } satisfies Record<
@@ -88,8 +71,8 @@ const roleMarkerDetails = {
 >;
 
 interface ResumePageContentProps {
+  currentPath?: "/" | "/resume";
   includeProfileJsonLd?: boolean;
-  showSiteNav?: boolean;
 }
 
 function CompanyLogo({
@@ -99,7 +82,7 @@ function CompanyLogo({
 }>) {
   return (
     <div
-      className={`mt-1 flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full shadow-sm ring-1 ring-[#e7e5e4] dark:ring-[#3a3836] ${logo.tileClassName}`}
+      className={`mt-1 flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full shadow-sm ring-1 ring-border ${logo.tileClassName}`}
       aria-hidden="true"
     >
       <img
@@ -118,7 +101,7 @@ function BulletLogo({
 }>) {
   return (
     <span
-      className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-full ring-1 ring-[#e7e5e4] dark:ring-[#3a3836] ${logo.tileClassName}`}
+      className={`mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-full ring-1 ring-border ${logo.tileClassName}`}
       aria-hidden="true"
       title={logo.alt}
     >
@@ -135,9 +118,7 @@ function BulletLogo({
 
 function SectionTitle({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <h2 className="font-[family-name:var(--resume-font-heading)] text-xl font-bold text-[#292524] dark:text-[#e7e5e4]">
-      {children}
-    </h2>
+    <h2 className="font-serif text-xl font-bold text-foreground">{children}</h2>
   );
 }
 
@@ -147,7 +128,7 @@ function RoleMarkers({ role }: Readonly<{ role: ResumeRole }>) {
   }
 
   return (
-    <span className="order-3 mt-2 inline-flex flex-wrap items-center gap-1 sm:order-none sm:mt-0">
+    <span className="order-3 mt-2 inline-flex -translate-y-px flex-wrap items-center gap-1 sm:order-none sm:mt-0">
       {role.markers.map((marker) => {
         const details = roleMarkerDetails[marker];
         const description =
@@ -175,7 +156,7 @@ function RoleBlock({ role }: Readonly<{ role: ResumeRole }>) {
     <div className="mt-4 sm:mt-3">
       <div className="flex flex-col items-start sm:flex-row sm:flex-wrap sm:items-baseline sm:justify-between sm:gap-x-4">
         <div className="contents sm:flex sm:min-w-0 sm:flex-wrap sm:items-center sm:gap-2">
-          <span className="order-1 text-sm font-medium leading-5 text-[#292524] sm:order-none dark:text-[#e7e5e4]">
+          <span className="order-1 text-sm font-medium leading-5 text-foreground sm:order-none">
             {role.title}
           </span>
           <RoleMarkers role={role} />
@@ -190,7 +171,7 @@ function RoleBlock({ role }: Readonly<{ role: ResumeRole }>) {
         <p className={`mt-2 text-sm ${mutedText}`}>{role.summary}</p>
       )}
       {role.bullets !== undefined && role.bullets.length > 0 ? (
-        <ul className={`mt-2 space-y-0.5 text-sm leading-[1.625] ${mutedText}`}>
+        <ul className={`mt-2 space-y-0.5 ${resumeBodyText}`}>
           {role.bullets.map((bullet) => {
             const isTextBullet = typeof bullet === "string";
             const text = isTextBullet ? bullet : bullet.text;
@@ -200,7 +181,7 @@ function RoleBlock({ role }: Readonly<{ role: ResumeRole }>) {
             return logo === undefined ? (
               <li
                 key={text}
-                className="relative pl-4 before:absolute before:left-0 before:text-[#b45309] before:content-['·'] dark:before:text-[#d97706]"
+                className="relative pl-4 before:absolute before:left-0 before:text-primary before:content-['·']"
               >
                 {text}
               </li>
@@ -210,7 +191,7 @@ function RoleBlock({ role }: Readonly<{ role: ResumeRole }>) {
                 <span>
                   {label === undefined ? null : (
                     <>
-                      <span className="font-medium text-[#292524] dark:text-[#e7e5e4]">
+                      <span className="font-medium text-foreground">
                         {label}
                       </span>
                       {": "}
@@ -228,14 +209,30 @@ function RoleBlock({ role }: Readonly<{ role: ResumeRole }>) {
 }
 
 function ExperienceItem({ item }: Readonly<{ item: ResumeExperience }>) {
+  const companyStage =
+    item.companyStage === undefined
+      ? undefined
+      : resumeCompanyStageLabels[item.companyStage];
+
   return (
     <div className="mt-6 grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-4 sm:flex sm:gap-4">
       <CompanyLogo logo={item.logo} />
       <div className="contents sm:block sm:min-w-0 sm:flex-1">
         <div className="col-start-2 min-w-0 sm:contents">
-          <h3 className="font-[family-name:var(--resume-font-heading)] font-bold text-[#292524] dark:text-[#e7e5e4]">
-            {item.company}
-          </h3>
+          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+            <h3 className="font-serif font-bold text-foreground">
+              {item.company}
+            </h3>
+            {companyStage === undefined ? null : (
+              <span
+                aria-label={`Company stage during this role: ${companyStage}`}
+                className="inline-flex h-5 translate-y-px items-center rounded-full border border-border bg-muted/40 px-2 text-[0.625rem] font-semibold leading-none tracking-[0.01em] text-muted-foreground"
+                title={`Company stage during this role: ${companyStage}`}
+              >
+                {companyStage}
+              </span>
+            )}
+          </div>
           <p className={`mt-1 text-xs italic ${mutedText}`}>{item.tagline}</p>
         </div>
         <div className="col-span-2 min-w-0 sm:contents">
@@ -248,127 +245,61 @@ function ExperienceItem({ item }: Readonly<{ item: ResumeExperience }>) {
   );
 }
 
-function Header() {
-  return (
-    <header className="print:hidden">
-      <div className="mx-auto max-w-5xl px-4 py-6 sm:px-8 lg:px-12">
-        <nav className="flex items-center justify-between">
-          <Link href="/" className="group flex items-center gap-3">
-            <img
-              src={resumeData.person.image}
-              alt="Sid Jain"
-              className="h-10 w-10 rounded-full object-cover ring-2 ring-[#e7e5e4] transition-shadow group-hover:ring-[#b45309] dark:ring-[#3a3836] dark:group-hover:ring-[#d97706]"
-            />
-            <span className="hidden font-[family-name:var(--resume-font-heading)] text-lg font-bold sm:block">
-              Sid Jain
-            </span>
-          </Link>
-          <div className="flex items-center gap-1">
-            <ul className="hidden items-center gap-1 md:flex">
-              {navItems.map((item) => (
-                <li key={item.href}>
-                  <Link
-                    href={item.href}
-                    target={item.external === true ? "_blank" : undefined}
-                    rel={
-                      item.external === true ? "noopener noreferrer" : undefined
-                    }
-                    className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
-                      item.active === true
-                        ? "text-[#b45309] dark:text-[#d97706]"
-                        : "text-[#78716c] hover:text-[#292524] dark:text-[#a8a29e] dark:hover:text-[#e7e5e4]"
-                    }`}
-                  >
-                    {item.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-            <ResumeThemeToggle />
-            <ResumeMobileMenu navItems={navItems} />
-          </div>
-        </nav>
-      </div>
-    </header>
-  );
-}
-
 export function ResumePageContent({
+  currentPath = "/resume",
   includeProfileJsonLd = true,
-  showSiteNav = true,
 }: Readonly<ResumePageContentProps> = {}) {
   return (
-    <div
-      className={`${literata.variable} ${sourceSans.variable} ${jetBrainsMono.variable} min-h-screen bg-[#faf9f6] text-[#292524] antialiased dark:bg-[#1a1918] dark:text-[#e7e5e4]`}
-    >
+    <>
       {includeProfileJsonLd ? <JsonLd data={profileJsonLd} /> : null}
-      <div className="font-[family-name:var(--resume-font-body)]">
-        {showSiteNav ? <Header /> : null}
-        <main className="mx-auto max-w-5xl px-4 pb-20 pt-16 sm:px-8 sm:pt-24 lg:px-12 print:pt-8">
-          <header className="max-w-5xl">
-            <div className="flex items-center justify-between gap-4">
-              <div className="flex min-w-0 items-center gap-4 sm:gap-5">
-                <img
-                  src={resumeData.person.image}
-                  alt=""
-                  aria-hidden="true"
-                  className="h-16 w-16 shrink-0 rounded-full border-2 border-white object-cover shadow-sm ring-1 ring-[#e7e5e4] sm:h-20 sm:w-20 dark:ring-[#3a3836]"
-                />
-                <h1 className="font-[family-name:var(--resume-font-heading)] text-4xl font-bold text-[#292524] sm:text-5xl dark:text-[#e7e5e4]">
-                  Sid Jain
-                </h1>
-              </div>
-              <ResumePrintButton />
+      <SiteShell activeHref="/resume" currentPath={currentPath}>
+        <SitePage title="Résumé" action={<ResumeDownloadButton />}>
+          <section>
+            <p className={resumeBodyText}>{summary}</p>
+            <p className={`mt-3 ${resumeBodyText}`}>
+              {formatResumeLocation(person)}
+            </p>
+            <div className="mt-4 flex flex-wrap gap-4 text-sm">
+              {links.map((link) => (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  className={accentText}
+                  target={link.href.startsWith("http") ? "_blank" : undefined}
+                  rel={
+                    link.href.startsWith("http")
+                      ? "noopener noreferrer"
+                      : undefined
+                  }
+                >
+                  {link.label}
+                </a>
+              ))}
             </div>
-          </header>
+          </section>
 
-          <div className="mt-8 max-w-4xl sm:mt-10 print:mt-8">
-            <section>
-              <p className={`text-sm leading-relaxed ${mutedText}`}>
-                {summary}
-              </p>
-              <div className="mt-4 flex flex-wrap gap-4 text-sm">
-                {links.map((link) => (
-                  <a
-                    key={link.href}
-                    href={link.href}
-                    className={accentText}
-                    target={link.href.startsWith("http") ? "_blank" : undefined}
-                    rel={
-                      link.href.startsWith("http")
-                        ? "noopener noreferrer"
-                        : undefined
-                    }
-                  >
-                    {link.label}
-                  </a>
-                ))}
-              </div>
-            </section>
+          <section className="mt-8">
+            <SectionTitle>Experience</SectionTitle>
+            <div className="mt-4">
+              {experience.map((item) => (
+                <ExperienceItem key={item.company} item={item} />
+              ))}
+            </div>
+          </section>
 
-            <section className="mt-8">
-              <SectionTitle>Experience</SectionTitle>
-              <div className="mt-4">
-                {experience.map((item) => (
-                  <ExperienceItem key={item.company} item={item} />
-                ))}
-              </div>
-            </section>
+          <section className="mt-8">
+            <SectionTitle>Education</SectionTitle>
+            <div className="mt-4">
+              {education.map((item) => (
+                <ExperienceItem key={item.company} item={item} />
+              ))}
+            </div>
+          </section>
 
-            <section className="mt-8">
-              <SectionTitle>Education</SectionTitle>
-              <div className="mt-4">
-                {education.map((item) => (
-                  <ExperienceItem key={item.company} item={item} />
-                ))}
-              </div>
-            </section>
-
-            <ResumeAskAgents actions={askAgents.actions} />
-          </div>
-        </main>
-      </div>
-    </div>
+          <ResumeAskAgents actions={askAgents.actions} />
+        </SitePage>
+      </SiteShell>
+    </>
   );
 }
 

--- a/src/app/(portfolio)/resume/resume-controls.tsx
+++ b/src/app/(portfolio)/resume/resume-controls.tsx
@@ -1,55 +1,24 @@
-"use client";
-
-import { Menu, Moon, Sun } from "lucide-react";
-import { useTheme } from "next-themes";
+import { Download } from "lucide-react";
 import Image from "next/image";
-import Link from "next/link";
-import { useEffect, useState } from "react";
 
-import type { ResumeNavItem } from "@/content/resume";
+import { SiteActionLink } from "@/components/site-action-link";
 import type { AskAgentAction } from "@/lib/resume";
 
-const baseIconButton =
-  "rounded-full p-2 text-[#78716c] transition-colors hover:text-[#b45309] dark:text-[#a8a29e] dark:hover:text-[#f59e0b]";
-
-export function ResumeThemeToggle() {
-  const { resolvedTheme, setTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  const isDark = mounted && resolvedTheme === "dark";
-
+export function ResumeDownloadButton() {
   return (
-    <button
-      type="button"
-      aria-label="Toggle dark mode"
-      className={baseIconButton}
-      onClick={() => {
-        setTheme(isDark ? "light" : "dark");
-      }}
-    >
-      {isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
-    </button>
-  );
-}
-
-export function ResumePrintButton() {
-  return (
-    <a
+    <SiteActionLink
       href="/resume/sid-jain-resume.pdf"
       download
-      className="rounded-lg border border-[#e7e5e4] px-4 py-2 text-sm font-medium text-[#292524] transition-colors hover:bg-[#b45309]/5 print:hidden dark:border-[#3a3836] dark:text-[#e7e5e4] dark:hover:bg-[#d97706]/10"
+      className="print:hidden"
+      icon={<Download aria-hidden="true" className="h-4 w-4" />}
     >
       Download PDF
-    </a>
+    </SiteActionLink>
   );
 }
 
 const agentButtonClass =
-  "group inline-flex items-center gap-1.5 rounded-md px-1 py-0.5 font-medium text-[#292524] underline-offset-4 transition-colors hover:text-[#b45309] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#b45309] dark:text-[#e7e5e4] dark:hover:text-[#f59e0b] dark:focus-visible:outline-[#f59e0b]";
+  "group inline-flex items-center gap-1.5 rounded-md px-1 py-0.5 font-medium text-foreground underline-offset-4 transition-colors hover:text-brand-hover hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring";
 
 export function ResumeAskAgents({
   actions,
@@ -57,8 +26,8 @@ export function ResumeAskAgents({
   actions: readonly AskAgentAction[];
 }>) {
   return (
-    <footer className="mt-12 border-t border-[#e7e5e4] pt-6 print:hidden dark:border-[#3a3836]">
-      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-2 text-sm text-[#78716c] dark:text-[#a8a29e]">
+    <footer className="mt-12 border-t border-border pt-6 print:hidden">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-2 text-sm text-muted-foreground">
         <span>Ask</span>
         {actions.map((action, index) => (
           <span
@@ -88,45 +57,5 @@ export function ResumeAskAgents({
         <span>about me.</span>
       </div>
     </footer>
-  );
-}
-
-export function ResumeMobileMenu({
-  navItems,
-}: Readonly<{ navItems: readonly ResumeNavItem[] }>) {
-  return (
-    <details className="relative md:hidden">
-      <summary className={`${baseIconButton} list-none cursor-pointer`}>
-        <Menu className="h-5 w-5" />
-      </summary>
-      <ul className="absolute right-0 top-full z-50 mt-2 w-48 rounded-xl bg-white p-2 shadow-lg ring-1 ring-[#e7e5e4] dark:bg-[#242322] dark:ring-[#3a3836]">
-        {navItems.map((item) => {
-          const className = `block rounded-lg px-3 py-2 text-sm transition-colors ${
-            item.active === true
-              ? "text-[#b45309] hover:text-[#92400e] dark:text-[#d97706] dark:hover:text-[#f59e0b]"
-              : "text-[#78716c] hover:text-[#292524] dark:text-[#a8a29e] dark:hover:text-[#e7e5e4]"
-          }`;
-
-          return (
-            <li key={item.href}>
-              {item.external === true ? (
-                <a
-                  href={item.href}
-                  className={className}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {item.label}
-                </a>
-              ) : (
-                <Link href={item.href} className={className}>
-                  {item.label}
-                </Link>
-              )}
-            </li>
-          );
-        })}
-      </ul>
-    </details>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,8 +8,22 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-site-body);
+  --font-serif: var(--font-site-heading);
+  --font-ui: var(--font-site-ui);
+  --font-mono: var(--font-site-mono);
+  --shadow-site-soft: var(--shadow-soft);
+  --shadow-site-floating: var(--shadow-floating);
+  --color-brand-hover: var(--brand-hover);
+  --color-control: var(--control);
+  --color-control-border-hover: var(--control-border-hover);
+  --color-control-background-hover: var(--control-background-hover);
+  --color-hands-on-border: var(--hands-on-border);
+  --color-hands-on-background: var(--hands-on-background);
+  --color-hands-on-foreground: var(--hands-on-foreground);
+  --color-leadership-border: var(--leadership-border);
+  --color-leadership-background: var(--leadership-background);
+  --color-leadership-foreground: var(--leadership-foreground);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -48,6 +62,55 @@
   --radius-4xl: calc(var(--radius) + 16px);
 }
 
+@layer components {
+  .site-container {
+    margin-inline: auto;
+    width: 100%;
+    max-width: 64rem;
+    padding-inline: 1rem;
+  }
+
+  .site-icon-button {
+    @apply rounded-full p-2 text-muted-foreground transition-colors hover:text-brand-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring;
+  }
+
+  .site-nav-link {
+    @apply rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring;
+  }
+
+  .site-nav-link-active {
+    @apply text-primary;
+  }
+
+  .site-mobile-nav-link {
+    @apply block rounded-lg px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring;
+  }
+
+  .site-mobile-nav-link-active {
+    @apply text-primary hover:bg-primary/5 hover:text-brand-hover;
+  }
+
+  .site-action-link {
+    @apply inline-flex shrink-0 items-center gap-2 rounded-lg border border-input bg-control px-3.5 py-2 text-sm font-medium text-foreground shadow-sm transition-colors hover:border-control-border-hover hover:bg-control-background-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring;
+  }
+
+  .site-kicker {
+    @apply text-xs font-semibold uppercase tracking-[0.22em] text-primary;
+  }
+
+  @media (min-width: 40rem) {
+    .site-container {
+      padding-inline: 2rem;
+    }
+  }
+
+  @media (min-width: 64rem) {
+    .site-container {
+      padding-inline: 3rem;
+    }
+  }
+}
+
 @layer base {
   :root {
     color-scheme: light;
@@ -67,7 +130,7 @@
 }
 
 body {
-  font-family: var(--font-geist-sans);
+  font-family: var(--font-site-body);
 }
 
 .theme-transition,
@@ -85,7 +148,27 @@ body {
   }
 }
 
-.prose :is(h2, h3, h4, h5, h6) {
+.prose {
+  --tw-prose-body: var(--muted-foreground);
+  --tw-prose-headings: var(--foreground);
+  --tw-prose-lead: var(--muted-foreground);
+  --tw-prose-links: var(--primary);
+  --tw-prose-bold: var(--foreground);
+  --tw-prose-counters: var(--muted-foreground);
+  --tw-prose-bullets: var(--primary);
+  --tw-prose-hr: var(--border);
+  --tw-prose-quotes: var(--foreground);
+  --tw-prose-quote-borders: var(--primary);
+  --tw-prose-captions: var(--muted-foreground);
+  --tw-prose-code: var(--foreground);
+  --tw-prose-pre-code: var(--foreground);
+  --tw-prose-pre-bg: var(--card);
+  --tw-prose-th-borders: var(--border);
+  --tw-prose-td-borders: var(--border);
+}
+
+.prose :is(h1, h2, h3, h4, h5, h6) {
+  font-family: var(--font-site-heading);
   scroll-margin-top: 6rem;
 }
 
@@ -107,7 +190,7 @@ body {
 
 .prose pre,
 .prose code {
-  font-family: var(--font-geist-mono);
+  font-family: var(--font-site-mono);
 }
 
 .dark .prose pre[data-theme] {
@@ -115,13 +198,13 @@ body {
 }
 
 .prose code:not(pre code) {
-  background: rgba(24, 24, 27, 0.08);
+  background: color-mix(in oklab, var(--muted) 75%, transparent);
   border-radius: 0.375rem;
   padding: 0.15rem 0.35rem;
 }
 
 .dark .prose code:not(pre code) {
-  background: rgba(250, 250, 250, 0.1);
+  background: color-mix(in oklab, var(--muted) 85%, transparent);
 }
 
 .prose a {
@@ -143,7 +226,7 @@ body {
 .prose :where(figure img, img) {
   border-radius: 0.75rem;
   border: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
-  box-shadow: 0 18px 45px -35px rgba(15, 23, 42, 0.45);
+  box-shadow: 0 18px 45px -35px rgb(41 37 36 / 25%);
 }
 
 .prose figcaption {
@@ -186,69 +269,85 @@ body {
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --background: #faf9f6;
+  --foreground: #292524;
+  --card: #ffffff;
+  --card-foreground: #292524;
+  --popover: #ffffff;
+  --popover-foreground: #292524;
+  --primary: #b45309;
+  --primary-foreground: #fff7ed;
+  --secondary: #f5f1eb;
+  --secondary-foreground: #57534e;
+  --muted: #f2efea;
+  --muted-foreground: #78716c;
+  --accent: #f7ead8;
+  --accent-foreground: #92400e;
+  --destructive: #b91c1c;
+  --border: #e7e5e4;
+  --input: #d6d3d1;
+  --ring: #b45309;
+  --brand-hover: #92400e;
+  --control: rgb(255 255 255 / 60%);
+  --control-border-hover: rgb(180 83 9 / 50%);
+  --control-background-hover: rgb(180 83 9 / 5%);
+  --hands-on-border: #e4c184;
+  --hands-on-background: #f9ebd2;
+  --hands-on-foreground: #835018;
+  --leadership-border: #d6c7cf;
+  --leadership-background: #f0eaee;
+  --leadership-foreground: #66505f;
+  --shadow-soft: 0 1px 2px rgb(41 37 36 / 8%);
+  --shadow-floating: 0 18px 40px -24px rgb(41 37 36 / 32%);
+  --chart-1: #b45309;
+  --chart-2: #a16207;
+  --chart-3: #78716c;
+  --chart-4: #d97706;
+  --chart-5: #92400e;
+  --sidebar: var(--card);
+  --sidebar-foreground: var(--foreground);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: var(--accent);
+  --sidebar-accent-foreground: var(--accent-foreground);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: #1a1918;
+  --foreground: #e7e5e4;
+  --card: #242322;
+  --card-foreground: #e7e5e4;
+  --popover: #242322;
+  --popover-foreground: #e7e5e4;
+  --primary: #d97706;
+  --primary-foreground: #1a1918;
+  --secondary: #2b2927;
+  --secondary-foreground: #d6d3d1;
+  --muted: #242322;
+  --muted-foreground: #a8a29e;
+  --accent: #322619;
+  --accent-foreground: #f59e0b;
+  --destructive: #f87171;
+  --border: #3a3836;
+  --input: #44403c;
+  --ring: #d97706;
+  --brand-hover: #f59e0b;
+  --control: rgb(255 255 255 / 5%);
+  --control-border-hover: rgb(217 119 6 / 60%);
+  --control-background-hover: rgb(217 119 6 / 10%);
+  --hands-on-border: #6a4b24;
+  --hands-on-background: #2b2319;
+  --hands-on-foreground: #e8ae58;
+  --leadership-border: #5b4b55;
+  --leadership-background: #282328;
+  --leadership-foreground: #d8becd;
+  --shadow-soft: 0 1px 2px rgb(0 0 0 / 35%);
+  --shadow-floating: 0 18px 40px -24px rgb(0 0 0 / 70%);
+  --chart-1: #d97706;
+  --chart-2: #f59e0b;
+  --chart-3: #a8a29e;
+  --chart-4: #b45309;
+  --chart-5: #fbbf24;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,10 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import {
+  Geist,
+  JetBrains_Mono,
+  Literata,
+  Source_Sans_3,
+} from "next/font/google";
 
 import { JsonLd } from "@/components/json-ld";
 import { ThemeProvider } from "@/components/theme-provider";
@@ -8,14 +13,28 @@ import { buildRootJsonLd } from "@/lib/structured-data";
 
 import "./globals.css";
 
-const geistSans = Geist({
+const literata = Literata({
   subsets: ["latin"],
-  variable: "--font-geist-sans",
+  variable: "--font-site-heading",
+  weight: ["400", "700"],
 });
 
-const geistMono = Geist_Mono({
+const sourceSans = Source_Sans_3({
   subsets: ["latin"],
-  variable: "--font-geist-mono",
+  variable: "--font-site-body",
+  weight: ["400", "600", "700"],
+});
+
+const geist = Geist({
+  subsets: ["latin"],
+  variable: "--font-site-ui",
+});
+
+const jetBrainsMono = JetBrains_Mono({
+  preload: false,
+  subsets: ["latin"],
+  variable: "--font-site-mono",
+  weight: ["400"],
 });
 
 export const metadata: Metadata = {
@@ -87,8 +106,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} min-h-screen antialiased`}
-        suppressHydrationWarning
+        className={`${literata.variable} ${sourceSans.variable} ${geist.variable} ${jetBrainsMono.variable} min-h-screen antialiased`}
       >
         <JsonLd data={buildRootJsonLd()} />
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,51 +2,31 @@
 
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
-
-import { Switch } from "@/components/ui/switch";
-import { cn } from "@/lib/utils";
 
 const TRANSITION_CLASS = "theme-transition";
 
 export default function ThemeToggle() {
-  const { theme, setTheme, systemTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
+  const { setTheme } = useTheme();
 
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  if (!mounted) {
-    return <div className="h-6 w-12" aria-hidden />;
-  }
-
-  const resolvedTheme = theme === "system" ? systemTheme : theme;
-  const isDark = resolvedTheme === "dark";
-
-  const handleToggle = (checked: boolean) => {
+  const handleToggle = () => {
     const root = window.document.documentElement;
+    const isDark = root.classList.contains("dark");
     root.classList.add(TRANSITION_CLASS);
     window.setTimeout(() => {
       root.classList.remove(TRANSITION_CLASS);
     }, 500);
-    setTheme(checked ? "dark" : "light");
+    setTheme(isDark ? "light" : "dark");
   };
 
   return (
-    <div className="flex items-center gap-2 text-foreground/70">
-      <Sun
-        className={cn("h-4 w-4 transition", isDark && "text-foreground/40")}
-      />
-      <Switch
-        size="sm"
-        checked={isDark}
-        onCheckedChange={handleToggle}
-        aria-label="Toggle dark mode"
-      />
-      <Moon
-        className={cn("h-4 w-4 transition", !isDark && "text-foreground/40")}
-      />
-    </div>
+    <button
+      type="button"
+      aria-label="Toggle color theme"
+      className="site-icon-button"
+      onClick={handleToggle}
+    >
+      <Moon aria-hidden="true" className="h-5 w-5 dark:hidden" />
+      <Sun aria-hidden="true" className="hidden h-5 w-5 dark:block" />
+    </button>
   );
 }

--- a/src/components/blog/AuthorCard.tsx
+++ b/src/components/blog/AuthorCard.tsx
@@ -1,5 +1,4 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { siteConfig } from "@/lib/site";
 
@@ -17,26 +16,19 @@ export default function AuthorCard() {
   const image = author.image.trim() === "" ? undefined : author.image;
 
   return (
-    <Card className="bg-gradient-to-br from-muted/60 via-background to-muted/40">
-      <CardHeader className="flex flex-row items-center gap-4">
-        <Avatar size="lg">
-          {image === undefined ? null : (
-            <AvatarImage src={image} alt={author.name} />
-          )}
-          <AvatarFallback>{initials}</AvatarFallback>
-        </Avatar>
-        <div className="space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-            About the author
-          </p>
+    <Card>
+      <CardHeader className="gap-4">
+        <p className="site-kicker">About Sid</p>
+        <div className="flex items-center gap-3">
+          <Avatar size="lg">
+            {image === undefined ? null : (
+              <AvatarImage src={image} alt={author.name} />
+            )}
+            <AvatarFallback>{initials}</AvatarFallback>
+          </Avatar>
           <div>
-            <h3 className="text-lg font-semibold">{author.name}</h3>
-            <div className="flex flex-wrap items-center gap-2">
-              <Badge variant="secondary">{author.role}</Badge>
-              <span className="text-xs text-muted-foreground">
-                Building products and leading engineering teams.
-              </span>
-            </div>
+            <h3 className="font-serif text-lg font-bold">{author.name}</h3>
+            <p className="text-xs font-semibold text-primary">{author.role}</p>
           </div>
         </div>
       </CardHeader>

--- a/src/components/blog/PostCard.tsx
+++ b/src/components/blog/PostCard.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/card";
 import type { BlogPost } from "@/lib/blog-utils";
 import { formatDate } from "@/lib/date";
+import { siteConfig } from "@/lib/site";
 import { cn } from "@/lib/utils";
 
 interface PostCardProps {
@@ -21,18 +22,20 @@ export default function PostCard({ post, variant = "list" }: PostCardProps) {
   const isFeatured = variant === "featured";
 
   return (
-    <Link href={`/blog/${post.slug}`} className="group block">
+    <Link
+      href={`/blog/${post.slug}`}
+      className="group block h-full rounded-xl focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
+    >
       <Card
         className={cn(
-          "transition-all duration-300 group-hover:-translate-y-1 group-hover:shadow-md",
-          isFeatured &&
-            "border-transparent bg-gradient-to-br from-muted/70 via-background to-muted/40"
+          "h-full transition-colors duration-200 group-hover:border-primary/40 group-hover:bg-accent/20",
+          isFeatured && "border-primary/20"
         )}
       >
         <CardHeader>
           <CardTitle
             className={cn(
-              "text-balance text-lg font-semibold tracking-tight",
+              "text-balance font-serif text-lg font-bold tracking-tight transition-colors group-hover:text-brand-hover",
               isFeatured && "text-2xl"
             )}
           >
@@ -44,14 +47,14 @@ export default function PostCard({ post, variant = "list" }: PostCardProps) {
         </CardHeader>
         <CardContent className="flex flex-wrap gap-2">
           {(post.metadata.tags ?? []).slice(0, 3).map((tag) => (
-            <Badge key={tag} variant="secondary">
+            <Badge key={tag} variant="tag">
               {tag}
             </Badge>
           ))}
         </CardContent>
         <CardFooter className="text-xs text-muted-foreground">
           <time dateTime={post.date.toISOString()}>
-            {formatDate(post.date)}
+            {formatDate(post.date, siteConfig.language)}
           </time>
           <span className="mx-2">·</span>
           <span>{post.readingTime}</span>

--- a/src/components/site-action-link.tsx
+++ b/src/components/site-action-link.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface SiteActionLinkProps {
+  children: ReactNode;
+  className?: string;
+  download?: boolean;
+  href: string;
+  icon?: ReactNode;
+}
+
+export function SiteActionLink({
+  children,
+  className,
+  download = false,
+  href,
+  icon,
+}: Readonly<SiteActionLinkProps>) {
+  const content = (
+    <>
+      {icon}
+      {children}
+    </>
+  );
+  const classes = cn("site-action-link", className);
+
+  return download ? (
+    <a className={classes} download href={href}>
+      {content}
+    </a>
+  ) : (
+    <Link className={classes} href={href}>
+      {content}
+    </Link>
+  );
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,0 +1,86 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import ThemeToggle from "@/components/ThemeToggle";
+import { resumeData } from "@/content/resume";
+
+import { SiteMobileMenu } from "./site-mobile-menu";
+
+interface SiteHeaderProps {
+  activeHref: "/blog" | "/resume";
+  currentPath?: "/" | "/blog" | "/resume";
+}
+
+export function SiteHeader({
+  activeHref,
+  currentPath = activeHref,
+}: Readonly<SiteHeaderProps>): React.ReactNode {
+  return (
+    <header className="bg-background font-ui text-foreground print:hidden">
+      <div className="site-container py-6">
+        <nav
+          aria-label="Primary navigation"
+          className="flex items-center justify-between"
+        >
+          <Link
+            href="/"
+            aria-label={`${resumeData.person.name} home`}
+            className="group flex items-center gap-3"
+          >
+            <Image
+              src={resumeData.person.image}
+              alt=""
+              className="h-10 w-10 rounded-full object-cover ring-2 ring-border transition-shadow group-hover:ring-primary"
+              height={40}
+              width={40}
+            />
+            <span className="hidden text-lg font-bold sm:block">
+              {resumeData.person.name}
+            </span>
+          </Link>
+          <div className="flex items-center gap-1">
+            <ul className="hidden items-center gap-1 md:flex">
+              {resumeData.navItems.map((item) => {
+                const isActive = item.href === activeHref;
+                const isCurrent = item.href === currentPath;
+                const className = `site-nav-link ${
+                  isActive ? "site-nav-link-active" : ""
+                }`;
+
+                return (
+                  <li key={item.href}>
+                    {item.external === true ? (
+                      <a
+                        href={item.href}
+                        aria-current={isCurrent ? "page" : undefined}
+                        className={className}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {item.label}
+                      </a>
+                    ) : (
+                      <Link
+                        href={item.href}
+                        aria-current={isCurrent ? "page" : undefined}
+                        className={className}
+                      >
+                        {item.label}
+                      </Link>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+            <ThemeToggle />
+            <SiteMobileMenu
+              activeHref={activeHref}
+              currentPath={currentPath}
+              navItems={resumeData.navItems}
+            />
+          </div>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/src/components/site-mobile-menu.tsx
+++ b/src/components/site-mobile-menu.tsx
@@ -1,0 +1,58 @@
+import { Menu } from "lucide-react";
+import Link from "next/link";
+
+import type { ResumeNavItem } from "@/content/resume";
+
+export function SiteMobileMenu({
+  activeHref,
+  currentPath,
+  navItems,
+}: Readonly<{
+  activeHref: "/blog" | "/resume";
+  currentPath: "/" | "/blog" | "/resume";
+  navItems: readonly ResumeNavItem[];
+}>) {
+  return (
+    <details className="relative md:hidden">
+      <summary
+        aria-label="Navigation menu"
+        className="site-icon-button list-none cursor-pointer"
+      >
+        <Menu aria-hidden="true" className="h-5 w-5" />
+      </summary>
+      <ul className="absolute right-0 top-full z-50 mt-2 w-48 rounded-xl bg-popover p-2 text-popover-foreground shadow-site-floating ring-1 ring-border">
+        {navItems.map((item) => {
+          const isActive = item.href === activeHref;
+          const isCurrent = item.href === currentPath;
+          const className = `site-mobile-nav-link ${
+            isActive ? "site-mobile-nav-link-active" : ""
+          }`;
+
+          return (
+            <li key={item.href}>
+              {item.external === true ? (
+                <a
+                  href={item.href}
+                  aria-current={isCurrent ? "page" : undefined}
+                  className={className}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {item.label}
+                </a>
+              ) : (
+                <Link
+                  href={item.href}
+                  aria-current={isCurrent ? "page" : undefined}
+                  className={className}
+                >
+                  {item.label}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </details>
+  );
+}

--- a/src/components/site-page.tsx
+++ b/src/components/site-page.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface SiteMainProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function SiteMain({ children, className }: Readonly<SiteMainProps>) {
+  return (
+    <main
+      className={cn("site-container pb-20 pt-8 sm:pt-12 print:pt-8", className)}
+    >
+      {children}
+    </main>
+  );
+}
+
+interface SitePageProps {
+  action?: ReactNode;
+  children: ReactNode;
+  title: ReactNode;
+}
+
+export function SitePage({ action, children, title }: Readonly<SitePageProps>) {
+  return (
+    <SiteMain>
+      <header className="max-w-4xl">
+        <div className="flex items-end justify-between gap-4">
+          <h1 className="font-serif text-3xl font-bold text-foreground sm:text-4xl">
+            {title}
+          </h1>
+          {action}
+        </div>
+      </header>
+      <div className="mt-8 max-w-4xl print:mt-8">{children}</div>
+    </SiteMain>
+  );
+}

--- a/src/components/site-shell.tsx
+++ b/src/components/site-shell.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+import { SiteHeader } from "@/components/site-header";
+
+interface SiteShellProps {
+  activeHref: "/blog" | "/resume";
+  children: ReactNode;
+  currentPath?: "/" | "/blog" | "/resume";
+}
+
+export function SiteShell({
+  activeHref,
+  children,
+  currentPath = activeHref,
+}: Readonly<SiteShellProps>) {
+  return (
+    <div className="min-h-screen bg-background font-sans text-foreground antialiased">
+      <SiteHeader activeHref={activeHref} currentPath={currentPath} />
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -23,6 +23,7 @@ const badgeVariants = cva(
           "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
         secondary:
           "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        tag: "border-primary/20 bg-primary/6 text-primary [a]:hover:bg-primary/10",
       },
     },
   }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "ring-foreground/10 bg-card text-card-foreground gap-6 overflow-hidden rounded-xl py-6 text-sm shadow-xs ring-1 has-[>img:first-child]:pt-0 data-[size=sm]:gap-4 data-[size=sm]:py-4 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl group/card flex flex-col",
+        "group/card flex flex-col gap-6 overflow-hidden rounded-xl border border-border bg-card py-6 text-sm text-card-foreground shadow-site-soft has-[>img:first-child]:pt-0 data-[size=sm]:gap-4 data-[size=sm]:py-4 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
         className
       )}
       {...props}
@@ -38,7 +38,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-title"
       className={cn(
-        "text-base leading-normal font-medium group-data-[size=sm]/card:text-sm",
+        "font-serif text-base leading-normal font-bold group-data-[size=sm]/card:text-sm",
         className
       )}
       {...props}

--- a/src/content/resume.ts
+++ b/src/content/resume.ts
@@ -19,6 +19,21 @@ export const resumeRoleMarkerLabels = {
   leadership: "Leadership",
 } satisfies Record<ResumeRoleMarker, string>;
 
+export type ResumeCompanyStage =
+  | "zero-to-one"
+  | "early-stage"
+  | "growth-stage"
+  | "scale-up"
+  | "late-stage";
+
+export const resumeCompanyStageLabels = {
+  "zero-to-one": "0 → 1",
+  "early-stage": "Early-stage",
+  "growth-stage": "Growth-stage",
+  "scale-up": "Scale-up",
+  "late-stage": "Late-stage",
+} satisfies Record<ResumeCompanyStage, string>;
+
 export interface ResumeRole {
   title: string;
   dates: string;
@@ -31,6 +46,7 @@ export interface ResumeRole {
 
 export interface ResumeExperience {
   company: string;
+  companyStage?: ResumeCompanyStage;
   logo: LogoAsset;
   pdfPageBreakBefore?: boolean;
   tagline: string;
@@ -43,13 +59,22 @@ export interface ResumeLink {
 }
 
 export interface ResumeNavItem extends ResumeLink {
-  active?: boolean;
   external?: boolean;
 }
 
 export interface PublicReference extends ResumeLink {
   note: string;
 }
+
+export interface ResumePersonLocation {
+  location: string;
+  mobility?: readonly string[];
+}
+
+export const formatResumeLocation = (
+  person: ResumePersonLocation,
+  separator = "\u2002•\u2002"
+) => [person.location, ...(person.mobility ?? [])].join(separator);
 
 interface DeepDiveSection {
   heading: string;
@@ -169,13 +194,14 @@ const dpsLogo: LogoAsset = {
 };
 
 export const resumeData = {
-  lastUpdated: "2026-07-28",
+  lastUpdated: "2026-07-30",
   person: {
     alternateNames: ["f0rr0", "yuppiestechdev"],
     avatarImage: "/resume/sid-jain-profile-avatar.png",
     email: "sid_26@outlook.com",
     image: "/resume/sid-jain-profile.png",
-    location: "Mumbai, India / Remote",
+    location: "Based in Mumbai",
+    mobility: ["Available for India/APAC travel"],
     name: "Sid Jain",
     role: "Applied AI Lead and Senior Full-Stack Engineer",
     targetPositioning:
@@ -183,7 +209,7 @@ export const resumeData = {
   },
   navItems: [
     { href: "/blog", label: "Blog" },
-    { active: true, href: "/resume", label: "Resume" },
+    { href: "/resume", label: "Résumé" },
     { external: true, href: "https://github.com/f0rr0", label: "GitHub" },
   ] satisfies ResumeNavItem[],
   links: [
@@ -192,10 +218,11 @@ export const resumeData = {
     { href: "https://github.com/f0rr0", label: "github.com/f0rr0" },
   ] satisfies ResumeLink[],
   summary:
-    "Applied AI Lead and hands-on engineering leader who turns loosely defined customer needs into production systems. Leads customer discovery, technical strategy, teams, architecture, and delivery while remaining directly involved in AI workflow design, evaluation, prototyping, and full-stack implementation across marketplaces, browsers, mobile apps, and infrastructure-heavy products.",
+    "Software engineer and technical leader with 10+ years building and operating production applications, platforms, and infrastructure. Leads Applied AI at Namefi, taking customer workflows from discovery and system design through evaluation, implementation, and support; previously built human-in-the-loop AI content systems at Memorang. Founded a 15-engineer consultancy and shipped browser, messaging, payments, travel, mobile, and cloud systems.",
   experience: [
     {
       company: "Namefi",
+      companyStage: "early-stage",
       tagline:
         "ICANN-accredited registrar building AI products for domain ownership and sales.",
       logo: namefiLogo,
@@ -203,40 +230,43 @@ export const resumeData = {
         {
           title: "Lead Applied AI Engineer",
           dates: "Jan 2025 - Present",
-          location: "San Francisco Bay Area / Remote",
+          location: "Mumbai / Remote",
           markers: ["hands-on"],
           bullets: [
-            "Interviewed owners of large domain portfolios and built Namefi Outbound to streamline buyer research, lead scoring, contact discovery, and outreach drafting, reducing sales preparation from days to minutes.",
-            "Designed Brand Studio, a multi-stage AI system that creates logos, posters, and motion concepts for domains. It separates strategy, concept generation, and animation while preserving the exact domain name, including its top-level domain.",
-            "Built Namefi Feed, which aggregates and structures roughly 4,000 to 5,000 public domain listings from X, forums, and marketplaces, making them searchable on the web and through RSS feeds.",
-            "Built production registrar systems for third-party integrations, registration, renewals, payments, checkout, and analytics. Added DNS record and DNSSEC management, nameserver controls, ENS and .eth support, and long-running Temporal workflows.",
+            "Built Namefi Outbound from customer discovery through production, cutting buyer research from days to about five minutes per domain: 50–70 ranked leads with fit rationales, decision-maker contacts, and tailored drafts.",
+            "Built model-judged evals for buyer fit, name and product similarity, and decision-maker contacts; validated outputs through seller reports covering hundreds of prospective buyers.",
+            "Built and operated Namefi Studio, a Temporal pipeline for logos, posters, website mockups, and motion; separated strategy from generation and used prompt constraints plus visual review for domain/TLD fidelity.",
+            "Built and operated Namefi Feed, a Temporal ingestion and AI-classification system serving nearly 8,000 active listings, with reliable concurrent ingestion, retries, price verification, and auditable decisions.",
+            "Built registrar and commerce systems across integrations, registration, checkout, payments, and analytics; replaced Airflow with testable Temporal workflows, simplifying recovery and making orchestration failures rare.",
           ],
         },
       ],
     },
     {
       company: "Memorang",
+      companyStage: "growth-stage",
       tagline:
         "AI-assisted educational content platform for structured curricula and assessments.",
       logo: memorangLogo,
       roles: [
         {
-          title: "Lead Product Engineer, AI Content Platform",
+          title: "Lead Applied AI Engineer",
           dates: "Apr 2024 - Jan 2025",
           leadershipScope: "Managed 3 developers",
-          location: "San Francisco Bay Area / Remote",
+          location: "Mumbai / Remote",
           markers: ["hands-on", "leadership"],
           bullets: [
-            "Built EdWrite, a graph-based headless CMS that represents Cambridge and TOEFL curricula and assessment requirements in versioned schemas exposed through content APIs.",
-            "Designed human-in-the-loop workflows that let subject-matter experts generate, review, and manage complete question sets with supporting audio and images. Also built adaptive practice and scoring, plus semantic recommendations for related media.",
-            "Managed a three-developer CMS team and owned its roadmap, coordinating with backend, frontend, and mobile teams while working directly with the CTO and CEO.",
-            "Led the gradual migration of a large Flow-typed JavaScript monorepo to TypeScript, introducing Bun, Biome, codemods, and AI-assisted refactoring.",
+            "Built and shipped EdWrite, a graph-based CMS and content API managing tens of thousands of Cambridge and TOEFL questions, with adaptive practice, scoring, and semantic media recommendations.",
+            "Built human-in-the-loop generation for question sets, audio, and images, cutting content cycles from months to days; SME review calibrated model-based evals, while client SMEs controlled publishing.",
+            "Led a three-developer CMS team and roadmap across backend, frontend, and mobile, working directly with the CTO and CEO.",
+            "Led an AI-assisted Flow-to-TypeScript migration across hundreds of thousands of lines; cut compilation to single-digit minutes, accelerated CI and merges, and enabled safer refactors with fewer runtime errors.",
           ],
         },
       ],
     },
     {
       company: "Yuppies Tech",
+      companyStage: "zero-to-one",
       tagline: "Product engineering consultancy for complex client products.",
       logo: yuppiesLogo,
       roles: [
@@ -247,7 +277,7 @@ export const resumeData = {
           location: "Mumbai / Remote",
           markers: ["hands-on", "leadership"],
           summary:
-            "Founded and grew Yuppies Tech to 15 engineers while remaining the client-facing technical lead. Turned unclear requirements into architecture, delivery plans, and production releases.",
+            "Founded and grew Yuppies Tech to 15 engineers while remaining the client-facing technical lead. Turned unclear requirements into architecture, delivery plans, and production releases. Selected engagements:",
           bullets: [
             {
               label: "Veera Browser",
@@ -262,7 +292,7 @@ export const resumeData = {
             {
               label: "ZebPay",
               logo: zebpayLogo,
-              text: "led modernization of ZebPay's iOS and Android apps, release infrastructure, exchange and payment features, and international KYC. During stabilization, increased the release cadence from every two weeks to weekly.",
+              text: "led modernization of ZebPay's iOS and Android apps, release infrastructure, exchange and payment features, and international KYC. During stabilization, increased the release cadence from monthly to weekly.",
             },
             {
               label: "Mitsubishi Motors",
@@ -280,6 +310,7 @@ export const resumeData = {
     },
     {
       company: "Kult",
+      companyStage: "zero-to-one",
       tagline: "Consumer beauty and skincare commerce.",
       logo: kultLogo,
       roles: [
@@ -298,6 +329,7 @@ export const resumeData = {
     },
     {
       company: "Yilu",
+      companyStage: "zero-to-one",
       tagline:
         "Smart travel platform built for Lufthansa Group with BCG Digital Ventures.",
       logo: yiluLogo,
@@ -305,17 +337,19 @@ export const resumeData = {
         {
           title: "Founding Engineer",
           dates: "Nov 2018 - Dec 2019",
+          leadershipScope: "Led a five-developer full-stack pod",
           location: "Berlin",
-          markers: ["hands-on"],
+          markers: ["hands-on", "leadership"],
           bullets: [
             "Designed the native mobile architecture and release automation, built Terraform-managed AWS infrastructure, and shipped iOS and Android features for Eurowings.",
-            "Helped establish the engineering team by writing job descriptions, creating technical exercises, and interviewing candidates. Also served as Scrum Master.",
+            "As the first engineering hire, led a five-developer full-stack pod with a product manager and designer; partnered with the CTO on key hires and served as Scrum Master for early sprints, establishing the team's delivery cadence.",
           ],
         },
       ],
     },
     {
       company: "8fit",
+      companyStage: "growth-stage",
       tagline: "Fitness and nutrition platform later acquired by Withings.",
       logo: eightfitLogo,
       roles: [
@@ -333,6 +367,7 @@ export const resumeData = {
     },
     {
       company: "Housing",
+      companyStage: "late-stage",
       tagline: "Indian real estate search and transaction platform.",
       logo: housingLogo,
       roles: [
@@ -399,7 +434,7 @@ export const resumeData = {
       "Sid founded Yuppies Tech and served as the client-facing technical partner, architect, and hands-on engineering lead for its client work.",
       "At Kult, Sid was a hands-on Vice President of Engineering who owned product and engineering strategy, set the technical direction for both native apps, and contributed in Swift and Kotlin.",
       "Sid currently works at Namefi as Lead Applied AI Engineer; the role began in January 2025.",
-      "Memorang was a separate Lead Product Engineer role from April 2024 through January 2025.",
+      "Memorang was a separate Lead Applied AI Engineer role from April 2024 through January 2025.",
     ],
     positioning:
       "Sid is a hands-on engineering leader who combines team and product leadership with staff-level full-stack and applied AI depth. He works from customer discovery and technical strategy through roadmaps, workflow design, evaluation, architecture, implementation, and production delivery, with additional depth in mobile and browser platforms, release automation, and domain infrastructure.",
@@ -424,21 +459,21 @@ export const resumeData = {
               "Company: Namefi.",
               "Title: Lead Applied AI Engineer.",
               "Dates: January 2025 - Present.",
-              "Location: San Francisco Bay Area / Remote.",
+              "Location: Mumbai / Remote.",
             ],
           },
           {
             heading: "Public company context",
             bullets: [
               "Namefi is an ICANN-accredited registrar that combines domain registration and DNS management with tools for tokenized ownership, trading, and AI-assisted sales.",
-              "Its public products include Namefi Outbound, Namefi Feed, Namefi Brand Studio, domain registration, DNS management, and domain discovery.",
+              "Its public products include Namefi Outbound, Namefi Feed, Namefi Studio, domain registration, DNS management, and domain discovery.",
             ],
           },
           {
             heading: "Sid's role",
             bullets: [
-              "Leads AI product engineering across Namefi Outbound, Namefi Brand Studio, Namefi Feed, and internal analytics workflows.",
-              "Builds registrar and domain infrastructure for DNS, payments, checkout, renewals, ENS and .eth domains, and long-running workflows.",
+              "Leads AI product engineering across Namefi Outbound, Namefi Studio, Namefi Feed, and internal analytics workflows.",
+              "Builds registrar and commerce infrastructure for third-party integrations, registration, checkout, payments, analytics, and long-running workflows.",
               "Owns projects from customer interviews and workflow design through evaluation, implementation, deployment, and ongoing production support.",
               "Established repeatable documentation, static checks, and CI practices for AI-assisted development.",
             ],
@@ -447,34 +482,36 @@ export const resumeData = {
             heading: "Namefi Outbound",
             bullets: [
               "Namefi Outbound helps domain sellers research likely buyers and prepare outreach.",
-              "Sid designed it after interviewing owners of large domain portfolios about their sales process.",
+              "Sid built it from direct customer discovery with domain sellers through production implementation and support.",
               "The previous process required sellers to choose domains, assess market timing, research buyers, maintain notes, find contacts, and draft messages by hand.",
-              "Outbound reduces that preparation from days to minutes by organizing domain selection, buyer research, lead scoring, contact discovery, and editable outreach drafts.",
+              "For each domain, Outbound produces 50 to 70 ranked leads with fit rationales, decision-maker contacts, and tailored drafts in about five minutes, replacing work that previously took multiple days.",
+              "Sid built model-judged evals for buyer fit, name and product similarity, and decision-maker contact quality, then validated outputs through seller reports covering hundreds of prospective buyers.",
               "Its results remain transparent and editable so sellers retain control of the process.",
             ],
           },
           {
-            heading: "Namefi Brand Studio",
+            heading: "Namefi Studio",
             bullets: [
-              "Namefi Brand Studio creates logos, posters, and motion concepts that help owners present domains to buyers.",
+              "Namefi Studio creates logos, posters, website mockups, and motion concepts that help owners present domains to buyers.",
               "It uses separate stages for brand strategy, concept development, image generation, validation, animation, and asset delivery.",
-              "The system preserves the exact domain name, including its top-level domain, and rejects common generation errors such as incorrect suffixes, slogans, mockups, and watermarks.",
+              "Prompt constraints and manual side-by-side visual review assess domain and top-level-domain fidelity alongside overall output quality.",
               "It supports still and animated assets, prepared frames, thumbnails, generation metadata, and cloud delivery.",
             ],
           },
           {
             heading: "Namefi Feed",
             bullets: [
-              "Namefi Feed collects roughly 4,000 to 5,000 public domain listings from X, NamePros, DNForum, marketplaces, and other public sources.",
-              "It extracts and standardizes domains, sellers, sources, prices, currencies, and other listing details.",
+              "Namefi Feed serves nearly 8,000 active listings from X, NamePros, DNForum, Namefi, and other public sources.",
+              "Its Temporal-backed ingestion and AI-classification system extracts and standardizes domains, sellers, sources, prices, currencies, and other listing details while handling concurrent scans, retries, price verification, and auditable outcomes.",
               "Buyers can search the listings or follow them through RSS instead of monitoring many forums, marketplaces, and social feeds.",
             ],
           },
           {
             heading: "Core registrar and domain infrastructure",
             bullets: [
-              "Built third-party registrar integrations and systems for domain registration, renewal, checkout, payments, DNS records, DNSSEC, nameserver management, and ENS and .eth support.",
-              "Led the migration from Airflow-style DAGs to Temporal for stateful, long-running processes, then applied Temporal to AI and operational workflows.",
+              "Built third-party registrar integrations and systems for domain registration, checkout, payments, and analytics.",
+              "Replaced Airflow-backed orchestration with declarative, testable Temporal workflows, then expanded the pattern across stateful AI and operational workflows.",
+              "The change simplified the operating mental model, recovery, and testing while making orchestration failures rare in day-to-day operation.",
             ],
           },
         ],
@@ -486,16 +523,17 @@ export const resumeData = {
             heading: "Role",
             bullets: [
               "Company: Memorang.",
-              "Title: Lead Product Engineer, AI Content Platform.",
+              "Title: Lead Applied AI Engineer.",
               "Dates: April 2024 - January 2025.",
-              "Location: San Francisco Bay Area / Remote.",
+              "Location: Mumbai / Remote.",
             ],
           },
           {
             heading: "Context and role",
             bullets: [
-              "EdWrite is a graph-based headless CMS for structured educational content and AI-assisted content production.",
-              "Sid led product engineering for EdWrite, managed three developers, worked directly with the CTO and CEO, and coordinated with backend, frontend, and mobile teams.",
+              "EdWrite is a production graph-based headless CMS and content API for structured educational content and AI-assisted content production.",
+              "It managed tens of thousands of questions across versioned Cambridge and TOEFL curricula.",
+              "Sid led product engineering for EdWrite, owned its roadmap, managed three developers, worked directly with the CTO and CEO, and coordinated with backend, frontend, and mobile teams.",
             ],
           },
           {
@@ -503,11 +541,13 @@ export const resumeData = {
             bullets: [
               "Translated Cambridge and TOEFL curricula and assessment requirements into versioned schemas exposed through content APIs.",
               "Modeled exam sections, question types, content groups, scoring, and adaptive practice as configurable structures.",
-              "Designed human-in-the-loop workflows for subject-matter experts to generate, review, and manage complete question sets with supporting audio and images.",
+              "Built human-in-the-loop workflows for generating complete question sets with supporting audio and images, reducing end-to-end content cycles from months to days.",
+              "Initial subject-matter-expert review calibrated model-based evals, while client subject-matter experts retained final publishing control.",
               "Built schema versioning so content and question formats could evolve without breaking existing client apps or backend services.",
               "Built adaptive practice flows that track scores, identify weak areas, and recommend personalized material.",
               "Built recommendations for supporting media using metadata embeddings and vector similarity search across products.",
-              "Led the gradual migration of a large Flow-typed JavaScript monorepo to TypeScript, introducing Bun, Biome, codemods, and AI-assisted refactoring.",
+              "Led a Flow-to-TypeScript migration across hundreds of thousands of lines using codemods and AI-assisted refactoring.",
+              "Cut compilation from double-digit to single-digit minutes, accelerated CI and merges, and enabled safer refactors with fewer type-related runtime errors.",
             ],
           },
         ],
@@ -613,7 +653,7 @@ export const resumeData = {
               "Shipped exchange and payment features, wallet SDK integrations, and support for new coin and token launches.",
               "Built over-the-counter workflows for high-net-worth traders and localized KYC processes.",
               "Implemented country-specific document handling, media capture, identity verification, integrations such as IDfy, and secure document access.",
-              "During stabilization, increased the release cadence from every two weeks to weekly.",
+              "During stabilization, increased the release cadence from monthly to weekly.",
             ],
           },
         ],

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,8 +1,10 @@
-export const formatDate = (value: Date | string) => {
+export const formatDate = (
+  value: Date | string,
+  locale: string | string[] = "en-US"
+) => {
   const date = typeof value === "string" ? new Date(value) : value;
-  return new Intl.DateTimeFormat("en-US", {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: "medium",
+    timeZone: "UTC",
   }).format(date);
 };

--- a/src/lib/resume.ts
+++ b/src/lib/resume.ts
@@ -1,4 +1,9 @@
-import { resumeData, resumeRoleMarkerLabels } from "@/content/resume";
+import {
+  formatResumeLocation,
+  resumeCompanyStageLabels,
+  resumeData,
+  resumeRoleMarkerLabels,
+} from "@/content/resume";
 import type { PublicReference, ResumeRole } from "@/content/resume";
 import type { BlogPost } from "@/lib/blog-utils";
 import { publicUrl } from "@/lib/site";
@@ -222,6 +227,7 @@ export const buildJsonResume = () => ({
   meta: {
     canonical: publicUrl("/resume.json"),
     lastModified: resumeData.lastUpdated,
+    mobility: [...resumeData.person.mobility],
     schema: "https://jsonresume.org/schema/",
     source: publicUrl("/resume"),
   },
@@ -241,6 +247,11 @@ export const buildJsonResume = () => ({
         location: role.location,
         name: item.company,
         position: role.title,
+        ...(item.companyStage === undefined
+          ? {}
+          : {
+              companyStage: resumeCompanyStageLabels[item.companyStage],
+            }),
         ...(role.markers === undefined
           ? {}
           : { roleMarkers: roleMarkers(role) }),
@@ -328,6 +339,15 @@ export const buildLlmsTxt = (blogPosts: BlogPost[] = []) => {
       })
     )
     .join("\n");
+  const companyStageAssignments = resumeData.experience
+    .flatMap((item) =>
+      item.companyStage === undefined
+        ? []
+        : [
+            `- ${item.company} — ${resumeCompanyStageLabels[item.companyStage]}.`,
+          ]
+    )
+    .join("\n");
   const deepDiveText = deepDives
     .map((deepDive) =>
       [
@@ -404,7 +424,7 @@ ${canonicalText}
 
 - Name: ${resumeData.person.name}.
 - Public aliases: ${formatNaturalList([...resumeData.person.alternateNames])}.
-- Location: ${resumeData.person.location}.
+- Location and mobility: ${formatResumeLocation(resumeData.person, "; ")}.
 - Professional focus: ${resumeData.person.role}.
 - Current role: ${currentRole?.title ?? resumeData.person.role} at ${currentExperience?.company ?? "the current company"}.
 - Roles of interest: ${resumeData.person.targetPositioning}.
@@ -423,6 +443,9 @@ Role indicators used on the human-readable resume:
 
 Role indicators by position:
 ${roleMarkerAssignments}
+
+Company stage during each role:
+${companyStageAssignments}
 
 ${claimGuidanceSection}
 ${deepDiveText}

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -45,7 +45,7 @@ const buildPersonNode = (): Person => ({
       sameAs: "https://dpsrkp.net/",
     },
   ],
-  description: siteConfig.description,
+  description: resumeData.summary,
   email: `mailto:${resumeData.person.email}`,
   image: publicUrl(resumeData.person.image),
   jobTitle: currentRole?.title ?? resumeData.person.role,
@@ -121,7 +121,7 @@ export const buildProfilePageJsonLd = (): WithContext<ProfilePage> => ({
     url: publicUrl("/"),
   },
   mainEntity: buildPersonNode(),
-  name: "Sid Jain Resume",
+  name: "Sid Jain Résumé",
   url: publicUrl("/resume"),
 });
 


### PR DESCRIPTION
## Summary

- add a shared responsive site shell, navigation, page/action primitives, typography, and theme tokens across the portfolio and blog
- simplify the blog index and article layouts while standardizing cards, tags, theme controls, and UTC-safe date formatting
- strengthen the résumé summary and experience evidence, update role titles and mobility details, and add concise company-stage context
- keep the web résumé, generated two-page PDF, JSON Resume, `llms.txt`, and structured metadata synchronized

## Why

The résumé and blog had separate navigation, typography, color, and component implementations. This consolidates those surfaces into one coherent system while sharpening the résumé for hands-on Applied AI engineering roles and keeping every public and machine-readable representation aligned.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run format:typ:check`
- `bun run resume:pdf`
- visually verified the résumé on desktop and mobile
- visually verified both PDF pages; all Yuppies content remains on page 1
- visually smoke-tested the blog on desktop and mobile, including the mobile navigation menu
- confirmed no browser console warnings or errors during smoke testing
