### PR TITLE
fix: align contact link separators

### DIFF
--- a/src/app/(portfolio)/resume/page.tsx
+++ b/src/app/(portfolio)/resume/page.tsx
@@ -7,6 +7,7 @@ import {
   formatResumeLocation,
   resumeCompanyStageLabels,
   resumeData,
+  resumeInlineSeparator,
   resumeRoleMarkerLabels,
 } from "@/content/resume";
 import type {
@@ -259,21 +260,25 @@ export function ResumePageContent({
             <p className={`mt-3 ${resumeBodyText}`}>
               {formatResumeLocation(person)}
             </p>
-            <div className="mt-4 flex flex-wrap gap-4 text-sm lg:text-base">
-              {links.map((link) => (
-                <a
-                  key={link.href}
-                  href={link.href}
-                  className={accentText}
-                  target={link.href.startsWith("http") ? "_blank" : undefined}
-                  rel={
-                    link.href.startsWith("http")
-                      ? "noopener noreferrer"
-                      : undefined
-                  }
-                >
-                  {link.label}
-                </a>
+            <div className="mt-4 text-sm lg:text-base">
+              {links.map((link, index) => (
+                <span className="whitespace-nowrap" key={link.href}>
+                  {index === 0 ? null : (
+                    <span aria-hidden="true">{resumeInlineSeparator}</span>
+                  )}
+                  <a
+                    href={link.href}
+                    className={accentText}
+                    target={link.href.startsWith("http") ? "_blank" : undefined}
+                    rel={
+                      link.href.startsWith("http")
+                        ? "noopener noreferrer"
+                        : undefined
+                    }
+                  >
+                    {link.label}
+                  </a>
+                </span>
               ))}
             </div>
           </section>

--- a/src/content/resume.ts
+++ b/src/content/resume.ts
@@ -71,9 +71,11 @@ export interface ResumePersonLocation {
   mobility?: readonly string[];
 }
 
+export const resumeInlineSeparator = "\u2002•\u2002";
+
 export const formatResumeLocation = (
   person: ResumePersonLocation,
-  separator = "\u2002•\u2002"
+  separator = resumeInlineSeparator
 ) => [person.location, ...(person.mobility ?? [])].join(separator);
 
 interface DeepDiveSection {


### PR DESCRIPTION
## What changed

- Added dot separators between the email, LinkedIn, and GitHub links on the résumé header.
- Reused the exact separator character and spacing already used between the Mumbai location and travel availability.
- Kept each separator attached to the following link so wrapped contact rows remain tidy.

## Why

The contact links previously used flex gap spacing without visible separators, so they did not match the adjacent location metadata. Sharing one separator constant keeps both rows visually consistent and prevents their spacing from drifting.

## Impact

The résumé contact row now reads consistently with the location row on both `/` and `/resume`. Existing responsive text sizing and link behavior are preserved.

## Validation

- `bun run build`
- TypeScript validation during the production build
- `oxfmt --check` on both changed files
- `oxlint` on both changed files
- `git diff --check`

The repository-wide pre-push lint hook still reports pre-existing formatting and lint failures in unrelated blog, JSON-LD, image, and Mermaid files on `next`; none are changed by this PR.
