### PR TITLE
docs(blog): revise unpublished posts

### DIFF
--- a/inspiration/unpublished-blog-visual-prompts.md
+++ b/inspiration/unpublished-blog-visual-prompts.md
@@ -1,0 +1,76 @@
+# Visual prompts for the unpublished posts
+
+These are short base prompts to paste into `gpt-image-2`. They follow OpenAI's [GPT Image Generation Models Prompting Guide](https://developers.openai.com/cookbook/examples/multimodal/image-gen-models-prompting-guide): intended use first, then scene, subject, details and explicit constraints. They are deliberately short so the first result is easy to steer with one-change follow-ups.
+
+## Shared direction, not a house-style prison
+
+- Use generated images for mood and metaphor. Use real screenshots for product comparisons, and Mermaid/SVG for labels, protocols, timings and measured data.
+- Default texture: loose pen or graphite marks on off-white paper, imperfect lines, plenty of breathing room, one dark ink plus one or two accent colours.
+- Avoid glossy 3D, neon futurism, stock-illustration people, fake UI text, decorative circuitry, logos, watermarks and visual clutter.
+- Do not ask an image model to render a factual graph. Plot the real values in code, then borrow the paper, ink and colour treatment.
+
+## Graph or diagram restyle
+
+Render the verified graph or Mermaid diagram first and attach it as Image 1. This edit prompt uses the guide's “change only X; preserve everything else” pattern:
+
+> Editorial diagram edit. Change only the rendering style of Image 1 to loose black-ink lines on warm off-white paper with one muted accent colour and slight hand-drawn irregularity. Preserve every word, number, axis, arrow, node, connection, order and relative position exactly. No new text, no missing marks, no watermark, no decorative objects.
+
+## Reviving My Website After 7 Years, 7 Months, and 7 Days
+
+**Use real material:** place an old-site screenshot beside the rebuilt page. Add a small, code-drawn timeline for 23 December 2018, the archived build, the April 2026 domain change and the July 2026 rebuild.
+
+**Optional opening illustration — 3:2 landscape**
+
+> Editorial blog illustration. On an off-white desk, an old browser window sits under a thin layer of dust while a fresh, sparse page is being redrawn beside it. The old side feels like a slightly faded photocopy; the new side is loose graphite with one warm-ochre mark, uneven human lines, quiet afternoon mood, generous negative space. No logos, no readable text, no glossy UI, no photorealism.
+
+## Reverse Engineering Meta’s Messaging Protocol
+
+**Use an exact diagram:** Mermaid for WebSocket → MQTT dialect → Thrift Compact → snapshot/delta state. Keep packet names in the article, not in generated art.
+
+**Optional section break — 16:9 landscape**
+
+> Technical editorial spot illustration. A single red packet travels through four translucent protocol layers like sheets in an engineer's notebook, ending in a small chat bubble assembled from fragments. Blue carbon-paper marks with one signal-red pencil accent, sparse annotations made only of dots and short strokes. No logos, no legible text, no cyberpunk glow, no polished infographic.
+
+## How a Chromium Browser Is Built
+
+**Use an exact diagram:** a compact build-time/runtime split in Mermaid. If a build-time graphic is added later, plot only measurements actually captured and label POC versus shipped work.
+
+**Optional header — 3:2 landscape**
+
+> Editorial engineering illustration. A browser is opened like a mechanical watch, with a few labelled-looking but unreadable layers being carefully lifted out while the central engine stays intact. Faint blueprint grid, scratchy cobalt pencil and one burnt-orange grease-pencil mark, precise enough to feel technical but visibly hand drawn. No brand marks, no tiny text, no 3D render, no excessive parts.
+
+## Building Semantic Image Search at Memorang
+
+**Use an exact diagram:** query text branching into a typed metadata filter and vector search, then rejoining before ranking. Do not illustrate Fitzpatrick types as colours inferred from faces; the article explicitly treats them as controlled, human-assigned metadata.
+
+**Optional opening illustration — 3:2 landscape**
+
+> Editorial search illustration. A librarian's hand passes a loose cloud of image cards through two simple gates—one shaped like a checklist, one like a field of nearby dots—and receives a small relevant set. Cut-paper cards, graphite arrows and muted teal rubber-stamp dots with one mustard tab, thoughtful rather than futuristic. No faces, no medical claims, no readable labels, no glowing AI brain.
+
+## ZeroClaw Decides What’s for Lunch
+
+**Use a synthetic transcript:** typeset the short redacted exchange in HTML or MDX. Pair it with a small exact permit-flow diagram if the prose still needs one.
+
+**Optional opening illustration — 4:3 landscape**
+
+> Warm editorial doodle. A family dining table, a phone with abstract message marks, a pantry notebook and a cooking pot are joined by one slightly tangled line that becomes tidy near the notebook. Loose charcoal with a leaf-green pencil and one tomato-red watercolour wash, imperfect domestic sketch, calm and lightly funny. No real people, no readable chat text, no logos, no robot character.
+
+**Optional pantry illustration — 3:2 landscape**
+
+> Rough ink-and-pencil cutaway of a pantry shelf beside a phone camera frame and a grocery-order receipt; a few hand-drawn arrows turn tomatoes, capsicum and lentils into three small states: present, uncertain, gone. Off-white paper, charcoal linework, one spinach-green wash and tiny tomato-red accents, observational weekend-sketchbook energy. Keep it sparse and domestic, not a polished product diagram. No logos, no readable app UI, no robot, no neon.
+
+## I Let an AI Agent Take Over My Hinge
+
+**Use a factual visual:** a small code-drawn boundary graphic showing recommendations in, private review, optional draft, and no automatic like/send. Do not use real profile photographs or conversations.
+
+**Optional header — 3:2 landscape**
+
+> Wry editorial line drawing. A short queue of anonymous profile cards reaches a small writing desk where a human still holds the pen; a machine only organises the cards beside them. Two-colour risograph in charcoal black and dusty pink, slightly misregistered ink, one deliberately awkward card leaning sideways, lots of empty space. No app logo, no real faces, no readable text, no hearts explosion, no glossy dating-ad style.
+
+## I Sent an AI Agent to Wait in Line for Me
+
+**Use an exact visual:** keep the watcher state progression in text/Mermaid and, if useful, add a tiny timeline showing that checks pause while the laptop is asleep and resume when it wakes.
+
+**Optional opening illustration — 3:2 landscape**
+
+> Restrained editorial sketch. A person leaves a long, faint appointment queue while a small clockwork note-holder keeps their place and raises a paper flag when one slot opens. Blue ballpoint drawn on a lightly creased appointment slip with a single marigold-yellow highlighter mark, everyday Indian urban mood, understated humour. No robots, no logos, no readable text, no surreal machinery, no polished vector art.

--- a/src/content/blog/building-on-zeroclaw/page.mdx
+++ b/src/content/blog/building-on-zeroclaw/page.mdx
@@ -3,124 +3,206 @@ export const metadata = {
   date: "2026-08-20",
   author: "Sid Jain",
   summary:
-    "I put ZeroClaw in our family Telegram group and asked it to choose lunch. It first had to learn when to speak, what to remember, and which decisions belonged to the family.",
+    "A weekend ZeroClaw hack that coordinates our split office/WFH household, turns pantry photos and Instamart orders into usable state, and helps our cook break the lunch loop.",
   tags: ["applied-ai", "rust", "ai-agents", "zeroclaw"],
   draft: true,
 };
 
-ZeroClaw had one job in our family group chat: decide what was for lunch.
-The trouble was that the family had usually started answering the question long
-before anyone asked it. One person had ruled out eggs, the cook had mentioned
-half a cabbage and some capsicum, and someone else remembered that yesterday's
-paneer felt too heavy. None of those messages was a meal plan on its own, but
-together they were the context behind “What should we make?” A model with access
-to recipes can answer that question in seconds. It can also suggest a dish
-nobody wants, assume an ingredient is still available, or ignore the person who
-will actually cook it.
+Every day, our family has roughly the same meeting without putting it on anyone's calendar: what should we make for lunch?
 
-That made lunch an unexpectedly good test for a personal assistant. I built a
-prototype on [ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw), a Rust agent
-runtime, and placed it in the Telegram group where the conversation already
-happened. The useful context arrived in fragments, and some of it was already
-going stale. I began with meal recommendations, but the recipe itself soon
-became the easy part.
+We don't have this discussion around the kitchen counter. On most weekdays, some of us are working from the office and others are working from home. We also have a cook who comes in to prepare breakfast, lunch and dinner. The cook needs a clear plan; the rest of us are replying between calls, meetings and whatever else the day has decided to throw at us. Chat became the obvious coordination layer because it is the one room everybody can be in.
 
-## Listening without interrupting
+The conversation is asynchronous; the cook's schedule is not. Once lunch preparation starts, a brilliant reply from somebody at the office is mostly useful for tomorrow.
 
-An assistant that sees only messages addressed to it misses most of a group
-chat. One that replies whenever it notices something relevant quickly becomes
-unbearable. It needed to follow the conversation without behaving as though
-every message had been sent for its benefit. I separated the right to observe
-from the right to participate. Messages from the allowed group could be recorded
-as context without starting a visible assistant turn. A command or question
-addressed to the assistant could proceed immediately. For everything else, a
-small classifier decided whether the message called for a response or should
-simply become part of the recent conversation.
+Someone asks the cook what's available. A few vegetables are listed. One person wants something light, another doesn't feel like eating paneer again, somebody at the office sees the thread late, and the whole thing starts moving backwards. The person at home becomes an unwilling message broker. None of this is particularly tragic. It is, however, an impressive amount of daily back-and-forth for lunch.
 
-I treated that classification as a suggestion, then enforced it in code. When a
-reply was warranted, the runtime recorded a permit against the incoming message.
-The outbound Telegram path checked for that permit before sending anything. If
-the classifier returned malformed output, the provider failed, or the permit was
-missing, ZeroClaw stayed quiet.
-This was a better boundary than a line in the prompt. Prompt changes and new
-tool paths could alter the model's behavior, but the channel check still
-controlled whether a message left the system. It also left a record of why the
-assistant had spoken instead of making me reconstruct the decision from its
-answer later. The boundary matched the social rule of the group too. Remembering
-a pantry update did not require commenting on it, so most of ZeroClaw's work
-could remain invisible until somebody actually wanted its opinion.
+The safe dishes also have a habit of returning. We forget why something didn't work last week, which ingredients are actually left, or who had already ruled out what. Decision paralysis eventually beats novelty and we settle on one of the usual suspects.
 
-## Giving memory an expiry date
+After going through this loop enough times, I began wondering whether AI could do more than produce another confident list of recipes. All the useful context already existed: it was just scattered across messages from the office and home, pantry photos, old orders and the cook's memory. Could an assistant quietly gather it, turn the conversation into a complete decision the cook could act on, and remember enough to avoid the same discussion tomorrow?
 
-The first version of memory looked deceptively simple. Save the messages,
-retrieve the recent ones, and let the model reason over them. That worked for a
-short conversation, but raw chat made a poor long-term household model. A
-preference belonged to a person, feedback referred to a particular meal, and
-pantry observations needed sources and timestamps. The system also had to
-distinguish a dish the family chose from one they had merely discussed.
-I kept the original messages and built the household state beside them. The
-system could derive per-person preferences, recent meal episodes, feedback,
-pantry observations, and open decisions without erasing where each fact came
-from. Retrieval began with ordinary full-text search over messages and episodes.
-Semantic ranking could help when the wording differed. Any retrieved fact still
-pointed back to the message that supported it.
+It sounded like a fun weekend project. It also sounded like an excellent excuse to hack on [ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw).
 
-Attribution needed stricter handling. “She does not like mushrooms” could not
-become a durable preference unless the system knew who “she” referred to. A
-passing dislike also could not become a dietary constraint. I kept ambiguous
-statements as questions and accepted hard constraints only from explicit,
-attributable messages. Asking for clarification was preferable to quietly
-inventing a profile of someone. The pantry made this problem more obvious. A
-grocery order showed that tomatoes had entered the house, not that they were
-still there. A photo captured one angle at one moment, and the cook's message
-was usually more current, although even that observation aged. I recorded the
-source and time of each observation, then reduced its weight according to age
-and perishability. The freshness model only needed to tell the assistant when it
-should ask. If capsicum had been mentioned that morning while paneer appeared
-only in an older order, ZeroClaw could say what it knew and ask the cook whether
-the paneer was still available. Each new source introduced more disagreement
-and staleness, but it also showed the system where its memory was weak.
+## Why ZeroClaw
 
-## Letting ZeroClaw choose
+I had already used ZeroClaw at work and spent enough time inside its Rust runtime to know where the interesting seams were. Two of my fixes had made it upstream: one for [authenticated Slack attachments and Socket Mode hardening](https://github.com/zeroclaw-labs/zeroclaw/pull/3086), and a much smaller one that made [Slack's `mention_only` setting work end to end](https://github.com/zeroclaw-labs/zeroclaw/pull/3715). So channels, attachments, reply policy and long-running agents were familiar territory.
 
-Once the context was in reasonable shape, meal suggestions became
-straightforward. In early tests, the model could interpret requests such as
-“something light but not boring,” connect them to recent feedback, and propose a
-few plausible dishes. I applied confirmed dietary constraints before ranking.
-Among the remaining options, I gave extra weight to the person whose preferences
-had been accommodated least often in recent meals, so one enthusiastic vote
-could not repeatedly dominate everyone else. The model could help interpret
-language and explain a tradeoff, while the constraints and ranking rule remained
-regular code.
+ZeroClaw already gave me a daemon, Telegram, model providers, tools, SQLite memory, scheduling and hooks around incoming messages. I could concentrate on the oddly specific household intelligence instead of starting with “first, build an agent framework”.
 
-Choosing a dish also changed durable state, which introduced another problem:
-saving that decision safely. Messaging systems retry deliveries, model calls
-time out, and workers restart. A conversation might simply end with, “We chose
-dal.” The assistant would record the decision and schedule one later question
-about how the meal went. If Telegram delivered that message twice, the household
-should not acquire two decisions and two reminders. The runtime therefore bound
-a write to the actual incoming message rather than trusting an identifier
-supplied by the model. Repeating the same operation returned the earlier result.
-Trying to reuse the message for a different change produced a conflict.
+The result lives publicly in [PR #8 on my ZeroClaw fork](https://github.com/f0rr0/zeroclaw/pull/8). The current diff adds 13,570 lines across 33 files. This got out of hand in the best possible way.
 
-Scheduling the follow-up added one complication. The meal state and the
-scheduler lived in separate stores, so they could not be committed atomically.
-The meal transaction recorded the intent to schedule a follow-up, and a worker
-reconciled that intent with a deterministic job name. The bookkeeping stayed
-invisible in the chat. A meal decision still produced one reminder, however many
-times the surrounding systems retried it. I could test these mechanical
-failures: an ambient message should become context without producing a reply, a
-duplicated decision should still create one follow-up, a missing permit should
-end in silence, and a confirmed constraint should survive the ranking path.
+## Listening is not the same as replying
 
-The questions that mattered more needed real conversations. Did ZeroClaw
-interrupt, miss a direct request, attribute a dislike to the wrong person, or
-claim that an old grocery order was still in the pantry? A weak suggestion was
-easy to ignore, but an assistant that kept interrupting the family would not
-last long. The cook's circumstances were the hardest to model because available
-time and effort could overturn every carefully ranked dish, and an edited
-message could make a recorded decision obsolete. The household would always be
-messier than its state model. ZeroClaw could read the scattered facts, keep
-track of uncertain memory, and offer a choice that reflected more than the
-latest message. That was the version worth keeping: it had clearly been
-listening, but left the final decision with the cook and the family.
+The assistant lives in the Telegram group where the discussion already happens. A representative exchange looks like this:
+
+```text
+Me: No eggs today, please.
+Cook: We have half a cabbage and some capsicum left.
+Family: Paneer was too heavy yesterday.
+Me: @mealbot, what should we make for lunch?
+```
+
+If the bot only sees the final mention, it misses almost everything that makes the answer useful. If it responds to every food-shaped message, it becomes the most enthusiastic and least welcome member of the family group.
+
+I split the two behaviours:
+
+```text
+message
+  -> store as household context
+  -> decide: ingest_only | respond
+  -> if respond: run the agent
+  -> if an outbound permit exists: reply in Telegram
+```
+
+Direct questions and commands can start an agent turn immediately. Ordinary messages pass through a small classifier that returns a deliberately boring schema:
+
+```json
+{
+  "decision": "respond | ingest_only",
+  "confidence": 0.0,
+  "intent": "meal | feedback | clarification | other",
+  "reason_code": "..."
+}
+```
+
+The default threshold is `0.72`; malformed output or a provider failure becomes `ingest_only`. Even a positive classification creates a reply permit that the outbound Telegram path checks before sending anything. A prompt saying “don't be annoying” is optimistic. A missing permit ending in silence is much more useful.
+
+This lets the bot hear the cook say that the cabbage is nearly finished without cheerfully explaining cabbage to everyone. When somebody later asks for lunch ideas, that message is waiting in context.
+
+## Learning who likes what
+
+A family is not one large user with internally inconsistent preferences. The assistant keeps per-person preference evidence, recent meals, feedback and temporary constraints separately.
+
+| Message | What it can become |
+| --- | --- |
+| “No eggs today” | A temporary constraint attributed to the speaker |
+| “Paneer was too heavy yesterday” | Feedback tied to a person and a meal |
+| “We have half a cabbage left” | A timestamped pantry observation from the cook |
+| “She doesn't like mushrooms” | A question, until “she” resolves to someone |
+
+That last case matters. The easiest implementation is to flatten every sentence into household memory and let retrieval sort it out later. It is also how one person's passing comment becomes everybody's permanent dislike. The branch stores the original message as evidence and only promotes a preference when it can attribute it with enough confidence. Ambiguous claims remain unresolved.
+
+The same separation helps with repetition. “We ate this recently”, “I didn't enjoy it”, and “everyone liked it” are different signals. The system records a meal episode, associates later feedback with it, and makes both available during the next round of suggestions.
+
+## The pantry was the fun part
+
+This is where the project stopped feeling like a recipe bot.
+
+Most meal assistants quietly assume somebody maintains a perfect inventory. I have never met this person. In our house, pantry state arrives in three rather more believable forms:
+
+1. The cook says what is left.
+2. Somebody sends a photo of the fridge, shelf or vegetables on the counter.
+3. Instamart remembers what we bought.
+
+I wired all three into one evidence pipeline:
+
+```text
+cook message ───────────────┐
+pantry photo ───────────────┼─> pantry observations
+order screenshot ──────────┤      + source
+Instamart order history ───┘      + time
+                                  + perishability
+                                         |
+                                         v
+                    likely_available | uncertain | likely_unavailable
+```
+
+The [image path](https://github.com/f0rr0/zeroclaw/blob/3e5eed1208b9b444830febcfeecb82a8f3259a3d/src/hooks/builtin/meal_ingress.rs#L615-L809) is especially satisfying. Drop a pantry photo or an order screenshot into the group and ZeroClaw queues it for extraction. A vision model has to return strict JSON containing the image kind, visible food items, rough quantity hints, observation time and a freshness profile. The prompt explicitly tells it not to invent food outside the frame, and non-food items such as soap are marked as such. Low-confidence images and items are ignored.
+
+A pantry photo can therefore produce observations shaped like:
+
+```json
+{
+  "image_kind": "pantry_photo",
+  "items": [
+    {
+      "item_name": "capsicum",
+      "quantity_hint": "2–3 visible",
+      "freshness_profile": "high",
+      "is_food": true,
+      "confidence": 0.91
+    }
+  ]
+}
+```
+
+Those observations are committed to the pantry store using the source message as an idempotency key. Retrying the image job doesn't mysteriously create three new capsicums. More importantly, the next meal recommendation can actually use what was visible in the photo. That small loop—send image, update pantry, get a better lunch suggestion—is ridiculously cool in practice.
+
+Instamart is connected rather than merely mentioned. A household member can link their account, after which the [meal tools can fetch recent order history](https://github.com/f0rr0/zeroclaw/blob/3e5eed1208b9b444830febcfeecb82a8f3259a3d/src/tools/meal_instamart_sync.rs#L532-L702) through the Instamart MCP integration. A pantry-related turn—or an empty pantry context—can trigger a bounded refresh for a connected user. Order items retain their original timestamps instead of all appearing magically fresh on sync day.
+
+Of course, buying tomatoes on Tuesday does not mean tomatoes still exist on Friday. The [pantry projection](https://github.com/f0rr0/zeroclaw/blob/3e5eed1208b9b444830febcfeecb82a8f3259a3d/src/meal/store.rs#L603-L650) gives each observation a source weight and then lets it decay with age. In simplified form:
+
+```text
+observation score =
+  source weight × extraction confidence × 2 ^ (-age / freshness half-life)
+```
+
+Direct photo evidence starts at `1.0`, a manual chat observation at `0.9`, and an Instamart order at `0.55`. Highly perishable items have a half-life of about 1.5 days; medium, low and very-low perishability profiles decay over roughly 5, 20 and 90 days. Multiple observations can reinforce one another, recorded use pushes availability down, and old observations eventually hit a hard cutoff. These are hand-tuned heuristics, not probabilities pretending to be science.
+
+This is not a magical fridge API. It is something more useful: a current best guess with enough provenance to say “capsicum is probably available; paneer needs checking”. The cook can correct it in one message and become the freshest source again.
+
+## Turning context into a decision
+
+Once the household context is assembled, I expose three main tools to the model:
+
+```text
+meal_context_read   -> preferences, feedback, recent meals and pantry state
+meal_options_rank   -> score a proposed set of dishes
+meal_memory_write   -> record the choice, feedback or a new observation
+```
+
+The model is good at interpreting requests such as “something light but not boring” and generating plausible candidates. It is not allowed to wave away a dietary constraint or decide that the loudest person's favourite should win every day.
+
+Confirmed hard constraints remove a dish before ranking. Ordinary code then considers per-person fit, pantry confidence, recent repetition and feedback. The remaining choices sort first by the least-happy person's score—a small fairness floor—and then by their total:
+
+```text
+score =
+    preference fit
+  + pantry confidence
+  + previous feedback
+  - recent repetition
+```
+
+The cook's messages remain part of the grounding context because “technically possible from the ingredient list” and “reasonable to cook today” are not the same thing. The assistant is there to get the group to a sensible shortlist and a visible decision, not to issue culinary decrees from a SQLite database.
+
+## Knowing when the meal decision is complete
+
+There was another bit of state hiding inside the chat: had we actually finished deciding?
+
+The completeness I cared about here was conversational, not nutritional. Had the family produced one decision that the cook could proceed with?
+
+A bot producing three good options has not completed anything. Neither has one person saying “looks good” while somebody else is still asking for a change. For our cook, the useful output is not an impressive recommendation—it is one clear answer.
+
+The [decision state in the branch](https://github.com/f0rr0/zeroclaw/blob/3e5eed1208b9b444830febcfeecb82a8f3259a3d/src/meal/store.rs#L2908-L2944) models this explicitly. Each household, local date and meal slot can have one open decision case:
+
+```text
+household_id:local_date:meal_slot:slot_instance
+                      |
+                      v
+                 decision open
+                      |
+         the discussion continues
+                      |
+         chosen meal -> record_episode(...)
+                      |
+                      v
+                decision closed
+```
+
+The case stays open while the group is discussing options. A `record_episode` operation is the closure signal: it [stores the chosen meal and tags, who decided it and the source message](https://github.com/f0rr0/zeroclaw/blob/3e5eed1208b9b444830febcfeecb82a8f3259a3d/src/meal/store.rs#L3109-L3163), then [timestamps the case as closed](https://github.com/f0rr0/zeroclaw/blob/3e5eed1208b9b444830febcfeecb82a8f3259a3d/src/meal/store.rs#L3423-L3443). A later rethink can become a new version rather than quietly rewriting how the first discussion ended.
+
+“Closed” has a deliberately narrow meaning. It says the coordination produced a recorded choice. It does not claim that the food has already been cooked, served or eaten.
+
+If Telegram retries a message or the model calls the write tool twice, the same operation returns the stored result instead of logging a second lunch. A separate `schedule_feedback_nudge` operation can create an outbox intent for later; a worker reconciles that with ZeroClaw's scheduler.
+
+So the loop finally closes:
+
+1. The group and cook converge on a meal.
+2. ZeroClaw records what was actually chosen.
+3. It asks how lunch went later.
+4. That feedback and the meal history influence tomorrow's options.
+
+The first version of this idea was “read the group from top to bottom and suggest lunch”, which is both vague and not really the problem. The problem was the repeated coordination: information arriving at different times, preferences belonging to different people, a pantry that changes underneath us, and no memory of how yesterday's choice went.
+
+This is still a weekend prototype. Photos and orders are evidence rather than truth, and our cook remains the final pantry sanity check. That is perfectly fine. The delightful part is that someone can send a photo, somebody else can have an Instamart account connected, the cook can mention what has run out, and the assistant turns all of it into one fresh, attributed view before suggesting lunch.
+
+Thirteen and a half thousand lines may be a ridiculous response to “what should we eat?”. Going through the same meeting every day was beginning to feel slightly more ridiculous.

--- a/src/content/blog/building-on-zeroclaw/page.mdx
+++ b/src/content/blog/building-on-zeroclaw/page.mdx
@@ -72,12 +72,12 @@ This lets the bot hear the cook say that the cabbage is nearly finished without 
 
 A family is not one large user with internally inconsistent preferences. The assistant keeps per-person preference evidence, recent meals, feedback and temporary constraints separately.
 
-| Message | What it can become |
-| --- | --- |
-| “No eggs today” | A temporary constraint attributed to the speaker |
-| “Paneer was too heavy yesterday” | Feedback tied to a person and a meal |
-| “We have half a cabbage left” | A timestamped pantry observation from the cook |
-| “She doesn't like mushrooms” | A question, until “she” resolves to someone |
+| Message                          | What it can become                               |
+| -------------------------------- | ------------------------------------------------ |
+| “No eggs today”                  | A temporary constraint attributed to the speaker |
+| “Paneer was too heavy yesterday” | Feedback tied to a person and a meal             |
+| “We have half a cabbage left”    | A timestamped pantry observation from the cook   |
+| “She doesn't like mushrooms”     | A question, until “she” resolves to someone      |
 
 That last case matters. The easiest implementation is to flatten every sentence into household memory and let retrieval sort it out later. It is also how one person's passing comment becomes everybody's permanent dislike. The branch stores the original message as evidence and only promotes a preference when it can attribute it with enough confidence. Ambiguous claims remain unresolved.
 

--- a/src/content/blog/building-veera-browser/page.mdx
+++ b/src/content/blog/building-veera-browser/page.mdx
@@ -72,12 +72,12 @@ autoninja -C out/Android brave
 
 The failure stage often told me which graph I had reached:
 
-| Failure | What it usually exposed |
-| --- | --- |
-| `gn gen` | A missing label, invalid include, or broken target edge |
-| Java/C++ compile | A surviving caller, override, source, or generated input |
-| Link | Registration remained after its implementation disappeared |
-| Resource packaging | XML, strings, icons, or commands still described old UI |
+| Failure                | What it usually exposed                                     |
+| ---------------------- | ----------------------------------------------------------- |
+| `gn gen`               | A missing label, invalid include, or broken target edge     |
+| Java/C++ compile       | A surviving caller, override, source, or generated input    |
+| Link                   | Registration remained after its implementation disappeared  |
+| Resource packaging     | XML, strings, icons, or commands still described old UI     |
 | Startup or interaction | A factory, observer, binder, or runtime assumption survived |
 
 That last row is important. GN describes the build graph; it doesn't prove the runtime behaviour. I still had to launch the APK, instrument registrations and initialisation paths, exercise the affected UI and browsing flows, and run behavioural checks. A dependency can be absent from one target while a fallback implementation, dynamically reached path, or stale resource keeps the product behaving differently from what the diff suggests.

--- a/src/content/blog/building-veera-browser/page.mdx
+++ b/src/content/blog/building-veera-browser/page.mdx
@@ -3,136 +3,133 @@ export const metadata = {
   date: "2026-08-06",
   author: "Sid Jain",
   summary:
-    "While building Veera on Brave’s fork, I learned how GN targets, source overlays, JNI and Mojo bindings, resources, and process lifetimes turn Chromium into an Android browser.",
+    "What a two-commit Veera proof of concept taught me about Brave’s Chromium overlay, GN targets, JNI and Mojo boundaries, resources, and runtime ownership.",
   tags: ["chromium", "brave", "android", "c++", "build-systems"],
   draft: true,
 };
 
 The first useful thing I built at Veera was a browser with less in it.
-Before Veera had a recognizable interface, I spent the earliest phase of the
-work making Brave look less like itself. I removed a piece, rebuilt, and followed
-whatever broke next. A compiler failure usually gave me somewhere to begin. A
-quiet build could be more worrying because it was not always clear which
-implementation had survived. My mental model of a browser fork was still too
-simple. I imagined a source tree with downstream changes layered on top, but the
-Android application emerged from GN targets, generated bindings, source
-substitutions, resources, and registrations spread across several processes.
 
-Brave offered a great deal that would have been wasteful to reproduce: Chromium
-integration, privacy work, and years of decisions about carrying a browser
-downstream. It also arrived as a product with its own assumptions. Before we
-invested in Veera's product surface, I needed to know whether we could separate
-those assumptions from the platform beneath them and maintain what remained with
-a small team.
+Before Veera had a recognisable interface, I spent the earliest phase of the work making Brave look less like itself. I removed a piece, rebuilt, and followed whatever broke next. A compiler failure usually gave me somewhere to begin. A quiet build could be more worrying because it wasn't always clear which implementation had survived.
+
+The version and scope matter here. I started with [Brave Core `1.51.40`](https://github.com/brave/brave-core/tree/v1.51.40), pinned to [Chromium `111.0.5563.64`](https://chromium.googlesource.com/chromium/src/+/111.0.5563.64). Across two exploratory commits touching 123 files, I removed enough Brave product machinery to produce a neutral Android browser that compiled, linked, packaged, launched, and could be inspected. This was a proof of concept, not the final architecture of the browser that shipped. The comments, disabled dependencies, and rough edges were a map for the next piece of work, not a patch stack I wanted to carry forever.
+
+Brave offered a great deal that would have been wasteful to reproduce: Chromium integration, selected privacy infrastructure, and years of decisions about carrying a browser downstream. It also arrived as a product with assumptions of its own. Before we invested in Veera's product surface, I needed to know whether a small team could separate those assumptions from the platform beneath them and understand what remained.
 
 ## Taking Brave apart
 
-Brave's fork behaved more like an overlay than a permanently modified copy of
-Chromium. It pinned an upstream revision, applied patches, added its own build
-targets, and substituted selected source files during compilation. I could see
-the reason for that structure. Keeping downstream changes identifiable makes an
-enormous upstream codebase easier to update than a permanently blended copy. The
-tradeoff was that the answer to “where does this feature live?” was rarely one
-directory. A product decision could enter the browser through a Brave-owned
-component, a patch against Chromium, a replacement source file, a generated
-binding, or a runtime registration. On Android, it could also survive in Java,
-XML, strings, icons, or packaging rules after the native implementation appeared
-to be gone. The source tree showed where files lived, but not all the ways they
-became part of the program.
+[Brave Core](https://github.com/brave/brave-core) behaves more like an overlay than a permanently blended copy of Chromium. It pins an upstream revision, applies patches, adds its own [GN](https://gn.googlesource.com/gn/+/main/docs/quick_start.md) targets, and substitutes selected source files during compilation. Brave's own [patching and `chromium_src` documentation](https://github.com/brave/brave-core/blob/master/docs/patching_and_chromium_src.md) is the best concise explanation of this arrangement.
 
-I started by subtracting. Adding a screen would show that we could build on top
-of the fork. Removing a product system would expose the paths that assembled it.
-The target was a stripped Android build that still compiled, packaged, launched,
-and behaved coherently. Brave Wallet became a useful case because it looked
-self-contained from the outside. There were recognizable activities, settings,
-menu entries, strings, and icons. Those visible parts disappeared quickly, while
-the code behind them continued to surface in the build. Behind the Android UI
-were generated JNI bindings between Java and C++, Mojo interfaces crossing
-component and process boundaries, native services created for each profile,
-renderer hooks, permission handlers, and dependencies spread across several GN
-targets. Removing one layer often revealed the next. A Java class could keep
-generated native glue alive, a factory could continue creating a service whose
-menu entry no longer existed, and a binder could preserve a route to code that
-appeared unreachable from the application.
+I could see why it was structured that way. Keeping downstream changes identifiable makes an enormous upstream codebase less painful to update. The trade-off was that the answer to “where does this feature live?” was rarely one directory. A product decision could enter the browser through:
 
-I stopped deleting by folder and began tracing reachability instead. Where was
-the feature first exposed? What created it? Which process used it? What generated
-code on its behalf? Which resources still described it? I worked from the
-product surface inward, taking one boundary at a time. Early changes were
-deliberately reversible. While I was still learning the architecture,
-temporarily excluding a source or dependency left a clearer trail than
-prematurely inventing a permanent configuration system. Once I understood the
-shape, those exploratory changes could become explicit build decisions. This
-took longer than deleting a directory, but each change left a clear trail for
-the next upstream update that touched the same area.
+- a Brave-owned component;
+- a patch against Chromium;
+- a replacement file under `chromium_src`;
+- a generated JNI or Mojo binding;
+- a browser, profile, tab, frame, or utility-process registration; or
+- an Android resource or packaging rule.
+
+On Android, Java, XML, strings, icons, and command IDs could keep referring to a feature after its native implementation appeared to be gone. The source tree showed where the files lived. It didn't show every route by which they became the program.
+
+I started by subtracting. Adding a screen would show that we could build on the fork; removing a product system would expose the paths that assembled it. Wallet was a useful case because it looked self-contained from the outside. The activities, settings, menu entries, strings, and icons disappeared quickly. Behind them were generated JNI inputs, [Mojo](https://chromium.googlesource.com/chromium/src/+/main/mojo/README.md) interfaces, profile services, renderer hooks, permission handlers, and dependencies in several GN targets.
+
+Rewards, Ads, IPFS and decentralised-DNS hooks exposed similar roots. I removed those product areas and the Android surfaces coupled to them, while deliberately retaining the Chromium browser foundation and selected Brave privacy infrastructure. “Less Brave” didn't mean pretending Brave Core wasn't there; it meant finding a boundary between a reusable browser base and Brave's product.
+
+## GN became the assembly plan
+
+I stopped deleting by folder and began tracing reachability. Where was the feature exposed? What created it? Which process used it? What generated code on its behalf? Which resources still described it?
+
+Early changes were deliberately reversible. A simplified fragment looked like this:
+
+```gn
+brave_chrome_java_deps = [
+  # Product-specific generated bindings removed for the POC:
+  # "//brave/components/brave_rewards/common/mojom:ledger_interfaces_java",
+  # "//brave/components/brave_wallet/common:mojom_java",
+
+  # Selected browser/privacy infrastructure retained:
+  "//brave/components/brave_shields/common:mojom_java",
+]
+
+generate_jni("jni_headers") {
+  sources = [
+    "//brave/android/java/org/chromium/chrome/browser/BraveSyncWorker.java",
+    # Rewards and Wallet JNI inputs removed here as their callers disappeared.
+  ]
+}
+```
+
+I wouldn't call commented-out edges a production configuration system. They were useful during dependency archaeology because every subtraction stayed visible while the compiler showed me the next one. Once the shape was clear, those decisions could become build flags, narrower interfaces, or maintained patches.
+
+Text search answered “where is this name mentioned?” GN answered “why is this target here?” These commands became regular navigation tools:
+
+```bash
+gn desc out/Android //brave:brave deps --tree
+gn refs out/Android //brave/components/brave_wallet/common:mojom_java
+gn path out/Android //brave:brave //brave/components/brave_wallet/common
+autoninja -C out/Android brave
+```
+
+The failure stage often told me which graph I had reached:
+
+| Failure | What it usually exposed |
+| --- | --- |
+| `gn gen` | A missing label, invalid include, or broken target edge |
+| Java/C++ compile | A surviving caller, override, source, or generated input |
+| Link | Registration remained after its implementation disappeared |
+| Resource packaging | XML, strings, icons, or commands still described old UI |
+| Startup or interaction | A factory, observer, binder, or runtime assumption survived |
+
+That last row is important. GN describes the build graph; it doesn't prove the runtime behaviour. I still had to launch the APK, instrument registrations and initialisation paths, exercise the affected UI and browsing flows, and run behavioural checks. A dependency can be absent from one target while a fallback implementation, dynamically reached path, or stale resource keeps the product behaving differently from what the diff suggests.
 
 ## The green build I didn't trust
 
-One of the more unsettling results was a successful build after a downstream
-source override had disappeared.
-Brave's source-redirection mechanism could select a downstream implementation in
-place of Chromium's file at the same path. If that downstream file was removed,
-the build could quietly return to the Chromium implementation. Nothing was
-necessarily missing from the linker’s point of view. The browser compiled, but
-the binary might no longer contain the behavior we thought we had preserved. I
-had to verify which source had been selected, which registrations still ran, and
-what happened along the runtime path. Sometimes returning to Chromium's
-implementation was exactly what we wanted, but I still needed to see and record
-that choice rather than discover it later as an accidental change in behavior.
+One of the more unsettling results was a successful build after a downstream source override had disappeared.
 
-In a smaller codebase, deleting an implementation usually creates an obvious
-hole. Here, it could reveal a complete upstream implementation instead. The
-green build confirmed that the pieces still fit together, but it did not tell
-me which implementation I had shipped. From then on, I checked each subtraction
-twice: first that the affected targets still built and the application launched,
-then that the resulting behavior came from the layer we intended. A clean build
-was a checkpoint, not the end of the investigation.
+Brave's source-redirection mechanism can select a downstream implementation instead of Chromium's file at the same path. Remove the downstream file and the build may quietly return to Chromium's implementation. Nothing is necessarily missing from the linker's point of view. The browser compiles, but it may no longer contain the behaviour we thought we had preserved.
 
-## Following a feature through Chromium
+Sometimes that return to Chromium was exactly what I wanted. I still needed to see and record it, rather than discover it in QA as an accidental product decision. From then on I checked each subtraction twice: first that the relevant targets built and the application launched, then that the runtime path used the implementation we intended. Green is a lovely colour, but it can be a bit of a liar.
 
-Once I began reading GN as the assembly plan for the browser, failures became
-more useful. Text search showed where a name appeared. The build graph showed
-why a target existed, who depended on it, and which generated edge had pulled it
-into the binary. A missing JNI class often meant that the Java declaration and
-its generation target no longer agreed. A link failure could reveal a surviving
-registration whose implementation had gone. When the browser launched and then
-failed on a particular path, I would look for a factory, observer, or
-cross-process binding that compilation could not exercise. Each failure showed
-me where my model of the browser was still incomplete.
+## Java, C++, generated code, and process boundaries
 
-The picture became clearer when I classified code by lifetime rather than by
-folder. Some objects belonged to the browser process and existed from startup.
-Others were created once per profile, attached to a tab, or installed in a
-renderer frame. A feature that crossed those lifetimes was not scattered by
-accident. The distribution described who owned its state and when its behavior
-was active. That model also made removal more precise. Hiding a button removed
-an entry point. Removing a profile factory stopped user-scoped state from being
-created. Removing a tab helper prevented work from attaching to every page, and
-cleaning up renderer and utility registrations closed paths in other processes.
-I considered the feature gone when its visible surface and ownership graph
-finally agreed.
+The Android UI in this Chromium version was primarily Java and resources, while much of the browser state lived in native C++. [JNI](https://source.chromium.org/chromium/chromium/src/+/main:docs/android_jni.md) crossed that language boundary inside a process. Mojo connected typed components, often across processes. Treating the two as interchangeable was a quick way to repair the wrong layer.
 
-Chromium builds are expensive enough that bundling several ideas into one attempt
-is always tempting. It saves a build, then makes the result harder to explain
-when something fails. We invested in a tighter loop so that we could change one
-edge, observe one consequence, and keep the decision close to its cause. Faster
-iteration made the investigation much safer. Over time, the failures gave us a
-more useful map than the directory tree. We could see how a piece entered the
-browser, when it came alive, and what would surface if we removed it.
+A Java class annotated with `@NativeMethods` could keep its generated `*Jni` shim and C++ header alive through a `generate_jni` target. A `.mojom` definition could generate both Java and C++ interfaces, while a binder registered elsewhere kept the service reachable. Deleting only the Android screen didn't touch any of that.
 
-The stripped Android build was visually unremarkable. Its value was that we
-could explain it. We knew which parts came from Chromium, which behavior Brave
-added, where Veera could intervene, and which temporary choices still needed to
-become maintained patches. That understanding changed the work that followed.
-New product surfaces were no longer additions to an opaque fork. We could place
-them according to their lifetime, keep Android and native boundaries deliberate,
-and decide where a downstream change justified the future cost of carrying it.
-Upstream rebases would remain real engineering work, but they were no longer
-encounters with an unknown system.
+The architecture became easier to read when I classified code by lifetime:
 
-Taking the browser apart also changed what ownership meant to me. Colors, icons,
-and onboarding can make a fork look like a different product. The team owns it
-only when it can predict where behavior enters, trace it across boundaries, and
-change it deliberately. The first build did not look much like the Veera people
-would eventually use, but we finally understood how this Chromium browser was
-put together. Only then did adding pieces back feel like building Veera.
+```text
+browser process  -> global browser facilities
+profile          -> user-scoped services and preferences
+WebContents      -> per-tab behaviour
+RenderFrame      -> per-document renderer behaviour
+utility process  -> isolated service implementations
+```
+
+A feature spread across those layers wasn't necessarily scattered by accident. The distribution described who owned its state and when it was active. Hiding a button removed an entry point. Removing a profile factory stopped user-scoped state from being created. Removing a tab helper prevented work attaching to every page. Cleaning up renderer and utility registrations closed paths in other processes.
+
+I considered a product system absent only when the visible surface, build dependencies, generated bindings, and runtime ownership graph agreed. That was more work than deleting a directory, admittedly. It was also much less likely to leave a ghost service waking up for every tab.
+
+## Making the feedback loop survivable
+
+Chromium builds are expensive enough that they change how one debugs. If every experiment costs hours, it's tempting to combine five ideas into one build and then learn very little from the failure.
+
+We built a faster loop around narrow targets, compiler caching, reusable artefacts, and separating app-layer work from full browser builds. On the shipped project, that eventually enabled near-instant UI iteration for changes that would otherwise have waited on four-to-six-hour full builds. Clean release builds came down to roughly two hours using compiler caching, prebuilt artefacts, separate build lanes, and architecture-specific variants.
+
+Those were later delivery improvements, not results produced magically by the two exploratory commits. The POC gave me the map needed to make them sensible: which layer had changed, which target was narrow enough to rebuild, and which artefact could safely be reused.
+
+The work after this prototype was much broader. I led the Android browser through its Play Store launch and later established the iOS platform and release setup. There were product features, monitoring, QA, upstream updates, and the usual release-day negotiations with reality. None of that turns the original subtraction exercise into the final shipped architecture. It explains why those 123 files were worth disturbing in the first place.
+
+## What the proof of concept actually proved
+
+The bland first build answered a few specific questions:
+
+- Brave's Chromium integration could support a distinct Android browser.
+- Wallet, Rewards, Ads, IPFS, decentralised-DNS hooks, and their product surfaces could be separated from the browser base we wanted to evaluate.
+- Selected Brave privacy infrastructure could be retained deliberately.
+- GN, JNI, Mojo, Android resources, and runtime registrations could be traced as connected but different graphs.
+- We could make the feedback loop practical enough to build a product on top.
+
+It didn't prove that upstream rebases would become easy, that every dormant path had vanished forever, or that the exploratory exclusions were maintainable as written. Those were the next engineering jobs.
+
+The first build didn't yet look much like the Veera people would eventually use. It compiled, opened, browsed, and—after a surprising amount of staring at GN output—contained fewer unexplained things. For that week, that was the interesting screenshot.

--- a/src/content/blog/facebook-messenger-protocol-stack/page.mdx
+++ b/src/content/blog/facebook-messenger-protocol-stack/page.mdx
@@ -3,7 +3,7 @@ export const metadata = {
   date: "2026-07-23",
   author: "Sid Jain",
   summary:
-    "While building a research client for Messenger, an unexpected MQTT keepalive led through MQTToT, compressed Thrift payloads, and session state shared across HTTP and realtime traffic.",
+    "A 2021 Facebook Messenger transport investigation that began with a backwards MQTT keepalive and became part of the production Messenger channel in Texts.",
   tags: ["reverse-engineering", "facebook", "mqtt", "thrift", "typescript"],
   draft: true,
 };
@@ -14,117 +14,92 @@ One of the most useful packets in this project contained no payload:
 C0 00
 ```
 
-Those two bytes are an MQTT `PINGREQ`, the small keepalive a client sends to a
-broker when it has nothing else to say. This one had traveled in the opposite
-direction. Facebook's broker had sent it to me. I was building a research
-client in 2021 that could load my existing Messenger conversations and follow
-new messages without the official mobile application. Login mostly worked, and
-I could establish what looked like a realtime connection. The empty packet
-made it clear that there was not one last private endpoint left to find. I had
-to reconstruct a stack of familiar protocols, then identify the small places
-where Facebook's implementation departed from them.
+Those two bytes are an MQTT `PINGREQ`. According to the [MQTT 3.1.1 specification](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html), the client sends one when it has nothing else to say, and the broker answers with `PINGRESP`. This one had travelled in the opposite direction. Facebook's broker had sent it to me.
 
-## The keepalive went the other way
+This happened in 2021, while I was building a client that could load my own Facebook Messenger conversations and follow new messages without the official mobile app. What began as protocol research became the foundation of the production Messenger channel I shipped for [Texts](https://texts.com/), its all-in-one desktop messaging client.
 
-MQTT assigns the two sides of a keepalive exchange clearly. The client sends
-`PINGREQ`, and the broker answers with `PINGRESP`. The state machine I was using
-therefore had no incoming path for `C0 00`. It was behaving correctly for the
-standard and incorrectly for the system in front of it. I initially wondered
-whether the MQTT client was the wrong abstraction altogether, but stream
-parsing, packet framing, QoS, reconnection, and ordinary publish flows still
-behaved as expected. Only the direction of this exchange had changed.
+The date matters. This is an account of Facebook Messenger's 2021 mobile transport dialect, not documentation for Meta's current endpoints or today's [end-to-end-encrypted Messenger clients](https://engineering.fb.com/2023/12/06/security/building-end-to-end-security-for-messenger/). Those systems have moved on. The useful part is how I separated what the bytes proved from what I merely suspected.
 
-I added the narrowest extension I could: accept an incoming `PINGREQ` and answer
-with `PINGRESP`. The connection stayed alive, and the rest of the state machine
-remained intact. I did not need a Messenger-specific transport. I needed a
-conventional transport with an explicit place for the dialect to depart from
-convention. That small fix gave me an approach for the rest of the protocol. I
-started from the standard, kept everything that matched the traffic, and
-isolated each deviation rather than rewriting the whole layer. When something
-later failed, I could narrow the question to standard MQTT, Messenger's dialect,
-or my own code.
+## A small packet, backwards
 
-## Reconstructing a Messenger session
+My first hypothesis was that MQTT was a misleading surface and the parser underneath it needed replacing. It was also the expensive hypothesis, which should have made me suspicious sooner. Packet framing, QoS acknowledgements, subscriptions, reconnection and ordinary publications all matched MQTT 3.1.1. Only this keepalive did not.
 
-Keeping the connection alive was progress, but it did not make the connection a
-Messenger session. The HTTP and realtime sides had to agree on the identity of
-the client: the same device, application, locale, account, and authenticated
-session. Authentication could not be reduced to a token attached at the end.
-Instead, the client's identity depended on state shared across several requests
-and both transports. I moved that state into one shared model. The login flow
-established the authenticated device and session context, and the realtime
-connection consumed that same context rather than recreating its own version.
-That eliminated a class of failures in which both sides looked individually
-plausible but described different clients.
+So I made the smallest deviation the evidence required: accept an incoming `PINGREQ`, answer with `PINGRESP`, and leave the rest of the state machine alone. The connection stayed up.
 
-Login still did not provide the history needed to interpret incoming events.
-Messenger used a snapshot-and-delta model. An HTTPS request returned the
-existing conversation state and a sequence cursor. The realtime client then
-used that cursor to establish the queue from which later changes would arrive.
-Authentication made the snapshot possible, and the snapshot made the stream
-meaningful. Skipping a step could leave me with a connection that appeared
-healthy but never received useful data.
+```ts
+// Messenger's 2021 dialect, pared down to the behavioural exception.
+client.on(PacketType.PingReq, () => {
+  transport.write(writePacket(PacketType.PingResp));
+});
+```
 
-The data also crossed several representations. A command could begin as a typed
-object, become a Thrift Compact structure, be compressed, travel inside an MQTT
-publication over TLS, and return through the reverse path. I needed to keep
-those layers separate while debugging. Otherwise, a wrong field number could
-look like a compression failure, or a stale sequence cursor could look like a
-broken transport. The realtime handshake made the layering especially clear.
-Messenger's mobile dialect, known as MQTToT, reused MQTT's fixed header and
-length framing but not an ordinary MQTT `CONNECT`. Inside that familiar
-envelope was a dialect-specific header followed by a compressed Thrift
-connection object. The acknowledgment and subscription setup also used
-structures a normal MQTT client did not expect.
+That looks laughably small after an evening spent doubting the transport. It also set the method for everything that followed: start with the public standard, keep what matches, and put each private variation behind a narrow seam.
 
-I treated MQTToT as a dialect with a narrow adapter rather than malformed MQTT.
-The adapter replaced the connection writer and acknowledgment reader. The
-underlying client continued to own transport, buffering, publication, QoS,
-keepalives, and reconnects. Keeping the adapter narrow made the unfamiliar
-part small enough to inspect without recreating a well-tested network state
-machine. That boundary was useful whenever a new packet arrived. A framing
-failure pointed to the transport boundary. A connection object that would not
-decode pointed to compression or Thrift. A valid publication with an unknown
-topic belonged above MQTT. I still had plenty of unknowns, but I no longer had
-to debug every layer at once.
+I did the research against accounts and devices I controlled. I used Ghidra for native code paths, Burp Suite and Frida for runtime inspection, and certificate unpinning on my test device to compare app behaviour with captured traffic. Credentials, personal message bodies, live private endpoints and other people's data don't belong in a retrospective, so they aren't here. Facebook's white-hat programme provided the research and reporting boundary; “reverse engineering” was not a decorative way of saying “anything goes”.
 
-## Learning schemas from traffic
+## One identity across two transports
 
-Once the connection stayed alive, many incoming publications were still
-compressed buffers without a local Thrift definition. Compact Protocol gave me
-structure in the form of field numbers, wire types, and container boundaries,
-but not meaning. A binary field might be text, an identifier, JSON, another
-Thrift object, or bytes that should remain opaque. I needed to distinguish what
-the bytes established from the names I was guessing.
+Keeping a socket alive did not make it a Messenger session. The HTTPS and realtime sides had to agree on the same account, app, device, locale and authenticated session. When I let each side assemble that identity independently, I got a particularly annoying failure mode: login succeeded, the realtime connection looked healthy, and nothing useful arrived.
 
-The first useful tool was a schema-free structural reader. It walked a payload
-and printed numbered fields, their wire types, and their nesting without
-pretending to know their names. Calling a field `userName` after seeing one
-familiar value would make the output easier to read while quietly turning a
-guess into a fact. I only named fields after controlled comparisons. I repeated
-the same operation, changed one visible input, and compared the resulting
-payloads. Stable positions and wire types justified a structural hypothesis. I
-gave a field a domain meaning only when its value changed consistently with an
-action I could observe. Fields that remained ambiguous stayed neutral.
+The missing piece was ordering. An HTTPS request established an initial snapshot and sequence cursor; the realtime client then used the same session state and cursor to subscribe to later deltas. Meta had publicly described this [snapshot-and-delta architecture](https://engineering.fb.com/2014/10/09/production-engineering/building-mobile-first-infrastructure-for-messenger/) years earlier: an initial message snapshot followed by updates over MQTT, with Thrift replacing JSON to reduce wire size. That description didn't provide the private operations or schemas, but it gave the traffic a sensible shape.
 
-Repeated observations could then become runtime schemas. A schema recorded the
-wire number, expected type, optionality, and TypeScript representation in one
-place. Known fields failed clearly when their wire type changed, while unknown
-fields could be skipped recursively so that a partial understanding remained
-useful as the remote payload evolved. Sixty-four-bit identifiers stayed as
-`bigint` rather than passing through a JavaScript number and quietly losing
-precision. The next payload could then test the schema, and a mismatch failed at
-a specific field instead of quietly corrupting application state. Most
-discoveries were incremental: unknown bytes became stable structure, and only
-then did some fields acquire names. I stopped at whichever level the
-observations supported.
+I moved the authenticated device and session context into one shared model:
 
-Not every event yielded its meaning. Some stopped at structural decoding, some
-fields remained uncertain, and the remote operations and identifiers continued
-to move. I never expected to finish with a complete, permanent map of
-Messenger. I reused the layers that already matched the traffic, isolated local
-deviations, left unknown fields unnamed, and turned repeated observations into
-schemas that later traffic could challenge. The empty `C0 00` packet contained
-no Messenger data, but it showed me exactly where the standard MQTT model no
-longer fit. The endpoints have long since changed, but I still use the same
-approach whenever I have to learn from a system that can change without notice.
+```mermaid
+flowchart LR
+  Login["HTTPS login"] --> State["Shared device + session state"]
+  State --> Snapshot["Snapshot + sequence cursor"]
+  State --> Realtime["Realtime connection"]
+  Snapshot --> Realtime
+  Realtime --> Deltas["Ordered deltas"]
+```
+
+Authentication made the snapshot possible; the snapshot made the stream meaningful. A green connection icon was not proof of either. I learnt to distrust green icons quite early in this project.
+
+## MQTT outside, MQTToT inside
+
+The realtime handshake made the layering visible. Facebook's dialect, usually called MQTToT, reused MQTT's fixed header and remaining-length framing but did not send an ordinary MQTT `CONNECT`. Inside that envelope sat an MQTToT header and a compressed Thrift connection object.
+
+The secret-free part of the connection writer was roughly this:
+
+```ts
+const PROTOCOL_LEVEL = 3;
+const CONNECT_FLAGS = 0xc2;
+
+stream
+  .writeString("MQTToT")
+  .writeByte(PROTOCOL_LEVEL)
+  .writeByte(CONNECT_FLAGS)
+  .writeWord(keepAlive)
+  .write(compressedThriftPayload);
+```
+
+The payload contained session and device context, which is precisely the part not reproduced here. The important implementation choice was the boundary: replace the connection writer and acknowledgement reader, while the MQTT client continued to own TLS transport, buffering, QoS, publications, keepalives and reconnects.
+
+A command therefore crossed a stack of ordinary-looking layers:
+
+```text
+typed object
+  → Thrift Compact
+  → DEFLATE
+  → MQTToT inside MQTT framing
+  → TLS
+```
+
+Keeping those layers separate saved a lot of theatrical debugging. A framing failure belonged near MQTT. A buffer that would not inflate belonged to compression. A valid Thrift structure with the wrong field type belonged to the schema. A perfectly decoded delta with a stale cursor belonged higher up. Without those boundaries, all four looked like “messages don't work”.
+
+## Giving numbered fields names, slowly
+
+Thrift Compact supplied field numbers, wire types and container boundaries, but not domain names. The [Compact Protocol specification](https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md) could tell me that a field was an `i64` or a list of structs. It could not tell me whether that `i64` represented a user, a thread, or a timestamp.
+
+I first wrote a schema-free structural reader. It printed numbered fields and nesting without pretending to know what they meant. Then I made controlled changes in the app—send a message, add a reaction, mark a thread read—and compared captures. A field earned a name only when its value changed consistently with the visible action. Some never did, and stayed unknown. That is less satisfying than naming everything, but considerably more honest.
+
+Repeated observations became runtime schemas in TypeScript. Each schema kept the wire number, expected type, optionality and TypeScript representation together. Unknown fields were skipped recursively, while a known field changing wire type failed at that field. Sixty-four-bit identifiers remained `bigint`; passing them through JavaScript's `number` would make two different accounts look the same eventually, which is a rather dramatic typing bug.
+
+I published the reusable, non-Messenger-specific parts as [`@f0rr0/thrift-compact-protocol`](https://github.com/f0rr0/thrift-compact-protocol). The extensible MQTT 3.1.1 state machine is also visible in my public [`mqtts` fork](https://github.com/f0rr0/mqtts). The product adapter, captured payloads and live operations remained private.
+
+## From packet archaeology to a product
+
+Decoding one event is a demo. A messaging channel has to keep doing it after sleep, reconnect, cursor advancement, an attachment upload, and a remote schema change. The research client grew into the Messenger integration in Texts: message synchronisation and encrypted payload handling, sending and receiving, threads and groups, photos, videos and files, reactions, read receipts, typing indicators, and presence.
+
+Not every field acquired a name, and no map of an undocumented service stays complete. The endpoints and operations from this work have long since changed. What survived in my own work was the habit that began with `C0 00`: don't rewrite the standard because one packet is odd; make the odd packet explain itself first.

--- a/src/content/blog/from-jsonb-filters-to-self-querying-media-search/page.mdx
+++ b/src/content/blog/from-jsonb-filters-to-self-querying-media-search/page.mdx
@@ -3,110 +3,189 @@ export const metadata = {
   date: "2026-08-13",
   author: "Sid Jain",
   summary:
-    "At Memorang, I built a semantic image search prototype that combined embeddings with typed PostgreSQL filters for clinical, product, and access constraints.",
+    "What two exploratory Memorang prototypes taught me about combining semantic retrieval with typed PostgreSQL filters for educational media.",
   tags: ["applied-ai", "postgresql", "search", "typescript"],
   draft: true,
 };
 
-At Memorang, I was working on an authoring platform for structured educational
-content. A question was rarely just text. It belonged to a versioned curriculum,
-carried answer choices and explanations, and connected to tags, source material,
-media, and assessment metadata. Finding a useful image for it looked like a
-natural job for embeddings, and they did find related concepts even when the
-question and media description used different words. The results also exposed
-the limits of similarity. A dermoscopic image could show the right kind of
-lesion and still be wrong for the lesson because it showed a different body
-location or skin phototype. It might also belong to an organization the editor
-was not allowed to access. An editor might ask for “a dermoscopic image relevant
-to this lesion, on the arm, for Fitzpatrick Type IV skin,” but the system still
-had to preserve a clinical idea, an exact body location, and a controlled skin
-phototype category all the way to the result.
+At Memorang, I worked on an authoring platform for structured educational content. A question was rarely just text. It belonged to a versioned curriculum, carried answer choices and explanations, and connected to tags, source material, media, and assessment metadata.
 
-## Separating similarity from constraints
+Finding a useful image for it looked like a natural job for embeddings. They did find related concepts when the question and media description used different words. The results also exposed the limits of similarity. A dermoscopic image could show the right lesion and still be wrong for the lesson because it showed a different body location or an incompatible, expert-assigned skin-phototype category. It might also belong to an organisation the editor wasn't allowed to access.
 
-The lesion and clinical concept belonged in the semantic query, while arm and
-Type IV were exact metadata constraints. Organization, project, visibility, and
-deletion state came from the application's access rules. Flattening all of that
-into the text sent to an embedding model would erase those distinctions. A
-vector can place “upper limb” near “arm,” which is useful when language varies,
-but it cannot guarantee that a record has the enumerated value required by the
-workflow. It should not determine whether an editor may see another
-organization's asset either.
+“Find a dermoscopic image relevant to this lesion, on the arm, for Type IV skin” is one sentence containing at least three different problems:
 
-SQL predicates solve the exact part of the problem, but they cannot reliably
-find an image related to an explanation when the words do not line up. Letting a
-language model generate unrestricted SQL would have made the system harder to
-reason about and secure without helping with this division. I split the query
-instead: semantic retrieval handled conceptual similarity, typed metadata
-filters enforced the editor's constraints, and application code added
-authorization independently so that model output could neither supply nor
-weaken it. If the parser could not understand an exact medical constraint, the
-search stopped or asked the editor to clarify. A broader result set would have
-silently discarded part of the request.
+1. the lesion and clinical concept are semantic intent;
+2. `Arm` and `TypeIV` are controlled metadata constraints; and
+3. organisation, project, visibility, and deletion state are access policy.
 
-## Building and checking the query path
+Trying to turn the whole sentence into either one vector or a blob of generated SQL seemed clever in exactly the wrong way.
 
-The application already contained much of the structure needed to make that
-split work. Stable operational fields such as status, version, organization,
-project, and timestamps were relational. Content that varied across question
-schemas lived in PostgreSQL JSONB. Tags, media, collections, and parent-child
-relationships remained relational because their identity and integrity
-mattered. Before adding a model to the query path, I built a typed filter
-contract over this hybrid schema. A caller could provide a known field, an
-allowlisted operator, and a value. The translator knew whether the field mapped
-to a column, a JSON path, or a relationship, and all values remained
-parameterized. An early version of the translator warned about an unknown field
-and continued without it. That was convenient, but a misspelled constraint could
-broaden the result set without making the failure visible. I changed the
-contract to reject the request, and model-generated filters went through the
-same validation. Editors did not need to know whether a request touched JSONB, a
-trigram index, a relationship, or a vector, but they did need to know when the
-system could not honor it.
+## What the prototypes actually were
 
-Editor search already crossed JSONB fields and relational tags. A query plan
-showed that hydrating those relationships during search was expensive, so I kept
-filtering and ranking on lightweight identifiers. After pagination, the
-application loaded the related content in one batched step. Semantic search
-returned through that existing query layer instead of introducing another way
-to load records. For each media record, I created a compact text representation
-from the fields that could change its meaning: title, description, diagnosis,
-media type, body location, and skin phototype. A question used its stem, correct
-answer, explanation, concept, diagnosis, and specialties. Timestamps and
-internal identifiers stayed out because they added no useful meaning to the
-embedding. I stored the canonical text beside its vector so I could inspect
-exactly what had been embedded when a result looked wrong. The vector index
-returned media identifiers, and the application loaded the current records
-through the existing query layer.
+This is a retrospective on two exploratory TypeScript prototypes from September 2024, with simplified and sanitised excerpts. The first put a typed query contract over a hybrid relational/[JSONB](https://www.postgresql.org/docs/current/datatype-json.html) content model. The second tried self-querying retrieval for image, audio, and video records using 1,536-dimensional embeddings.
 
-The model translated the editor's sentence into a semantic phrase and a small
-metadata expression drawn from the allowlisted schema. A parser rejected unknown
-fields, values, and operators before application-owned authorization was added.
-It never saw a database connection or wrote SQL. An invalid expression stopped
-the search or prompted a precise follow-up. I kept the prototype in PostgreSQL,
-where the source text, vector, filter, current record, and query plan could be
-inspected together. A separate retrieval service might have made sense later,
-but it was unnecessary until we knew whether the recommendations were useful to
-editors.
+They answered useful architectural questions. They were not a final production search system, and a few things I would now require were either rough or absent:
 
-To check the prototype, I used media that editors had previously attached to
-questions. For each question, the system retrieved a small candidate set and
-checked whether it recovered an earlier selection. Consistently missing those
-known associations suggested a problem with the representation or filtering,
-but historical choices were signals rather than ground truth. A new
-recommendation could be better than an old selection made from a smaller catalog
-or under constraints that had never been recorded. Nearest neighbors also tended
-to cluster around variants of the same asset, so a candidate list could look
-strong on paper while offering little real choice.
+- unknown filter keys were logged and dropped instead of failing the request;
+- the query constructor ran at temperature `0.7` and accepted a fairly broad comparator and logical-operator set;
+- the verifiable vector-search RPC did not itself enforce authentication or tenancy; and
+- an experimental maximal-marginal-relevance ranker existed, but wasn't wired into the self-query path.
 
-Historical attachments could expose a broken representation, but they could not
-tell us whether a new image was clinically appropriate. That required review by
-subject-matter experts. Editors also needed to tell us whether a suggestion
-saved time, whether they accepted or replaced it, and why. Those reviews could
-explain failures hidden by an aggregate retrieval score, from a missing
-controlled attribute or a poor text representation to an overly broad synonym
-or a constraint that belonged in the authoring model itself. Latency and parse
-failures still mattered, but neither measured the quality of the final editorial
-decision. For the original request, the system could retrieve a candidate for
-the right lesion, on the arm, for Fitzpatrick Type IV skin, then show the text
-and filters that put it there. The editor could review the recommendation before
-deciding what students would see.
+Those aren't footnotes to hide. They are much of what the prototypes taught me.
+
+## First, make exact queries boring
+
+Stable operational fields such as status, version, organisation, project, and timestamps were relational. Schema-dependent question content lived in JSONB. Tags, media, collections, and parent-child relationships remained relational because their identity and integrity mattered.
+
+Before involving a model, I made the filter language explicit. A simplified version looked like this:
+
+```ts
+type FilterOperator =
+  | "eq"
+  | "ne"
+  | "gt"
+  | "gte"
+  | "lt"
+  | "lte"
+  | "like"
+  | "ilike"
+  | "contains";
+
+type FilterKey =
+  | "type"
+  | "status"
+  | "metadata.speciality_primary"
+  | "metadata.speciality_secondary";
+
+type FilterInput = {
+  key: FilterKey;
+  operator: FilterOperator;
+  value: unknown;
+};
+
+function buildNestedObject(path: string, value: unknown) {
+  return path.split(".").reduceRight((child, key) => ({ [key]: child }), value);
+}
+
+function jsonbContains(key: `metadata.${string}`, value: unknown) {
+  const path = key.slice("metadata.".length);
+  return sql`
+    ${items.metadata} @> ${sql.param(buildNestedObject(path, value))}::jsonb
+  `;
+}
+```
+
+The translator knew whether a key mapped to a column, a JSON path, or a relationship, and the SQL builder parameterised values. The intentionally small contract was easier to test and log than arbitrary SQL. It also let the product hide whether a field happened to live in JSONB.
+
+The POC's permissive behaviour was still a correctness bug waiting for a typo: it warned about an unknown field and continued without that constraint. If `body_location` becomes `body_loction`, silently returning broader results is not graceful degradation. A production parser should reject the complete expression or ask for clarification.
+
+Search also had to inspect nested answer explanations, sources, and tag labels. For partial labels I tried PostgreSQL's [`pg_trgm`](https://www.postgresql.org/docs/current/pgtrgm.html) with a GIN trigram index. One captured `EXPLAIN ANALYZE` returned the first 100 records in about `72.7 ms`. That isn't a universal latency claim; it is one recorded plan from one exploratory dataset.
+
+The plan was more interesting than the headline number. It showed the trigram index being used, while relationship hydration repeated work per returned item. Filtering and ranking lightweight IDs first, then hydrating related content in a batched step, was the obvious next shape. PostgreSQL was being quite direct with me there.
+
+## Then split meaning from constraints
+
+For each media record I built compact, labelled text from fields that could change its meaning: title, description, diagnosis, media type, body location, and skin phototype. Question text combined the stem, correct answer, explanation, concept, diagnosis, and specialties. Timestamps and internal IDs stayed out. I stored the canonical text beside its vector so a strange result could be traced back to what had actually been embedded.
+
+The language model's job was narrow in principle: turn an editor's sentence into a semantic phrase plus a metadata expression. It didn't receive a database connection or generate SQL. Deterministic code parsed the expression and translated allowed fields and operators into a retrieval filter.
+
+The prototype derived much of that contract from Zod. If I were tightening it now, I would make the allowed combinations smaller and more explicit, along these lines:
+
+```ts
+const proposedQuery = z
+  .object({
+    semanticQuery: z.string().min(1),
+    filters: z.array(
+      z.discriminatedUnion("field", [
+        z.object({
+          field: z.literal("body_location"),
+          op: z.literal("eq"),
+          value: z.enum([
+            "Scalp",
+            "Face",
+            "Neck",
+            "Arm",
+            "Hands",
+            "Trunk",
+            "Leg",
+          ]),
+        }),
+        z.object({
+          field: z.literal("skin_phototype"),
+          op: z.literal("eq"),
+          value: z.enum([
+            "TypeI",
+            "TypeII",
+            "TypeIII",
+            "TypeIV",
+            "TypeV",
+            "TypeVI",
+          ]),
+        }),
+      ])
+    ),
+  })
+  .strict();
+```
+
+This is a proposed hardened shape, not a claim that the September POC used this exact schema. In particular, `0.7` is a perfectly cheerful temperature for some prose and less charming for a query planner. In production I'd test a lower-variance structured-output path, version the schema and prompt together, bound retries, and treat parse failure as an ordinary product state.
+
+There is also a clinical caveat hidden inside the example. Fitzpatrick type should be controlled metadata assigned by a qualified clinician or editor. It must not be guessed from pixels, names, or ethnicity. The scale was devised around response to ultraviolet exposure and has [documented limitations across diverse populations](https://pubmed.ncbi.nlm.nih.gov/32186531/?dopt=Abstract). Even when it is useful in a particular editorial workflow, the system should show its provenance and allow review rather than turn it into machine-produced fact.
+
+## The access boundary belongs below retrieval
+
+The architectural rule is straightforward: organisation, project, visibility, and deletion predicates must come from the authenticated application or the database. A model-generated filter may narrow an already-authorised set. It must not establish the set.
+
+The sanitised RPC preserved with the prototype didn't implement that boundary, so I can't honestly write that tenancy was solved there. A production path would need mandatory application predicates or row-level-security policies applied independently of the model output, with tests proving that a missing or malformed semantic filter cannot widen access.
+
+That separation also changes fallback behaviour. If structured parsing fails, semantic-only retrieval might still be acceptable _inside_ mandatory tenant and visibility constraints. “Try something broader” is never permission to search another organisation's media.
+
+## A filtered-vector trap worth knowing about
+
+Keeping vectors in [pgvector](https://github.com/pgvector/pgvector) was appealing because the source record, filter, vector, and query plan stayed inspectable in one system. It doesn't remove the need to choose the search strategy.
+
+With exact nearest-neighbour search, PostgreSQL can apply predicates and compute distance without approximate-index recall trade-offs, though cost grows with the candidate set. With an HNSW or IVFFlat approximate index, pgvector documents that [filtering is applied after the approximate index scan](https://github.com/pgvector/pgvector#filtering). A narrow metadata filter can therefore return fewer than `k` useful rows because the qualifying neighbours weren't in the scanned candidates. Iterative scans, higher search parameters, partial indexes, partitioning, or exact search over a pre-filtered subset are possible responses; each changes latency or operational complexity.
+
+The prototype didn't preserve a benchmark strong enough to declare one answer. I would first measure exact search at the real catalogue and tenant sizes, then introduce an approximate index only when the workload justified it. “We use vectors” isn't yet a retrieval design.
+
+## Similarity isn't variety
+
+Nearest neighbours tended to return variants of the same asset. That can make a top-five list look numerically excellent and editorially dull.
+
+I experimented with maximal marginal relevance (MMR), where each next document balances relevance to the query against similarity to already selected results:
+
+`score(d) = λ · similarity(d, query) − (1 − λ) · max similarity(d, selected)`
+
+At `λ = 1`, ranking is pure relevance. Lower values increasingly penalise redundancy. The code existed in the POC, but it wasn't connected to the final self-querying route. I learnt something from it; I didn't ship an evaluated diversity policy.
+
+## What evaluation would have to prove
+
+Historical question-to-media attachments were available as a weak offline signal. Recovering an earlier selection in the top `k` could expose a broken representation or filter, but it wasn't ground truth. An old choice may have come from a smaller catalogue, and a different recommendation may be better. The prototype retained a harness, not a trustworthy final score, so I don't have a magic percentage to put here.
+
+A serious evaluation would combine:
+
+| Measure | Question it answers |
+| --- | --- |
+| Recall or hit rate at several values of `k` | Can the system recover known plausible assets? |
+| SME review | Is the result clinically and educationally appropriate? |
+| Editor acceptance, replacement, and reason | Did it save work, and where did it fail? |
+| Duplicate and diversity rate | Are five results actually five choices? |
+| Parse failures and fallback rate | Can editors understand and recover from ambiguity? |
+| End-to-end latency by tenant and filter | Does the complete path remain usable? |
+
+I would also stratify those results by media type, clinical category, metadata coverage, and tenant size. An average can hide the exact minority of cases where a controlled attribute matters most.
+
+## What production would require
+
+The experiments left a fairly practical list:
+
+- reject unknown filters rather than dropping them;
+- enforce authentication and tenancy below the model-generated plan;
+- version the embedding model, dimensions, text template, schema, and source-row revision;
+- preserve similarity score and rank while hydrating authoritative records;
+- choose exact or approximate vector search from measured filtered workloads;
+- make re-indexing resumable and observable;
+- evaluate retrieval, diversity, clinical suitability, and editor behaviour together; and
+- document deletion, retention, model-provider, and audit boundaries for the content sent through the pipeline.
+
+I still like the original idea. A structured editor request can become a useful semantic search without surrendering the structure that made the content trustworthy in the first place. The two POCs got far enough to show where that division could work—and, slightly more usefully, where the confident demo would have been lying.

--- a/src/content/blog/from-jsonb-filters-to-self-querying-media-search/page.mdx
+++ b/src/content/blog/from-jsonb-filters-to-self-querying-media-search/page.mdx
@@ -164,14 +164,14 @@ Historical question-to-media attachments were available as a weak offline signal
 
 A serious evaluation would combine:
 
-| Measure | Question it answers |
-| --- | --- |
-| Recall or hit rate at several values of `k` | Can the system recover known plausible assets? |
-| SME review | Is the result clinically and educationally appropriate? |
-| Editor acceptance, replacement, and reason | Did it save work, and where did it fail? |
-| Duplicate and diversity rate | Are five results actually five choices? |
-| Parse failures and fallback rate | Can editors understand and recover from ambiguity? |
-| End-to-end latency by tenant and filter | Does the complete path remain usable? |
+| Measure                                     | Question it answers                                     |
+| ------------------------------------------- | ------------------------------------------------------- |
+| Recall or hit rate at several values of `k` | Can the system recover known plausible assets?          |
+| SME review                                  | Is the result clinically and educationally appropriate? |
+| Editor acceptance, replacement, and reason  | Did it save work, and where did it fail?                |
+| Duplicate and diversity rate                | Are five results actually five choices?                 |
+| Parse failures and fallback rate            | Can editors understand and recover from ambiguity?      |
+| End-to-end latency by tenant and filter     | Does the complete path remain usable?                   |
 
 I would also stratify those results by media type, clinical category, metadata coverage, and tenant size. An average can hide the exact minority of cases where a controlled attribute matters most.
 

--- a/src/content/blog/i-wanted-a-queue-not-a-matchmaker/page.mdx
+++ b/src/content/blog/i-wanted-a-queue-not-a-matchmaker/page.mdx
@@ -3,7 +3,7 @@ export const metadata = {
   date: "2026-08-27",
   author: "Sid Jain",
   summary:
-    "I let an AI agent read my Hinge queue, describe profile photos, and draft openings and replies. The protocol layer behind it became hinge-rs, an open-source Rust client.",
+    "I built a local Hinge queue and protocol client, then separately tested an AI drafting layer that never chose likes or sent messages.",
   tags: [
     "applied-ai",
     "rust",
@@ -14,80 +14,49 @@ export const metadata = {
   draft: true,
 };
 
-I had not planned to put an AI agent between me and Hinge. I only wanted to stop
-making a decision on one profile just to see the next. One Saturday in 2025, I
-built a local client for my own account that collected the day's recommendations
-into a list I could leave and return to later. Once it could assemble profiles,
-photos, prompts, and conversations in one place, I put a local AI agent on top
-of it. The agent began describing profile photos, proposing opening messages,
-and drafting replies from the conversation so far. It felt like a takeover the
-first time the blank text box stopped being blank.
+The title overstates it. The agent never chose whom I liked and never sent a message. It drafted text in a later experiment, after I had already built the queue and protocol client. Apparently “I Let an AI Agent Fill a Text Box Whilst I Hovered Nervously Nearby” wasn't going to survive the headline meeting.
 
-A recommendation card turned out not to be a card at all. The feed carried a
-subject identifier, an origin, and metadata needed for a later action. Profile
-details and media arrived through other requests. Conversations crossed into
-Sendbird, which brought its own credentials, REST resources, and WebSocket
-connection. Before a model could write anything useful, the application had to
-join those pieces without mixing up the profile being viewed, the rating token
-attached to it, or the history of a different conversation. A model is very good
-at making incomplete context sound complete, so I made context assembly a
-deterministic part of the system.
+There is a more important qualification. Hinge's current [policy on third-party automated tools](https://help.hinge.co/hc/en-us/articles/49657802257683-Note-on-Third-Party-Automated-Tools) says that third-party automation violates its terms and can lead to an account ban. A human pressing the final button doesn't make the tool permitted. This is a retrospective on an unofficial personal experiment, not a recommendation or a usage guide.
 
-Authentication created a similar assembly problem. Device, installation, and
-session identifiers lived for different lengths of time, but the server expected
-one coherent client. Replacing one while retaining the others could leave a
-session that looked valid locally and failed remotely. The early Python probe was
-useful for learning that protocol. I moved the stateful core to Rust once the
-client had to survive between runs, preserve recommendation metadata, hydrate
-profiles in batches, and keep a second chat session alive. Known responses
-stayed typed. Unknown WebSocket frames remained available as raw data instead of
-bringing down the connection.
+## First, I only wanted the queue
 
-The reply generator could use written prompts directly, but photos needed their
-own pass. They often carried more personality than the written answers, so
-ignoring them stripped away much of what made a profile specific. I added an
-image-description pass that produced a short description of what was visible,
-then placed it beside the prompts and profile details. The agent could now notice
-an activity, a place, or a small background detail that the text alone never
-mentioned. For a new profile, it used that assembled context to draft opening
-messages. Generic charm is cheap, and a message that could be sent to anyone was
-not worth generating. A useful draft had to connect to a particular prompt or
-something visible in a photo. I still chose, edited, or ignored the result, but
-the first sentence was no longer a cold start.
+One Saturday in 2025, Hinge was showing me one profile at a time. I wanted to see the available recommendations as a list, leave, and return later without making a decision merely to reveal the next card. I stopped seeing a dating app and started seeing a badly paginated API. Four hours later I had the first rough client, which is a fairly normal way to spend a Saturday if you don't inspect it too closely.
 
-Replies needed a different context window. After a match, the application could
-retrieve the Sendbird transcript and combine the recent exchange with the
-original profile context. The agent drafted a response with both in view, which
-helped it continue a thread instead of asking a question that had already been
-answered. The output was a draft, not an unattended message. I could change it,
-ignore it, or send it. That small boundary kept the feature useful: the model
-handled recall and the first draft, while the conversation still sounded like
-one I had chosen to have.
+That first phase was intentionally mechanical. It authenticated my own account, fetched recommendation feeds, joined their subjects to profiles and media, and preserved the metadata needed for a later human action. It didn't rank people, or generate replies. The early protocol probe eventually proved one explicit, human-triggered skip, but the queue itself made no choice and there was never an autoswiper. Those omissions were part of the design, not missing weekend scope.
 
-The visible AI layer was thinner than the plumbing beneath it. The model
-described photos and drafted messages. Rust handled identity, joins, persistence,
-retries, protocol drift, and message transport. Keeping those responsibilities
-separate made failures legible. If a reply was poor, I could inspect the exact
-profile and transcript the model had seen. If the context was wrong, no amount
-of prompting would disguise a broken join or a stale session. This is still the
-most useful lesson I took from the project: an agent becomes dependable when the
-uncertain part sits on top of boring, inspectable tools.
+A recommendation card wasn't a card on the wire. The feed carried a subject identifier, an origin, and a rating token needed for a later like or skip. Profile details and media came from separate requests. Chat crossed into Sendbird, with its own credentials, REST resources, and WebSocket session. Mixing up any of those joins could show the right photo beside the wrong action token, which is the sort of bug one notices rather quickly.
 
-The part worth releasing was the part that knew nothing about my taste. I
-extracted the protocol layer into
-[hinge-rs](https://github.com/f0rr0/hinge-rs), an open-source, typed Rust client
-for Hinge and its Sendbird chat transport. It covers authentication,
-recommendations, profiles, likes, ratings, connections, message history, and
-live chat events, while retaining raw escape hatches for an undocumented API
-that will inevitably change. The crate stops at that boundary. It is the reliable
-protocol layer an agent could use.
+The reusable piece became [hinge-rs](https://github.com/f0rr0/hinge-rs), a public, unofficial Rust client for Hinge and its Sendbird transport. The recommendation join in the public API is deliberately boring:
 
-The agent never chose who I liked or carried a conversation unattended. It took
-over the tedious parts: gathering the queue, interpreting photos, remembering
-what had been said, and getting the first words onto the screen. That was enough
-to change the experience, and enough to turn a personal Saturday experiment into
-a public Rust library.
+```rust
+let recs = client.recommendations().get().await?;
 
-_This is a retrospective on a personal experiment. Hinge now
-[prohibits third-party automated
-tools](https://help.hinge.co/hc/en-us/articles/49657802257683-Note-on-Third-Party-Automated-Tools)._
+let subject_ids = recs
+    .feeds
+    .iter()
+    .flat_map(|feed| &feed.subjects)
+    .map(|subject| subject.subject_id.clone())
+    .collect();
+
+let profiles = client.profiles().public(subject_ids).await?;
+```
+
+The early Python probe was quickest for learning the protocol. Rust became useful later because the client had a growing set of typed response states, a session identity that had to remain coherent, an undocumented WebSocket protocol that would drift, and a distributable binary. Rust did not magically provide persistence; the application still needed an explicit session store and careful restore path. What it did provide was a good place to make muddled states difficult to construct. Known frames stayed typed, while unfamiliar ones could remain raw rather than bringing down the connection.
+
+## Then I tried the drafting layer
+
+The AI experiment came later and sat on top of that queue. Its orchestration and client ran locally. That word needs care: it doesn't prove that inference ran on the device. If a hosted vision or language provider is used, profile photos, prompts, or conversation excerpts leave the machine. A local provider changes that boundary; a local command line does not.
+
+For a new profile, the experiment assembled written prompts, profile details, and a short description of visible photo content, then proposed an opening. Generic charm is cheap. A draft was only interesting if it referred to a particular prompt or something actually visible in the profile. I still chose, edited, or ignored it.
+
+Replies used a different context window. The client retrieved the recent Sendbird exchange and combined it with the original profile context so the model didn't cheerfully ask a question that had been answered three messages earlier. Again, the output stopped at a draft. There was no automatic send path and no unattended conversation.
+
+The separation made failures easier to inspect. If a draft was poor, I could look at the exact context supplied to the model. If the context was wrong, prompting wasn't going to repair a broken join or a stale session. Sometimes the correct diagnosis was simply that the model had written a line no human being should send. Delete remains an excellent feature.
+
+## Other people's data is not test fixture
+
+A dating profile, photo, or private conversation belongs to another person as well as appearing in my account. Treating it as convenient model input would be a serious consent and security choice. Published examples should therefore be synthetic or used with explicit consent, and logs, caches, model-provider retention, and deletion need to be considered before any real data crosses that boundary.
+
+The public crate doesn't contain my taste or an AI matchmaker. It exposes the typed protocol layer: authentication, recommendations, profiles, ratings, connections, message history, and live chat events, with raw escape hatches for an API that will inevitably change. That extraction is early software, and using it against Hinge remains contrary to Hinge's current policy even if every like and message stays human-controlled.
+
+So no, the agent didn't really take over my Hinge. It gathered a queue and, in a separate experiment, got some first words onto the screen. Chemistry, mercifully, still doesn't implement `serde::Deserialize`.

--- a/src/content/blog/no-slots-so-i-built-tranquilo/page.mdx
+++ b/src/content/blog/no-slots-so-i-built-tranquilo/page.mdx
@@ -8,99 +8,121 @@ export const metadata = {
   draft: true,
 };
 
-Pronto's House Help appointments had become a queue I could only join by
-repeatedly checking the app. For several evenings, I opened it after work and
-found nothing useful. I knew appointments were becoming available because I
-would occasionally catch one, only to see it disappear before I could act.
-Checking every few minutes would probably have worked. I did not want to spend
-my evenings doing that, so I gave an AI agent a simple instruction: “Find an
-hour tomorrow after six. If there is nothing, keep looking.”
+Pronto's House Help appointments had become a queue I could only join by repeatedly opening the app. For several evenings I checked after work, found nothing useful, closed it, and tried again later. Every so often a decent slot would appear and disappear before I could act. The supply existed; my timing was rubbish.
 
-People fill in quite a lot when they hear a request like that. The software had
-to turn “after six” into a time window, “an hour” into a preference with
-acceptable fallbacks, and “keep looking” into work that survived a sleeping
-laptop, a reboot, and stale availability. It also had to account for a more
-important problem: finding a slot did not reserve it.
+Checking every few minutes would probably have worked. I didn't want to donate my evenings to a refresh button, so I built [Tranquilo](https://github.com/f0rr0/tranquilo) and gave an agent a fairly ordinary instruction:
 
-## Turning the request into a watch
+> Find an hour tomorrow after six. If there is nothing, keep looking.
 
-I started by treating every availability result as an observation made at a
-particular time, rather than a promise that the slot would still be there later.
-That kept search and booking as separate operations from the beginning. The
-availability responses did not always describe slots in the same way. A
-duration could also map to different service identifiers depending on the
-selected address or live catalog. I normalized those variations at the edge
-and carried the resolved service and duration through the rest of the workflow.
-The rest of the program could then use one small model instead of knowing every
-shape the upstream service might return.
+“The agent waited in line” is a convenient description, but it collapses three different bits of software. The model translated my sentence into structured intent. Ordinary TypeScript ranked and revalidated slots. An operating-system scheduler did the waiting. Keeping those jobs separate turned out to matter more than making the agent sound clever.
 
-Availability was only one part of the request. On most days, I preferred a slot
-after work, then an earlier date, then a particular duration, with a few
-acceptable fallbacks. Those preferences were ordered, not interchangeable. A
-slot in the wrong time window should not win merely because it was twenty
-minutes earlier. I encoded the preferences in priority order: time window
-first, then date, duration, and clock time. Each priority occupied a separate
-score range, so a lower-priority choice could not overpower a higher-priority
-one. Without that separation, a mathematically good score could still produce
-a slot I would never choose.
+## First, make “after six” boring
 
-Time itself required care. Appointment times are local civil times, while
-scheduled checks run at UTC instants. Treating both as ordinary JavaScript dates
-invites quiet errors around parsing and conversion. I used the Temporal model to
-keep those concepts separate, rejecting past or out-of-horizon slots even when
-an old response still contained them. I exposed the workflow as a Model Context
-Protocol tool. The model could translate my sentence into tomorrow's date, a
-six-p.m. boundary, a sixty-minute preference, and instructions to keep looking.
-The tool validated those parameters and stored them as a watch that could
-continue after the conversation ended.
+An availability response is an observation, not a reservation. By the time I read it, the remote state may already have changed. Tranquilo therefore normalises the response at the edge and carries one small slot model through the rest of the program:
 
-My first instinct was a JavaScript loop with a sleep call, but that was a poor
-fit for a laptop that closes, reboots, changes networks, and gets upgraded. A
-loop is simple while it is running, but keeping it reliable for several days is
-a different problem. On my Mac, each check became a short-lived `launchd` job.
-The operating system woke the program, which acquired an exclusive file lock,
-loaded the watches that were due, checked current availability, recorded the
-next state, and exited. The same design could map to a `systemd` timer or Task
-Scheduler elsewhere.
+```ts
+type SlotObservation = {
+  startTime: string;
+  durationMinutes: number;
+  listingId: string;
+  listingItemId: string;
+  slotsLeft?: number;
+  isFull: boolean;
+  observedAt: Temporal.Instant;
+};
+```
 
-Instead of keeping a process alive, I persisted the watch. A crash could
-interrupt one check without erasing the instruction to keep looking, and a
-reboot did not require me to remember to restart a daemon. The exclusive lock
-stopped a manual check and a scheduled one from updating the same state at
-once. Each run recorded one event: no match, a transient error, an expiry, or a
-slot worth seeing. Errors delayed the next attempt more than an ordinary miss.
+That also avoids hard-coding “60 minutes” to one product identifier. The listing depends on the selected address and live catalogue, so search resolves the service first and carries the identifiers forward.
 
-When a useful slot appeared, the watcher saved the exact result, sent a
-notification, cleared its next run, and stopped. The notification marked the
-point where the agent was done and I took over. I had sent it to wait, not to
-choose who entered my home or spend money on my behalf.
+My preferences weren't interchangeable. After work mattered more than whether the appointment began twenty minutes earlier; tomorrow mattered more than a slightly better duration three days later. The interactive `find` command uses separate score bands to preserve that order:
 
-## Finding a slot was not booking it
+```ts
+const rank =
+  matchedWindow.rank * 1_000_000 +
+  datePenalty * 10_000 +
+  durationRank * 100 +
+  hour * 2 +
+  minute / 30;
+```
 
-Time still passed between seeing a slot and acting on it, and no local lock
-could reserve an appointment held by a remote service. When I chose a result,
-the booking path searched again for the exact duration and timestamp. If the
-slot had disappeared, it stopped there and returned to fresh availability. If
-the slot remained, the program resolved the service for the selected address
-again before touching the cart.
+It is a lexicographic sort wearing a numerical moustache. A lower-priority preference can't accumulate enough points to defeat a higher-priority one.
 
-The cart was another source of stale state. It could contain an old item, a
-change made by another client, or a listing that no longer represented the
-duration I had selected. After setting the item and slot, the program fetched
-the cart again and verified the service identifiers against the choice. The
-checkout used the amount and cart version from that read, not values remembered
-from the earlier search. This narrowed the race without pretending to eliminate
-it. Another customer could still take the appointment after revalidation and
-before checkout completed. I treated that overbooking response as an expected
-outcome and sent the workflow back to search. Careful local code could reduce
-the window, but it could not make the remote booking system transactional.
+The watch path is deliberately simpler: it checks the concrete date, duration and window saved in the watch and stops at the first acceptable live result. It does **not** currently run every candidate through the full weighted ranker. That distinction had disappeared in my first account of the project, and the code is more interesting when I don't make it tidier than it is.
 
-I deliberately stopped the automation at payment. The tool could prepare
-checkout and render a UPI option locally, but provider credentials never entered
-the model's context and I still had to approve the payment. It was less
-convenient than a single “book it” operation, but I knew exactly where control
-changed hands. The agent was the part I spoke to. The scheduler did the
-waiting, ordinary ranking code compared the slots, and a notification brought
-the decision back to me. I no longer had to keep opening an empty booking
-screen. The agent waited in line, and when it reached the front, it came back
-to get me.
+Appointment times are local civil times; scheduled checks happen at instants. Tranquilo uses the [`Temporal`](https://tc39.es/proposal-temporal/docs/) model to keep those concepts apart and rejects past or out-of-horizon results. The [MCP](https://modelcontextprotocol.io/) tool can turn “tomorrow after six” into validated dates, a time window and duration preferences. It then persists a watch rather than leaving the conversation open.
+
+## A scheduler, not an immortal loop
+
+My first version wanted to do this:
+
+```ts
+while (true) {
+  await checkForSlots();
+  await sleep(60_000);
+}
+```
+
+That works until the laptop sleeps, the network changes, the process dies, or I forget why a random Bun process has been alive for four days.
+
+The repository implements all three desktop scheduler adapters:
+
+| Platform | What Tranquilo installs            |
+| -------- | ---------------------------------- |
+| macOS    | a per-user `launchd` agent         |
+| Linux    | a `systemd` user service and timer |
+| Windows  | a Task Scheduler task              |
+
+Each trigger launches a short-lived check which loads due watches, queries availability, records the result and exits. On macOS, `StartInterval` doesn't magically poll while a laptop is asleep. The useful property is that the saved watch is still there when the machine is available again; this is durable intent, not an always-on service.
+
+The state progression is small enough to read without a diagram:
+
+```text
+enabled --no match--> enabled (next run)
+enabled --error-----> enabled (delayed retry)
+enabled --slot------> found
+enabled --date past-> expired
+paused  --resume----> enabled
+```
+
+There are two reliability details worth stating precisely. The current lock is an exclusive `wx` sentinel file. It prevents a scheduled run and a manual run from overlapping normally, but it isn't a lease and it has no stale-lock recovery after an abnormal exit. State is also written directly as JSON rather than through a temporary file plus `fsync` and atomic rename. So a reboot doesn't require a daemon restart, but I won't claim the watch store is crash-proof.
+
+Notification delivery has a similar edge. Today the watcher notifies before it saves the final `found` state. If the notification succeeds and the process dies before the write, a later run can notify twice. If notification fails and the error is swallowed, the watch can still become `found` and stop checking. This is best-effort delivery. A production-grade version needs a small outbox, an atomic state transition and retryable notification records. “Exactly once” would be a very ambitious phrase for a desktop notification anyway.
+
+Those aren't theoretical distributed-systems flourishes. They're the bits I would harden before telling someone else to depend on a week-long watch.
+
+## Finding a slot still isn't booking it
+
+No local lock can reserve an appointment in a remote service. When I select a result, the booking path searches again for the exact timestamp and duration. If the slot has gone, it stops before checkout. If it remains, Tranquilo:
+
+1. resolves the saved address and current House Help listing;
+2. sets exactly one resolved item and the selected slot in the cart;
+3. fetches the cart again;
+4. verifies both listing identifiers against the choice; and
+5. creates checkout using the amount and cart version from that fresh read.
+
+Another customer can still take the appointment between the final check and checkout. Tranquilo treats `SLOT_OVERBOOKED` as an expected result and returns to fresh availability. The revalidation narrows the race; it doesn't turn Pronto into my database transaction.
+
+Preparing a booking is itself a remote mutation: it changes the cart and can create the Juspay order before I pay. That is why it is a separate, explicit operation rather than something a notify-only watch may call.
+
+## The agent-facing boundary is narrow, not magic
+
+The MCP catalogue gives search, watching, booking preparation and payment handoff different capabilities:
+
+| Tool                        | Behaviour | Boundary                         |
+| --------------------------- | --------- | -------------------------------- |
+| `househelp_find_slots`      | read-only | never touches cart or checkout   |
+| `househelp_watch_create`    | mutating  | persists a notify-only watch     |
+| `househelp_prepare_booking` | mutating  | needs an exact duration and slot |
+| `househelp_payment_handoff` | read-only | returns a local payment command  |
+
+The watch can't auto-book, and search can't quietly mutate the cart. Long-lived authentication tokens and the payment URI are kept out of the public agent-facing response; payment approval stays in my terminal. That is narrower than saying “provider credentials never enter model context”. A phone number, OTP, address label or order metadata can still be exposed if someone places it in a prompt or chooses a hosted model. The boundary depends on the client and model provider as well as Tranquilo's response schema.
+
+I also don't regard an undocumented personal-service API as an invitation to hammer it. The current watcher uses a fixed cadence and a coarse delay after errors. Before broader use, I would add jitter, explicit `Retry-After` handling, a longer adaptive backoff and a conservative ceiling on requests. The tool should remain a quiet substitute for my own refreshes, not become a small denial-of-service project because I wanted a clean floor.
+
+## What the repository proves
+
+The [public source](https://github.com/f0rr0/tranquilo) contains the TypeScript CLI, MCP server, scheduler adapters, booking revalidation and local payment handoff. The [documentation](https://tranquilo-ai.vercel.app/docs) describes the commands and installation. It demonstrates the mechanism; it isn't a controlled experiment in slot-acquisition speed, and I don't have a neat graph of polls-to-booking to pretend otherwise.
+
+What changed for me was much smaller. I stopped keeping an empty booking screen in my working memory. The model parsed the request, the scheduler checked when my laptop was awake, and a notification returned the choice to me.
+
+I had sent the machine to spend time, not authority. Then I got on with my evening.

--- a/src/content/blog/the-website-that-waited-2776-days/page.mdx
+++ b/src/content/blog/the-website-that-waited-2776-days/page.mdx
@@ -3,67 +3,56 @@ export const metadata = {
   date: "2026-07-30",
   author: "Sid Jain",
   summary:
-    "On July 30, 2026, I reopened a personal site I had last updated 2,776 days earlier, left its 2018 version intact, and rebuilt it around the work I do now.",
+    "On July 30, 2026—2,776 days after my last published post—I preserved the site's 2018 frame and rebuilt its front door around the work I do now.",
   tags: ["personal web", "web development", "writing"],
   draft: true,
 };
 
-On July 30, 2026, I came back to this website after seven years, seven months,
-and seven days. It still thought I lived in Berlin, described my job at
-Lufthansa, and tried unsuccessfully to load my recent music and activity from
-Last.fm and RescueTime. The last post was dated December 23, 2018. The gap was
-long enough to make the old homepage feel less like an outdated profile and
-more like a letter from an earlier version of me. Before I could publish again,
-I had to decide whether to correct that letter, replace it, or let it remain
-true to the moment in which it was written.
+On July 30, 2026, I came back to this website exactly seven years, seven months, and seven days after its newest published post. _2018 Music in Review_ was dated December 23, 2018. That makes the publishing gap 2,776 days, which is so suspiciously tidy that it feels less like neglect and more like a very slow countdown.
 
-The old homepage mixed professional facts with details I would never put on a
-résumé. It showed where I lived, what I was building, what music I had played
-recently, and how I was spending my time. Some of the live feeds were now
-broken, but their presence said something useful about how I thought personal
-software should work in 2018. I wanted the site to do more than describe me. I
-wanted it to show small, current traces of my days.
+That number measures the gap between posts. It doesn't mean every byte of the site sat untouched for 2,776 days. The static build was committed on December 24, 2018, and on April 27, 2026 I removed its old `yuppi.es` CNAME. The page itself, though, still thought I lived in Berlin, worked at Lufthansa, and could fetch my recent life from RescueTime and Last.fm.
 
-What remained on disk was the deployed site rather than a maintainable
-application. I could have reconstructed the source, upgraded the dependencies,
-repaired the integrations, and edited facts that had aged. Each repair would
-have made the page easier to run and slightly less accurate as a record, so I
-chose to preserve it instead. The final deployed build stayed untouched while I
-began the new site separately. The dead feeds are not useful now, but they
-belong to that version of the site. The old location and job are wrong today
-and right for the page. Keeping it intact lets the page say what I considered
-worth sharing then without quietly editing the past.
+I put the two useful frames side by side: the [old deployed snapshot](https://github.com/f0rr0/f0rr0.github.io/tree/0dd47f41a0073b5e9b60f0b2b4596824c3f8bd58) and the [July 2026 rebuild](https://github.com/f0rr0/f0rr0.github.io/tree/4861fefc61f6794a12018aabf2730dc673049c52). Git considers their branches unrelated histories. The human evidence is less confused.
 
-The old site was organized around three invitations: About, Blog, and Hire Me.
-It introduced a young engineer, collected technical notes, and gave prospective
-clients a way to get in touch. The live activity streams filled some of the
-space between posts. Preserving it answered one question, but I still had to
-decide what the replacement was for. Its front door is now the
-[résumé](/resume), a structured account of my work. The blog fills in what that
-format leaves out: the reasoning, compromises, and wrong turns behind the
-finished systems. That change made rebuilding more sensible than migration.
-Carrying the old architecture forward would have made both versions harder to
-understand. I wanted the earlier site to remain inspectable on its own terms
-and the current one to reflect the work I can maintain now.
+## The frame I reopened
 
-Rebuilding also exposed how easily a personal site can contradict itself. The
-résumé page, its PDF, and the structured versions now read from the same record,
-while the feeds and metadata read from the posts. I kept that machinery simple.
-It should keep the current site consistent without changing the old one.
+It was quite a room: Inconsolata in a narrow 700-pixel column, midnight-blue walls, cyan links, and a slab of razzmatazz pink announcing `YUPPI.ES`. The navigation offered three doors—About, Blog, and Hire Me. No gradients, cookie banners, or urgent button asking anyone to book a demo.
 
-The seven-year gap created a different editorial problem. I was tempted to
-reconstruct it in order, treating the missing years as a backlog, assigning old
-dates to old projects, and working forward until the archive appeared
-continuous. That would have produced a neat chronology and a false account of
-when the writing happened. These new pieces are retrospectives, written with
-the context I have now, and their publication dates should say so. I can
-reconstruct many of the decisions and tradeoffs, but I cannot turn that
-reconstruction into a contemporaneous journal.
+The introduction crossed out Los Angeles, New Delhi, and Mumbai before arriving in Berlin. I worked at Lufthansa and was passionate about lambda calculus, house music, and Mexican food. Then came the heartbeat. The page said I had been lifelogging since 2014 and promised fresh RescueTime activity and Last.fm plays beneath a tiny **“Crunching latest data...”** animation. That promise had not aged brilliantly.
 
-I eventually stopped treating the silence as a backlog. I want this site to be
-a place where I can examine work while the important questions are still
-visible, then return when distance reveals something the first account missed.
-Some posts will look back, while others can follow projects that are still
-unfolding. The old site can remain in 2018, complete with Berlin, Lufthansa, and
-the feeds that no longer answer. This one is for what I can still observe
-clearly and for what happens next.
+The rest was equally specific. The About page remembered sixth-grade Logo, Flash animations—`.swf`, anyone?—Near-Earth Object observations, card tricks, and winning a Wordmaster championship after misspelling “hygiene”. The 404 page said:
+
+> You should know better than hitting routes that don't exist.
+
+Naturally, it followed this with a GIF.
+
+The checkout I reopened was the deployed `master` branch: generated HTML, `bundle.js`, a source map, feed, icons, and article media. It had no `package.json`, so it looked at first like the editable application had gone. It hadn't. The [source survives on `dev`](https://github.com/f0rr0/f0rr0.github.io/tree/dev), running Gatsby `0.12.10` and React `15.3.2`.
+
+I could have revived that source, but “revive” hides quite a lot of work: reconcile an obsolete Node toolchain, update old loaders, replace dead feed integrations, and then decide which 2018 facts to correct. Every repair would make the site easier to run and slightly less accurate as a record. I chose to leave the archived frame as it was and build the current site separately.
+
+## The site I need now
+
+The old site was organised around an introduction and live traces of my days. The current front door is the [résumé](/resume), a structured account of the work. The [blog](/blog) gets to hold what a résumé cannot: the bad hypotheses, compromises, code, and things I only understood after a project had shipped.
+
+The contrast is useful:
+
+| 2018 frame                          | 2026 frame                         |
+| ----------------------------------- | ---------------------------------- |
+| `YUPPI.ES`                          | Sid Jain / `F0RR0`                 |
+| About · Blog · Hire Me              | Blog · Résumé · GitHub             |
+| Berlin · Lufthansa                  | Mumbai · recent work               |
+| Inconsolata · midnight · neon pink  | Literata · paper · amber           |
+| RescueTime and Last.fm live streams | Structured résumé and blog content |
+| “Crunching latest data...”          | RSS, JSON, and `llms.txt`          |
+
+Under the paper surface it is very much a different internet era: Next 16, React 19, MDX, generated social images, Schema.org metadata, [RSS](/rss.xml), a [JSON résumé](/resume.json), and a [plain-text profile](/llms.txt). Those outputs aren't separate biographies. The résumé page, its PDF and the machine-readable versions all derive from the same structured record; feeds and post metadata derive from the articles. I don't want to update my job in four places and discover a fifth one six months later.
+
+That canonical-source decision is also why I rebuilt instead of migrating. The old source remains public and inspectable on its own terms. The [current repository](https://github.com/f0rr0/f0rr0.github.io) is the source of truth for what the site says now. One is an archive; the other is allowed to change.
+
+## Not filling the silence
+
+The gap created an editorial temptation: reconstruct seven years in order, assign old dates to old projects, and work forward until the archive looked continuous. It would also be untrue. These pieces are retrospectives written with what I know now. Their dates should say when the writing happened, not when I wish I had kept notes.
+
+So I am not treating the silence as a backlog. Some posts will look back; others can follow work while the awkward questions are still visible. The old homepage can keep Berlin, Lufthansa, its five-bar music visualiser, and the feeds forever crunching their latest data. This site can be a little less patient.
+
+Not the fastest hot reload I have ever shipped.


### PR DESCRIPTION
## Summary

- revise all seven unpublished blog posts to better match the voice, pacing, punctuation, vocabulary and formatting of the published archive
- strengthen technical substance with code samples, diagrams, primary-source links and organic references to public GitHub work
- rebuild the ZeroClaw post around the real office/WFH household lunch problem, the cook workflow, pantry-photo ingestion, Instamart state and meal-decision completion
- add restrained, article-specific GPT Image prompts for optional illustrations and diagrams
- retain every existing article title and keep all posts unpublished

## Why

The drafts were accurate but often too detached and defensive for a personal engineering blog. Several of the most interesting things built—especially the ZeroClaw pantry loop—were treated as implementation footnotes. This pass makes the motivation clearer, foregrounds the impressive work, and preserves the author's natural contractions, Indian/British phrasing, candid observations and occasional jokes without reproducing old grammar mistakes.

## Impact

All affected posts remain `draft: true`. No published article, route or title changes as part of this PR.

## Validation

- targeted `oxfmt --check` passes for all eight changed files
- independent MDX compilation passes for the seven posts
- `bun run typecheck` passes
- `bun run build` passes
- draft routes were verified in development

Full-repository `bun run lint` remains blocked by unchanged baseline issues on `next`: formatting in six existing Markdown/MDX files plus four existing component-rule violations in `json-ld.tsx`, `Mermaid.tsx` and `MDXImage.tsx`. None of those paths is modified by this branch.
