### PR TITLE
feat(blog): add seven engineering and site retrospectives

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -24,7 +24,7 @@ export const metadata = {
   summary: "Short description used for listings + meta tags.",
   tags: ["tag", "tag"], // optional
   updated: "2025-02-12", // optional
-  draft: false, // optional (true hides from listings/RSS)
+  draft: false, // optional (true hides from production)
 };
 ```
 
@@ -32,6 +32,9 @@ Gotchas:
 
 - `date` / `updated` must be valid ISO or `YYYY-MM-DD`. Invalid dates fail builds.
 - `summary` is required and used for SEO + RSS.
+- Drafts remain visible locally and on Vercel preview deployments for review.
+- Production excludes drafts from direct routes, listings, RSS, sitemap, and
+  `llms.txt`.
 
 ## Co-located assets
 

--- a/src/content/blog/building-on-zeroclaw/page.mdx
+++ b/src/content/blog/building-on-zeroclaw/page.mdx
@@ -1,0 +1,126 @@
+export const metadata = {
+  title: "ZeroClaw Decides What’s for Lunch",
+  date: "2026-08-20",
+  author: "Sid Jain",
+  summary:
+    "I put ZeroClaw in our family Telegram group and asked it to choose lunch. It first had to learn when to speak, what to remember, and which decisions belonged to the family.",
+  tags: ["applied-ai", "rust", "ai-agents", "zeroclaw"],
+  draft: true,
+};
+
+ZeroClaw had one job in our family group chat: decide what was for lunch.
+The trouble was that the family had usually started answering the question long
+before anyone asked it. One person had ruled out eggs, the cook had mentioned
+half a cabbage and some capsicum, and someone else remembered that yesterday's
+paneer felt too heavy. None of those messages was a meal plan on its own, but
+together they were the context behind “What should we make?” A model with access
+to recipes can answer that question in seconds. It can also suggest a dish
+nobody wants, assume an ingredient is still available, or ignore the person who
+will actually cook it.
+
+That made lunch an unexpectedly good test for a personal assistant. I built a
+prototype on [ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw), a Rust agent
+runtime, and placed it in the Telegram group where the conversation already
+happened. The useful context arrived in fragments, and some of it was already
+going stale. I began with meal recommendations, but the recipe itself soon
+became the easy part.
+
+## Listening without interrupting
+
+An assistant that sees only messages addressed to it misses most of a group
+chat. One that replies whenever it notices something relevant quickly becomes
+unbearable. It needed to follow the conversation without behaving as though
+every message had been sent for its benefit. I separated the right to observe
+from the right to participate. Messages from the allowed group could be recorded
+as context without starting a visible assistant turn. A command or question
+addressed to the assistant could proceed immediately. For everything else, a
+small classifier decided whether the message called for a response or should
+simply become part of the recent conversation.
+
+I treated that classification as a suggestion, then enforced it in code. When a
+reply was warranted, the runtime recorded a permit against the incoming message.
+The outbound Telegram path checked for that permit before sending anything. If
+the classifier returned malformed output, the provider failed, or the permit was
+missing, ZeroClaw stayed quiet.
+This was a better boundary than a line in the prompt. Prompt changes and new
+tool paths could alter the model's behavior, but the channel check still
+controlled whether a message left the system. It also left a record of why the
+assistant had spoken instead of making me reconstruct the decision from its
+answer later. The boundary matched the social rule of the group too. Remembering
+a pantry update did not require commenting on it, so most of ZeroClaw's work
+could remain invisible until somebody actually wanted its opinion.
+
+## Giving memory an expiry date
+
+The first version of memory looked deceptively simple. Save the messages,
+retrieve the recent ones, and let the model reason over them. That worked for a
+short conversation, but raw chat made a poor long-term household model. A
+preference belonged to a person, feedback referred to a particular meal, and
+pantry observations needed sources and timestamps. The system also had to
+distinguish a dish the family chose from one they had merely discussed.
+I kept the original messages and built the household state beside them. The
+system could derive per-person preferences, recent meal episodes, feedback,
+pantry observations, and open decisions without erasing where each fact came
+from. Retrieval began with ordinary full-text search over messages and episodes.
+Semantic ranking could help when the wording differed. Any retrieved fact still
+pointed back to the message that supported it.
+
+Attribution needed stricter handling. “She does not like mushrooms” could not
+become a durable preference unless the system knew who “she” referred to. A
+passing dislike also could not become a dietary constraint. I kept ambiguous
+statements as questions and accepted hard constraints only from explicit,
+attributable messages. Asking for clarification was preferable to quietly
+inventing a profile of someone. The pantry made this problem more obvious. A
+grocery order showed that tomatoes had entered the house, not that they were
+still there. A photo captured one angle at one moment, and the cook's message
+was usually more current, although even that observation aged. I recorded the
+source and time of each observation, then reduced its weight according to age
+and perishability. The freshness model only needed to tell the assistant when it
+should ask. If capsicum had been mentioned that morning while paneer appeared
+only in an older order, ZeroClaw could say what it knew and ask the cook whether
+the paneer was still available. Each new source introduced more disagreement
+and staleness, but it also showed the system where its memory was weak.
+
+## Letting ZeroClaw choose
+
+Once the context was in reasonable shape, meal suggestions became
+straightforward. In early tests, the model could interpret requests such as
+“something light but not boring,” connect them to recent feedback, and propose a
+few plausible dishes. I applied confirmed dietary constraints before ranking.
+Among the remaining options, I gave extra weight to the person whose preferences
+had been accommodated least often in recent meals, so one enthusiastic vote
+could not repeatedly dominate everyone else. The model could help interpret
+language and explain a tradeoff, while the constraints and ranking rule remained
+regular code.
+
+Choosing a dish also changed durable state, which introduced another problem:
+saving that decision safely. Messaging systems retry deliveries, model calls
+time out, and workers restart. A conversation might simply end with, “We chose
+dal.” The assistant would record the decision and schedule one later question
+about how the meal went. If Telegram delivered that message twice, the household
+should not acquire two decisions and two reminders. The runtime therefore bound
+a write to the actual incoming message rather than trusting an identifier
+supplied by the model. Repeating the same operation returned the earlier result.
+Trying to reuse the message for a different change produced a conflict.
+
+Scheduling the follow-up added one complication. The meal state and the
+scheduler lived in separate stores, so they could not be committed atomically.
+The meal transaction recorded the intent to schedule a follow-up, and a worker
+reconciled that intent with a deterministic job name. The bookkeeping stayed
+invisible in the chat. A meal decision still produced one reminder, however many
+times the surrounding systems retried it. I could test these mechanical
+failures: an ambient message should become context without producing a reply, a
+duplicated decision should still create one follow-up, a missing permit should
+end in silence, and a confirmed constraint should survive the ranking path.
+
+The questions that mattered more needed real conversations. Did ZeroClaw
+interrupt, miss a direct request, attribute a dislike to the wrong person, or
+claim that an old grocery order was still in the pantry? A weak suggestion was
+easy to ignore, but an assistant that kept interrupting the family would not
+last long. The cook's circumstances were the hardest to model because available
+time and effort could overturn every carefully ranked dish, and an edited
+message could make a recorded decision obsolete. The household would always be
+messier than its state model. ZeroClaw could read the scattered facts, keep
+track of uncertain memory, and offer a choice that reflected more than the
+latest message. That was the version worth keeping: it had clearly been
+listening, but left the final decision with the cook and the family.

--- a/src/content/blog/building-veera-browser/page.mdx
+++ b/src/content/blog/building-veera-browser/page.mdx
@@ -1,0 +1,138 @@
+export const metadata = {
+  title: "How a Chromium Browser Is Built",
+  date: "2026-08-06",
+  author: "Sid Jain",
+  summary:
+    "While building Veera on Brave’s fork, I learned how GN targets, source overlays, JNI and Mojo bindings, resources, and process lifetimes turn Chromium into an Android browser.",
+  tags: ["chromium", "brave", "android", "c++", "build-systems"],
+  draft: true,
+};
+
+The first useful thing I built at Veera was a browser with less in it.
+Before Veera had a recognizable interface, I spent the earliest phase of the
+work making Brave look less like itself. I removed a piece, rebuilt, and followed
+whatever broke next. A compiler failure usually gave me somewhere to begin. A
+quiet build could be more worrying because it was not always clear which
+implementation had survived. My mental model of a browser fork was still too
+simple. I imagined a source tree with downstream changes layered on top, but the
+Android application emerged from GN targets, generated bindings, source
+substitutions, resources, and registrations spread across several processes.
+
+Brave offered a great deal that would have been wasteful to reproduce: Chromium
+integration, privacy work, and years of decisions about carrying a browser
+downstream. It also arrived as a product with its own assumptions. Before we
+invested in Veera's product surface, I needed to know whether we could separate
+those assumptions from the platform beneath them and maintain what remained with
+a small team.
+
+## Taking Brave apart
+
+Brave's fork behaved more like an overlay than a permanently modified copy of
+Chromium. It pinned an upstream revision, applied patches, added its own build
+targets, and substituted selected source files during compilation. I could see
+the reason for that structure. Keeping downstream changes identifiable makes an
+enormous upstream codebase easier to update than a permanently blended copy. The
+tradeoff was that the answer to “where does this feature live?” was rarely one
+directory. A product decision could enter the browser through a Brave-owned
+component, a patch against Chromium, a replacement source file, a generated
+binding, or a runtime registration. On Android, it could also survive in Java,
+XML, strings, icons, or packaging rules after the native implementation appeared
+to be gone. The source tree showed where files lived, but not all the ways they
+became part of the program.
+
+I started by subtracting. Adding a screen would show that we could build on top
+of the fork. Removing a product system would expose the paths that assembled it.
+The target was a stripped Android build that still compiled, packaged, launched,
+and behaved coherently. Brave Wallet became a useful case because it looked
+self-contained from the outside. There were recognizable activities, settings,
+menu entries, strings, and icons. Those visible parts disappeared quickly, while
+the code behind them continued to surface in the build. Behind the Android UI
+were generated JNI bindings between Java and C++, Mojo interfaces crossing
+component and process boundaries, native services created for each profile,
+renderer hooks, permission handlers, and dependencies spread across several GN
+targets. Removing one layer often revealed the next. A Java class could keep
+generated native glue alive, a factory could continue creating a service whose
+menu entry no longer existed, and a binder could preserve a route to code that
+appeared unreachable from the application.
+
+I stopped deleting by folder and began tracing reachability instead. Where was
+the feature first exposed? What created it? Which process used it? What generated
+code on its behalf? Which resources still described it? I worked from the
+product surface inward, taking one boundary at a time. Early changes were
+deliberately reversible. While I was still learning the architecture,
+temporarily excluding a source or dependency left a clearer trail than
+prematurely inventing a permanent configuration system. Once I understood the
+shape, those exploratory changes could become explicit build decisions. This
+took longer than deleting a directory, but each change left a clear trail for
+the next upstream update that touched the same area.
+
+## The green build I didn't trust
+
+One of the more unsettling results was a successful build after a downstream
+source override had disappeared.
+Brave's source-redirection mechanism could select a downstream implementation in
+place of Chromium's file at the same path. If that downstream file was removed,
+the build could quietly return to the Chromium implementation. Nothing was
+necessarily missing from the linker’s point of view. The browser compiled, but
+the binary might no longer contain the behavior we thought we had preserved. I
+had to verify which source had been selected, which registrations still ran, and
+what happened along the runtime path. Sometimes returning to Chromium's
+implementation was exactly what we wanted, but I still needed to see and record
+that choice rather than discover it later as an accidental change in behavior.
+
+In a smaller codebase, deleting an implementation usually creates an obvious
+hole. Here, it could reveal a complete upstream implementation instead. The
+green build confirmed that the pieces still fit together, but it did not tell
+me which implementation I had shipped. From then on, I checked each subtraction
+twice: first that the affected targets still built and the application launched,
+then that the resulting behavior came from the layer we intended. A clean build
+was a checkpoint, not the end of the investigation.
+
+## Following a feature through Chromium
+
+Once I began reading GN as the assembly plan for the browser, failures became
+more useful. Text search showed where a name appeared. The build graph showed
+why a target existed, who depended on it, and which generated edge had pulled it
+into the binary. A missing JNI class often meant that the Java declaration and
+its generation target no longer agreed. A link failure could reveal a surviving
+registration whose implementation had gone. When the browser launched and then
+failed on a particular path, I would look for a factory, observer, or
+cross-process binding that compilation could not exercise. Each failure showed
+me where my model of the browser was still incomplete.
+
+The picture became clearer when I classified code by lifetime rather than by
+folder. Some objects belonged to the browser process and existed from startup.
+Others were created once per profile, attached to a tab, or installed in a
+renderer frame. A feature that crossed those lifetimes was not scattered by
+accident. The distribution described who owned its state and when its behavior
+was active. That model also made removal more precise. Hiding a button removed
+an entry point. Removing a profile factory stopped user-scoped state from being
+created. Removing a tab helper prevented work from attaching to every page, and
+cleaning up renderer and utility registrations closed paths in other processes.
+I considered the feature gone when its visible surface and ownership graph
+finally agreed.
+
+Chromium builds are expensive enough that bundling several ideas into one attempt
+is always tempting. It saves a build, then makes the result harder to explain
+when something fails. We invested in a tighter loop so that we could change one
+edge, observe one consequence, and keep the decision close to its cause. Faster
+iteration made the investigation much safer. Over time, the failures gave us a
+more useful map than the directory tree. We could see how a piece entered the
+browser, when it came alive, and what would surface if we removed it.
+
+The stripped Android build was visually unremarkable. Its value was that we
+could explain it. We knew which parts came from Chromium, which behavior Brave
+added, where Veera could intervene, and which temporary choices still needed to
+become maintained patches. That understanding changed the work that followed.
+New product surfaces were no longer additions to an opaque fork. We could place
+them according to their lifetime, keep Android and native boundaries deliberate,
+and decide where a downstream change justified the future cost of carrying it.
+Upstream rebases would remain real engineering work, but they were no longer
+encounters with an unknown system.
+
+Taking the browser apart also changed what ownership meant to me. Colors, icons,
+and onboarding can make a fork look like a different product. The team owns it
+only when it can predict where behavior enters, trace it across boundaries, and
+change it deliberately. The first build did not look much like the Veera people
+would eventually use, but we finally understood how this Chromium browser was
+put together. Only then did adding pieces back feel like building Veera.

--- a/src/content/blog/facebook-messenger-protocol-stack/page.mdx
+++ b/src/content/blog/facebook-messenger-protocol-stack/page.mdx
@@ -1,0 +1,130 @@
+export const metadata = {
+  title: "Reverse Engineering Meta’s Messaging Protocol",
+  date: "2026-07-23",
+  author: "Sid Jain",
+  summary:
+    "While building a research client for Messenger, an unexpected MQTT keepalive led through MQTToT, compressed Thrift payloads, and session state shared across HTTP and realtime traffic.",
+  tags: ["reverse-engineering", "facebook", "mqtt", "thrift", "typescript"],
+  draft: true,
+};
+
+One of the most useful packets in this project contained no payload:
+
+```text
+C0 00
+```
+
+Those two bytes are an MQTT `PINGREQ`, the small keepalive a client sends to a
+broker when it has nothing else to say. This one had traveled in the opposite
+direction. Facebook's broker had sent it to me. I was building a research
+client in 2021 that could load my existing Messenger conversations and follow
+new messages without the official mobile application. Login mostly worked, and
+I could establish what looked like a realtime connection. The empty packet
+made it clear that there was not one last private endpoint left to find. I had
+to reconstruct a stack of familiar protocols, then identify the small places
+where Facebook's implementation departed from them.
+
+## The keepalive went the other way
+
+MQTT assigns the two sides of a keepalive exchange clearly. The client sends
+`PINGREQ`, and the broker answers with `PINGRESP`. The state machine I was using
+therefore had no incoming path for `C0 00`. It was behaving correctly for the
+standard and incorrectly for the system in front of it. I initially wondered
+whether the MQTT client was the wrong abstraction altogether, but stream
+parsing, packet framing, QoS, reconnection, and ordinary publish flows still
+behaved as expected. Only the direction of this exchange had changed.
+
+I added the narrowest extension I could: accept an incoming `PINGREQ` and answer
+with `PINGRESP`. The connection stayed alive, and the rest of the state machine
+remained intact. I did not need a Messenger-specific transport. I needed a
+conventional transport with an explicit place for the dialect to depart from
+convention. That small fix gave me an approach for the rest of the protocol. I
+started from the standard, kept everything that matched the traffic, and
+isolated each deviation rather than rewriting the whole layer. When something
+later failed, I could narrow the question to standard MQTT, Messenger's dialect,
+or my own code.
+
+## Reconstructing a Messenger session
+
+Keeping the connection alive was progress, but it did not make the connection a
+Messenger session. The HTTP and realtime sides had to agree on the identity of
+the client: the same device, application, locale, account, and authenticated
+session. Authentication could not be reduced to a token attached at the end.
+Instead, the client's identity depended on state shared across several requests
+and both transports. I moved that state into one shared model. The login flow
+established the authenticated device and session context, and the realtime
+connection consumed that same context rather than recreating its own version.
+That eliminated a class of failures in which both sides looked individually
+plausible but described different clients.
+
+Login still did not provide the history needed to interpret incoming events.
+Messenger used a snapshot-and-delta model. An HTTPS request returned the
+existing conversation state and a sequence cursor. The realtime client then
+used that cursor to establish the queue from which later changes would arrive.
+Authentication made the snapshot possible, and the snapshot made the stream
+meaningful. Skipping a step could leave me with a connection that appeared
+healthy but never received useful data.
+
+The data also crossed several representations. A command could begin as a typed
+object, become a Thrift Compact structure, be compressed, travel inside an MQTT
+publication over TLS, and return through the reverse path. I needed to keep
+those layers separate while debugging. Otherwise, a wrong field number could
+look like a compression failure, or a stale sequence cursor could look like a
+broken transport. The realtime handshake made the layering especially clear.
+Messenger's mobile dialect, known as MQTToT, reused MQTT's fixed header and
+length framing but not an ordinary MQTT `CONNECT`. Inside that familiar
+envelope was a dialect-specific header followed by a compressed Thrift
+connection object. The acknowledgment and subscription setup also used
+structures a normal MQTT client did not expect.
+
+I treated MQTToT as a dialect with a narrow adapter rather than malformed MQTT.
+The adapter replaced the connection writer and acknowledgment reader. The
+underlying client continued to own transport, buffering, publication, QoS,
+keepalives, and reconnects. Keeping the adapter narrow made the unfamiliar
+part small enough to inspect without recreating a well-tested network state
+machine. That boundary was useful whenever a new packet arrived. A framing
+failure pointed to the transport boundary. A connection object that would not
+decode pointed to compression or Thrift. A valid publication with an unknown
+topic belonged above MQTT. I still had plenty of unknowns, but I no longer had
+to debug every layer at once.
+
+## Learning schemas from traffic
+
+Once the connection stayed alive, many incoming publications were still
+compressed buffers without a local Thrift definition. Compact Protocol gave me
+structure in the form of field numbers, wire types, and container boundaries,
+but not meaning. A binary field might be text, an identifier, JSON, another
+Thrift object, or bytes that should remain opaque. I needed to distinguish what
+the bytes established from the names I was guessing.
+
+The first useful tool was a schema-free structural reader. It walked a payload
+and printed numbered fields, their wire types, and their nesting without
+pretending to know their names. Calling a field `userName` after seeing one
+familiar value would make the output easier to read while quietly turning a
+guess into a fact. I only named fields after controlled comparisons. I repeated
+the same operation, changed one visible input, and compared the resulting
+payloads. Stable positions and wire types justified a structural hypothesis. I
+gave a field a domain meaning only when its value changed consistently with an
+action I could observe. Fields that remained ambiguous stayed neutral.
+
+Repeated observations could then become runtime schemas. A schema recorded the
+wire number, expected type, optionality, and TypeScript representation in one
+place. Known fields failed clearly when their wire type changed, while unknown
+fields could be skipped recursively so that a partial understanding remained
+useful as the remote payload evolved. Sixty-four-bit identifiers stayed as
+`bigint` rather than passing through a JavaScript number and quietly losing
+precision. The next payload could then test the schema, and a mismatch failed at
+a specific field instead of quietly corrupting application state. Most
+discoveries were incremental: unknown bytes became stable structure, and only
+then did some fields acquire names. I stopped at whichever level the
+observations supported.
+
+Not every event yielded its meaning. Some stopped at structural decoding, some
+fields remained uncertain, and the remote operations and identifiers continued
+to move. I never expected to finish with a complete, permanent map of
+Messenger. I reused the layers that already matched the traffic, isolated local
+deviations, left unknown fields unnamed, and turned repeated observations into
+schemas that later traffic could challenge. The empty `C0 00` packet contained
+no Messenger data, but it showed me exactly where the standard MQTT model no
+longer fit. The endpoints have long since changed, but I still use the same
+approach whenever I have to learn from a system that can change without notice.

--- a/src/content/blog/from-jsonb-filters-to-self-querying-media-search/page.mdx
+++ b/src/content/blog/from-jsonb-filters-to-self-querying-media-search/page.mdx
@@ -1,0 +1,112 @@
+export const metadata = {
+  title: "Building Semantic Image Search at Memorang",
+  date: "2026-08-13",
+  author: "Sid Jain",
+  summary:
+    "At Memorang, I built a semantic image search prototype that combined embeddings with typed PostgreSQL filters for clinical, product, and access constraints.",
+  tags: ["applied-ai", "postgresql", "search", "typescript"],
+  draft: true,
+};
+
+At Memorang, I was working on an authoring platform for structured educational
+content. A question was rarely just text. It belonged to a versioned curriculum,
+carried answer choices and explanations, and connected to tags, source material,
+media, and assessment metadata. Finding a useful image for it looked like a
+natural job for embeddings, and they did find related concepts even when the
+question and media description used different words. The results also exposed
+the limits of similarity. A dermoscopic image could show the right kind of
+lesion and still be wrong for the lesson because it showed a different body
+location or skin phototype. It might also belong to an organization the editor
+was not allowed to access. An editor might ask for “a dermoscopic image relevant
+to this lesion, on the arm, for Fitzpatrick Type IV skin,” but the system still
+had to preserve a clinical idea, an exact body location, and a controlled skin
+phototype category all the way to the result.
+
+## Separating similarity from constraints
+
+The lesion and clinical concept belonged in the semantic query, while arm and
+Type IV were exact metadata constraints. Organization, project, visibility, and
+deletion state came from the application's access rules. Flattening all of that
+into the text sent to an embedding model would erase those distinctions. A
+vector can place “upper limb” near “arm,” which is useful when language varies,
+but it cannot guarantee that a record has the enumerated value required by the
+workflow. It should not determine whether an editor may see another
+organization's asset either.
+
+SQL predicates solve the exact part of the problem, but they cannot reliably
+find an image related to an explanation when the words do not line up. Letting a
+language model generate unrestricted SQL would have made the system harder to
+reason about and secure without helping with this division. I split the query
+instead: semantic retrieval handled conceptual similarity, typed metadata
+filters enforced the editor's constraints, and application code added
+authorization independently so that model output could neither supply nor
+weaken it. If the parser could not understand an exact medical constraint, the
+search stopped or asked the editor to clarify. A broader result set would have
+silently discarded part of the request.
+
+## Building and checking the query path
+
+The application already contained much of the structure needed to make that
+split work. Stable operational fields such as status, version, organization,
+project, and timestamps were relational. Content that varied across question
+schemas lived in PostgreSQL JSONB. Tags, media, collections, and parent-child
+relationships remained relational because their identity and integrity
+mattered. Before adding a model to the query path, I built a typed filter
+contract over this hybrid schema. A caller could provide a known field, an
+allowlisted operator, and a value. The translator knew whether the field mapped
+to a column, a JSON path, or a relationship, and all values remained
+parameterized. An early version of the translator warned about an unknown field
+and continued without it. That was convenient, but a misspelled constraint could
+broaden the result set without making the failure visible. I changed the
+contract to reject the request, and model-generated filters went through the
+same validation. Editors did not need to know whether a request touched JSONB, a
+trigram index, a relationship, or a vector, but they did need to know when the
+system could not honor it.
+
+Editor search already crossed JSONB fields and relational tags. A query plan
+showed that hydrating those relationships during search was expensive, so I kept
+filtering and ranking on lightweight identifiers. After pagination, the
+application loaded the related content in one batched step. Semantic search
+returned through that existing query layer instead of introducing another way
+to load records. For each media record, I created a compact text representation
+from the fields that could change its meaning: title, description, diagnosis,
+media type, body location, and skin phototype. A question used its stem, correct
+answer, explanation, concept, diagnosis, and specialties. Timestamps and
+internal identifiers stayed out because they added no useful meaning to the
+embedding. I stored the canonical text beside its vector so I could inspect
+exactly what had been embedded when a result looked wrong. The vector index
+returned media identifiers, and the application loaded the current records
+through the existing query layer.
+
+The model translated the editor's sentence into a semantic phrase and a small
+metadata expression drawn from the allowlisted schema. A parser rejected unknown
+fields, values, and operators before application-owned authorization was added.
+It never saw a database connection or wrote SQL. An invalid expression stopped
+the search or prompted a precise follow-up. I kept the prototype in PostgreSQL,
+where the source text, vector, filter, current record, and query plan could be
+inspected together. A separate retrieval service might have made sense later,
+but it was unnecessary until we knew whether the recommendations were useful to
+editors.
+
+To check the prototype, I used media that editors had previously attached to
+questions. For each question, the system retrieved a small candidate set and
+checked whether it recovered an earlier selection. Consistently missing those
+known associations suggested a problem with the representation or filtering,
+but historical choices were signals rather than ground truth. A new
+recommendation could be better than an old selection made from a smaller catalog
+or under constraints that had never been recorded. Nearest neighbors also tended
+to cluster around variants of the same asset, so a candidate list could look
+strong on paper while offering little real choice.
+
+Historical attachments could expose a broken representation, but they could not
+tell us whether a new image was clinically appropriate. That required review by
+subject-matter experts. Editors also needed to tell us whether a suggestion
+saved time, whether they accepted or replaced it, and why. Those reviews could
+explain failures hidden by an aggregate retrieval score, from a missing
+controlled attribute or a poor text representation to an overly broad synonym
+or a constraint that belonged in the authoring model itself. Latency and parse
+failures still mattered, but neither measured the quality of the final editorial
+decision. For the original request, the system could retrieve a candidate for
+the right lesion, on the arm, for Fitzpatrick Type IV skin, then show the text
+and filters that put it there. The editor could review the recommendation before
+deciding what students would see.

--- a/src/content/blog/i-wanted-a-queue-not-a-matchmaker/page.mdx
+++ b/src/content/blog/i-wanted-a-queue-not-a-matchmaker/page.mdx
@@ -1,0 +1,93 @@
+export const metadata = {
+  title: "I Let an AI Agent Take Over My Hinge",
+  date: "2026-08-27",
+  author: "Sid Jain",
+  summary:
+    "I let an AI agent read my Hinge queue, describe profile photos, and draft openings and replies. The protocol layer behind it became hinge-rs, an open-source Rust client.",
+  tags: [
+    "applied-ai",
+    "rust",
+    "reverse-engineering",
+    "distributed-systems",
+    "product-engineering",
+  ],
+  draft: true,
+};
+
+I had not planned to put an AI agent between me and Hinge. I only wanted to stop
+making a decision on one profile just to see the next. One Saturday in 2025, I
+built a local client for my own account that collected the day's recommendations
+into a list I could leave and return to later. Once it could assemble profiles,
+photos, prompts, and conversations in one place, I put a local AI agent on top
+of it. The agent began describing profile photos, proposing opening messages,
+and drafting replies from the conversation so far. It felt like a takeover the
+first time the blank text box stopped being blank.
+
+A recommendation card turned out not to be a card at all. The feed carried a
+subject identifier, an origin, and metadata needed for a later action. Profile
+details and media arrived through other requests. Conversations crossed into
+Sendbird, which brought its own credentials, REST resources, and WebSocket
+connection. Before a model could write anything useful, the application had to
+join those pieces without mixing up the profile being viewed, the rating token
+attached to it, or the history of a different conversation. A model is very good
+at making incomplete context sound complete, so I made context assembly a
+deterministic part of the system.
+
+Authentication created a similar assembly problem. Device, installation, and
+session identifiers lived for different lengths of time, but the server expected
+one coherent client. Replacing one while retaining the others could leave a
+session that looked valid locally and failed remotely. The early Python probe was
+useful for learning that protocol. I moved the stateful core to Rust once the
+client had to survive between runs, preserve recommendation metadata, hydrate
+profiles in batches, and keep a second chat session alive. Known responses
+stayed typed. Unknown WebSocket frames remained available as raw data instead of
+bringing down the connection.
+
+The reply generator could use written prompts directly, but photos needed their
+own pass. They often carried more personality than the written answers, so
+ignoring them stripped away much of what made a profile specific. I added an
+image-description pass that produced a short description of what was visible,
+then placed it beside the prompts and profile details. The agent could now notice
+an activity, a place, or a small background detail that the text alone never
+mentioned. For a new profile, it used that assembled context to draft opening
+messages. Generic charm is cheap, and a message that could be sent to anyone was
+not worth generating. A useful draft had to connect to a particular prompt or
+something visible in a photo. I still chose, edited, or ignored the result, but
+the first sentence was no longer a cold start.
+
+Replies needed a different context window. After a match, the application could
+retrieve the Sendbird transcript and combine the recent exchange with the
+original profile context. The agent drafted a response with both in view, which
+helped it continue a thread instead of asking a question that had already been
+answered. The output was a draft, not an unattended message. I could change it,
+ignore it, or send it. That small boundary kept the feature useful: the model
+handled recall and the first draft, while the conversation still sounded like
+one I had chosen to have.
+
+The visible AI layer was thinner than the plumbing beneath it. The model
+described photos and drafted messages. Rust handled identity, joins, persistence,
+retries, protocol drift, and message transport. Keeping those responsibilities
+separate made failures legible. If a reply was poor, I could inspect the exact
+profile and transcript the model had seen. If the context was wrong, no amount
+of prompting would disguise a broken join or a stale session. This is still the
+most useful lesson I took from the project: an agent becomes dependable when the
+uncertain part sits on top of boring, inspectable tools.
+
+The part worth releasing was the part that knew nothing about my taste. I
+extracted the protocol layer into
+[hinge-rs](https://github.com/f0rr0/hinge-rs), an open-source, typed Rust client
+for Hinge and its Sendbird chat transport. It covers authentication,
+recommendations, profiles, likes, ratings, connections, message history, and
+live chat events, while retaining raw escape hatches for an undocumented API
+that will inevitably change. The crate stops at that boundary. It is the reliable
+protocol layer an agent could use.
+
+The agent never chose who I liked or carried a conversation unattended. It took
+over the tedious parts: gathering the queue, interpreting photos, remembering
+what had been said, and getting the first words onto the screen. That was enough
+to change the experience, and enough to turn a personal Saturday experiment into
+a public Rust library.
+
+_This is a retrospective on a personal experiment. Hinge now
+[prohibits third-party automated
+tools](https://help.hinge.co/hc/en-us/articles/49657802257683-Note-on-Third-Party-Automated-Tools)._

--- a/src/content/blog/no-slots-so-i-built-tranquilo/page.mdx
+++ b/src/content/blog/no-slots-so-i-built-tranquilo/page.mdx
@@ -1,0 +1,106 @@
+export const metadata = {
+  title: "I Sent an AI Agent to Wait in Line for Me",
+  date: "2026-09-03",
+  author: "Sid Jain",
+  summary:
+    "Pronto’s best House Help slots appeared while I was away, so I asked an AI agent to keep looking and come back when it found one I could actually use.",
+  tags: ["typescript", "mcp", "ai-agents", "automation", "distributed-systems"],
+  draft: true,
+};
+
+Pronto's House Help appointments had become a queue I could only join by
+repeatedly checking the app. For several evenings, I opened it after work and
+found nothing useful. I knew appointments were becoming available because I
+would occasionally catch one, only to see it disappear before I could act.
+Checking every few minutes would probably have worked. I did not want to spend
+my evenings doing that, so I gave an AI agent a simple instruction: “Find an
+hour tomorrow after six. If there is nothing, keep looking.”
+
+People fill in quite a lot when they hear a request like that. The software had
+to turn “after six” into a time window, “an hour” into a preference with
+acceptable fallbacks, and “keep looking” into work that survived a sleeping
+laptop, a reboot, and stale availability. It also had to account for a more
+important problem: finding a slot did not reserve it.
+
+## Turning the request into a watch
+
+I started by treating every availability result as an observation made at a
+particular time, rather than a promise that the slot would still be there later.
+That kept search and booking as separate operations from the beginning. The
+availability responses did not always describe slots in the same way. A
+duration could also map to different service identifiers depending on the
+selected address or live catalog. I normalized those variations at the edge
+and carried the resolved service and duration through the rest of the workflow.
+The rest of the program could then use one small model instead of knowing every
+shape the upstream service might return.
+
+Availability was only one part of the request. On most days, I preferred a slot
+after work, then an earlier date, then a particular duration, with a few
+acceptable fallbacks. Those preferences were ordered, not interchangeable. A
+slot in the wrong time window should not win merely because it was twenty
+minutes earlier. I encoded the preferences in priority order: time window
+first, then date, duration, and clock time. Each priority occupied a separate
+score range, so a lower-priority choice could not overpower a higher-priority
+one. Without that separation, a mathematically good score could still produce
+a slot I would never choose.
+
+Time itself required care. Appointment times are local civil times, while
+scheduled checks run at UTC instants. Treating both as ordinary JavaScript dates
+invites quiet errors around parsing and conversion. I used the Temporal model to
+keep those concepts separate, rejecting past or out-of-horizon slots even when
+an old response still contained them. I exposed the workflow as a Model Context
+Protocol tool. The model could translate my sentence into tomorrow's date, a
+six-p.m. boundary, a sixty-minute preference, and instructions to keep looking.
+The tool validated those parameters and stored them as a watch that could
+continue after the conversation ended.
+
+My first instinct was a JavaScript loop with a sleep call, but that was a poor
+fit for a laptop that closes, reboots, changes networks, and gets upgraded. A
+loop is simple while it is running, but keeping it reliable for several days is
+a different problem. On my Mac, each check became a short-lived `launchd` job.
+The operating system woke the program, which acquired an exclusive file lock,
+loaded the watches that were due, checked current availability, recorded the
+next state, and exited. The same design could map to a `systemd` timer or Task
+Scheduler elsewhere.
+
+Instead of keeping a process alive, I persisted the watch. A crash could
+interrupt one check without erasing the instruction to keep looking, and a
+reboot did not require me to remember to restart a daemon. The exclusive lock
+stopped a manual check and a scheduled one from updating the same state at
+once. Each run recorded one event: no match, a transient error, an expiry, or a
+slot worth seeing. Errors delayed the next attempt more than an ordinary miss.
+
+When a useful slot appeared, the watcher saved the exact result, sent a
+notification, cleared its next run, and stopped. The notification marked the
+point where the agent was done and I took over. I had sent it to wait, not to
+choose who entered my home or spend money on my behalf.
+
+## Finding a slot was not booking it
+
+Time still passed between seeing a slot and acting on it, and no local lock
+could reserve an appointment held by a remote service. When I chose a result,
+the booking path searched again for the exact duration and timestamp. If the
+slot had disappeared, it stopped there and returned to fresh availability. If
+the slot remained, the program resolved the service for the selected address
+again before touching the cart.
+
+The cart was another source of stale state. It could contain an old item, a
+change made by another client, or a listing that no longer represented the
+duration I had selected. After setting the item and slot, the program fetched
+the cart again and verified the service identifiers against the choice. The
+checkout used the amount and cart version from that read, not values remembered
+from the earlier search. This narrowed the race without pretending to eliminate
+it. Another customer could still take the appointment after revalidation and
+before checkout completed. I treated that overbooking response as an expected
+outcome and sent the workflow back to search. Careful local code could reduce
+the window, but it could not make the remote booking system transactional.
+
+I deliberately stopped the automation at payment. The tool could prepare
+checkout and render a UPI option locally, but provider credentials never entered
+the model's context and I still had to approve the payment. It was less
+convenient than a single “book it” operation, but I knew exactly where control
+changed hands. The agent was the part I spoke to. The scheduler did the
+waiting, ordinary ranking code compared the slots, and a notification brought
+the decision back to me. I no longer had to keep opening an empty booking
+screen. The agent waited in line, and when it reached the front, it came back
+to get me.

--- a/src/content/blog/the-website-that-waited-2776-days/page.mdx
+++ b/src/content/blog/the-website-that-waited-2776-days/page.mdx
@@ -1,0 +1,69 @@
+export const metadata = {
+  title: "Reviving My Website After 7 Years, 7 Months, and 7 Days",
+  date: "2026-07-30",
+  author: "Sid Jain",
+  summary:
+    "On July 30, 2026, I reopened a personal site I had last updated 2,776 days earlier, left its 2018 version intact, and rebuilt it around the work I do now.",
+  tags: ["personal web", "web development", "writing"],
+  draft: true,
+};
+
+On July 30, 2026, I came back to this website after seven years, seven months,
+and seven days. It still thought I lived in Berlin, described my job at
+Lufthansa, and tried unsuccessfully to load my recent music and activity from
+Last.fm and RescueTime. The last post was dated December 23, 2018. The gap was
+long enough to make the old homepage feel less like an outdated profile and
+more like a letter from an earlier version of me. Before I could publish again,
+I had to decide whether to correct that letter, replace it, or let it remain
+true to the moment in which it was written.
+
+The old homepage mixed professional facts with details I would never put on a
+résumé. It showed where I lived, what I was building, what music I had played
+recently, and how I was spending my time. Some of the live feeds were now
+broken, but their presence said something useful about how I thought personal
+software should work in 2018. I wanted the site to do more than describe me. I
+wanted it to show small, current traces of my days.
+
+What remained on disk was the deployed site rather than a maintainable
+application. I could have reconstructed the source, upgraded the dependencies,
+repaired the integrations, and edited facts that had aged. Each repair would
+have made the page easier to run and slightly less accurate as a record, so I
+chose to preserve it instead. The final deployed build stayed untouched while I
+began the new site separately. The dead feeds are not useful now, but they
+belong to that version of the site. The old location and job are wrong today
+and right for the page. Keeping it intact lets the page say what I considered
+worth sharing then without quietly editing the past.
+
+The old site was organized around three invitations: About, Blog, and Hire Me.
+It introduced a young engineer, collected technical notes, and gave prospective
+clients a way to get in touch. The live activity streams filled some of the
+space between posts. Preserving it answered one question, but I still had to
+decide what the replacement was for. Its front door is now the
+[résumé](/resume), a structured account of my work. The blog fills in what that
+format leaves out: the reasoning, compromises, and wrong turns behind the
+finished systems. That change made rebuilding more sensible than migration.
+Carrying the old architecture forward would have made both versions harder to
+understand. I wanted the earlier site to remain inspectable on its own terms
+and the current one to reflect the work I can maintain now.
+
+Rebuilding also exposed how easily a personal site can contradict itself. The
+résumé page, its PDF, and the structured versions now read from the same record,
+while the feeds and metadata read from the posts. I kept that machinery simple.
+It should keep the current site consistent without changing the old one.
+
+The seven-year gap created a different editorial problem. I was tempted to
+reconstruct it in order, treating the missing years as a backlog, assigning old
+dates to old projects, and working forward until the archive appeared
+continuous. That would have produced a neat chronology and a false account of
+when the writing happened. These new pieces are retrospectives, written with
+the context I have now, and their publication dates should say so. I can
+reconstruct many of the decisions and tradeoffs, but I cannot turn that
+reconstruction into a contemporaneous journal.
+
+I eventually stopped treating the silence as a backlog. I want this site to be
+a place where I can examine work while the important questions are still
+visible, then return when distance reveals something the first account missed.
+Some posts will look back, while others can follow projects that are still
+unfolding. The old site can remain in 2018, complete with Berlin, Lufthansa, and
+the feeds that no longer answer. This one is for what I can still observe
+clearly and for what happens next.

--- a/src/lib/blog-utils.tsx
+++ b/src/lib/blog-utils.tsx
@@ -5,9 +5,15 @@ import { cache } from "react";
 import readingTime from "reading-time";
 import { z } from "zod";
 
+import { env } from "@/env";
+
 const BLOG_DIR = path.join(process.cwd(), "src", "content", "blog");
 const MDX_EXT = "mdx";
 const FOLDER_ENTRY = `page.${MDX_EXT}`;
+const shouldShowDraftPosts =
+  env.NODE_ENV === "development" ||
+  env.VERCEL_ENV === "development" ||
+  env.VERCEL_ENV === "preview";
 
 const metadataSchema = z.object({
   author: z.string(),
@@ -240,7 +246,7 @@ export const getBlogPosts = cache(async (): Promise<BlogPost[]> => {
   );
 
   return posts
-    .filter((post) => post.metadata.draft !== true)
+    .filter((post) => shouldShowDraftPosts || post.metadata.draft !== true)
     .toSorted((a, b) => b.date.getTime() - a.date.getTime());
 });
 


### PR DESCRIPTION
## Summary

Adds seven personal technical essays, all kept as drafts.

The requested preview order follows a weekly Thursday cadence:

1. **I Sent an AI Agent to Wait in Line for Me** — Sep 3, 2026
2. **I Let an AI Agent Take Over My Hinge** — Aug 27, 2026
3. **ZeroClaw Decides What’s for Lunch** — Aug 20, 2026
4. **Building Semantic Image Search at Memorang** — Aug 13, 2026
5. **How a Chromium Browser Is Built** — Aug 6, 2026
6. **Reviving My Website After 7 Years, 7 Months, and 7 Days** — Jul 30, 2026

**Reverse Engineering Meta’s Messaging Protocol** follows on Jul 23, 2026.

All seven articles are visible in local development and Vercel preview deployments for review. Production builds exclude drafts from direct article and share-image routes, the blog index and JSON-LD, RSS, sitemap, and `llms.txt`.

The essays were edited as one collection for a consistent, experienced voice and natural reading rhythm. No article images, generated diagrams, private repository names, or unsupported metrics are included. The Hinge essay covers AI-assisted photo descriptions, profile-grounded openings, and replies informed by conversation history, and introduces the public [hinge-rs](https://github.com/f0rr0/hinge-rs) protocol library.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run format:typ:check`
- `bun run build`
- verified all drafts return 404 in a production build and remain absent from the blog index, RSS, sitemap, `llms.txt`, and generated share-image routes
- verified all requested drafts return 200 in a Vercel preview build and appear in the requested order across the blog index, RSS, sitemap, and `llms.txt`
- visually checked the requested order and dates at a 390px viewport
- branch is one commit based directly on `next`
