### PR TITLE
feat(blog): polish code blocks and diagrams

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -63,19 +63,29 @@ Gotchas:
 
 - GFM tables and footnotes are enabled.
 - Syntax highlighting uses Shiki via `rehype-pretty-code`.
+- Code blocks show their language and include a copy control. Long lines scroll
+  within the code frame instead of widening the page.
+- Add a lowercase language after the opening fence whenever possible. Blocks
+  without one are labeled as plain text.
 - Headings get slugs and clickable anchors.
-- Mermaid diagrams are supported with fenced blocks:
+- Mermaid diagrams are generated from fenced blocks and rendered with the
+  site's deterministic hand-drawn theme:
 
 ````md
 ```mermaid
 flowchart LR
+  accTitle: Request flow
+  accDescr: A request moves from the browser to the application.
   A --> B
 ```
 ````
 
-```
-
-If rendering fails, the raw code block is shown.
+- Add `accTitle` and `accDescr` so the generated SVG has a useful accessible
+  name and description.
+- Dense flowcharts can select `layout: elk` in Mermaid YAML frontmatter. The ELK
+  renderer is loaded only for diagrams that request it.
+- Diagrams automatically follow the site theme and provide horizontal
+  scrolling, zoom, and full-screen controls.
 
 ## RSS + SEO endpoints
 
@@ -92,4 +102,3 @@ Canonical URLs are derived from Vercel system environment variables when deploye
 3. (Optional) add `opengraph-image.png` and/or `twitter-image.png` next to the post.
 4. Reference images with `./` paths (Markdown) or `src="./..."` (JSX).
 5. Keep `draft: true` until ready to publish.
-```

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@base-ui/react": "^1.6.0",
         "@mdx-js/loader": "^3.1.1",
         "@mdx-js/react": "^3.1.1",
+        "@mermaid-js/layout-elk": "0.1.9",
         "@next/mdx": "^16.2.12",
         "@t3-oss/env-nextjs": "^0.13.11",
         "@tailwindcss/typography": "^0.5.20",
@@ -214,6 +215,8 @@
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
+
+    "@mermaid-js/layout-elk": ["@mermaid-js/layout-elk@0.1.9", "", { "dependencies": { "d3": "^7.9.0", "elkjs": "^0.9.3" }, "peerDependencies": { "mermaid": "^11.0.2" } }, "sha512-HuvaqFZBr6yT9PpWYockvKAZPJVd89yn/UjOYPxhzbZxlybL2v+2BjVCg7MVH6vRs1irUohb/s42HEdec1CCZw=="],
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.2.0", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA=="],
 
@@ -766,6 +769,8 @@
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.283", "", {}, "sha512-3vifjt1HgrGW/h76UEeny+adYApveS9dH2h3p57JYzBSXJIKUJAvtmIytDKjcSCt9xHfrNCFJ7gts6vkhuq++w=="],
+
+    "elkjs": ["elkjs@0.9.3", "", {}, "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -44,6 +44,9 @@ const withMDX = createMDX({
       [
         "rehype-pretty-code",
         {
+          defaultLang: {
+            block: "plaintext",
+          },
           theme: {
             light: "github-light",
             dark: "github-dark",

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -3,6 +3,8 @@ import ultracite from "ultracite/oxfmt";
 
 export default defineConfig({
   ...ultracite,
+  // Preserve authored and historical code samples exactly as published.
+  embeddedLanguageFormatting: "off",
   ignorePatterns: [
     ...(ultracite.ignorePatterns ?? []),
     "**/.rulesync",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@base-ui/react": "^1.6.0",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
+    "@mermaid-js/layout-elk": "0.1.9",
     "@next/mdx": "^16.2.12",
     "@t3-oss/env-nextjs": "^0.13.11",
     "@tailwindcss/typography": "^0.5.20",

--- a/src/app/(blog)/blog/[slug]/page.tsx
+++ b/src/app/(blog)/blog/[slug]/page.tsx
@@ -169,7 +169,7 @@ export default async function BlogPostPage({ params }: { params: PageParams }) {
             )}
           </div>
         </header>
-        <div className="prose w-full max-w-4xl prose-h2:text-2xl prose-h3:text-xl prose-p:leading-relaxed">
+        <div className="prose min-w-0 w-full max-w-4xl prose-h2:text-2xl prose-h3:text-xl prose-p:leading-relaxed">
           <Content components={mdxComponents} />
         </div>
       </article>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -146,6 +146,10 @@ body {
   .theme-transition * {
     transition: none;
   }
+
+  .prose .mermaid-placeholder-mark {
+    animation: none;
+  }
 }
 
 .prose {
@@ -181,30 +185,430 @@ body {
   text-decoration: underline;
 }
 
-.prose pre[data-theme] {
-  background-color: var(--shiki-light);
-  border-radius: 0.75rem;
-  padding: 1.25rem;
-  overflow-x: auto;
-}
-
 .prose pre,
 .prose code {
   font-family: var(--font-site-mono);
 }
 
-.dark .prose pre[data-theme] {
-  background-color: var(--shiki-dark);
+.prose figure[data-rehype-pretty-code-figure] {
+  margin: 2.25rem 0;
+}
+
+.prose .code-block {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid color-mix(in oklab, var(--border) 88%, var(--foreground));
+  border-radius: 0.875rem;
+  background: color-mix(in oklab, var(--card) 92%, var(--muted));
+  box-shadow:
+    0 1px 2px rgb(41 37 36 / 8%),
+    0 16px 38px -32px rgb(41 37 36 / 38%);
+}
+
+.dark .prose .code-block {
+  box-shadow:
+    0 1px 2px rgb(0 0 0 / 30%),
+    0 18px 42px -30px rgb(0 0 0 / 85%);
+}
+
+.prose .code-block-toolbar {
+  display: flex;
+  min-height: 2.625rem;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.25rem;
+  border-bottom: 1px solid color-mix(in oklab, var(--border) 88%, transparent);
+  background: color-mix(in oklab, var(--muted) 72%, var(--card));
+  padding: 0.35rem 0.5rem 0.35rem 1rem;
+  font-family: var(--font-site-ui);
+}
+
+.prose .code-block-language {
+  margin-right: 0.25rem;
+  color: color-mix(in oklab, var(--muted-foreground) 88%, var(--foreground));
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.075em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.prose .code-block-copy {
+  display: inline-flex;
+  height: 1.875rem;
+  min-width: 4.625rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  border: 1px solid transparent;
+  border-radius: 0.5rem;
+  padding: 0 0.5rem;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease;
+}
+
+.prose .code-block-copy:hover {
+  border-color: color-mix(in oklab, var(--border) 86%, var(--foreground));
+  background: color-mix(in oklab, var(--card) 75%, transparent);
+  color: var(--foreground);
+}
+
+.prose .code-block-copy:focus-visible {
+  border-color: var(--ring);
+  outline: 2px solid color-mix(in oklab, var(--ring) 38%, transparent);
+  outline-offset: 1px;
+}
+
+.prose .code-block-copy svg {
+  width: 0.875rem;
+  height: 0.875rem;
+  stroke-width: 1.8;
+}
+
+.prose .code-block pre[data-theme] {
+  max-width: 100%;
+  margin: 0;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  scrollbar-color: color-mix(in oklab, var(--muted-foreground) 48%, transparent)
+    transparent;
+  scrollbar-width: thin;
+}
+
+.prose .code-block pre[data-theme]:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+}
+
+.prose .code-block pre[data-theme]::-webkit-scrollbar {
+  height: 0.75rem;
+}
+
+.prose .code-block pre[data-theme]::-webkit-scrollbar-track {
+  border-top: 1px solid color-mix(in oklab, var(--border) 72%, transparent);
+  background: color-mix(in oklab, var(--muted) 58%, transparent);
+}
+
+.prose .code-block pre[data-theme]::-webkit-scrollbar-thumb {
+  border: 0.2rem solid transparent;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--muted-foreground) 52%, transparent);
+  background-clip: padding-box;
+}
+
+.prose .code-block pre[data-theme] > code {
+  display: grid;
+  width: max-content;
+  min-width: 100%;
+  padding: 1.125rem 0 1.25rem;
+  background: transparent;
+  color: var(--foreground);
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.7;
+}
+
+.prose .code-block [data-line] {
+  min-width: 100%;
+  padding: 0 1.25rem;
+}
+
+.prose .code-block [data-highlighted-line] {
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+  box-shadow: inset 2px 0 0 color-mix(in oklab, var(--primary) 82%, transparent);
+}
+
+.prose .code-block [data-highlighted-chars] {
+  border-radius: 0.25rem;
+  background: color-mix(in oklab, var(--primary) 15%, transparent);
+  box-shadow: 0 0 0 0.125rem
+    color-mix(in oklab, var(--primary) 15%, transparent);
+}
+
+.prose code[data-theme],
+.prose code[data-theme] span {
+  color: var(--shiki-light);
+  font-style: var(--shiki-light-font-style);
+  font-weight: var(--shiki-light-font-weight);
+  text-decoration: var(--shiki-light-text-decoration);
+}
+
+.dark .prose code[data-theme],
+.dark .prose code[data-theme] span {
+  color: var(--shiki-dark);
+  font-style: var(--shiki-dark-font-style);
+  font-weight: var(--shiki-dark-font-weight);
+  text-decoration: var(--shiki-dark-text-decoration);
+}
+
+.prose .mermaid-block {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid color-mix(in oklab, var(--border) 88%, var(--foreground));
+  border-radius: 0.875rem;
+  background: color-mix(in oklab, var(--card) 94%, var(--muted));
+  box-shadow:
+    0 1px 2px rgb(41 37 36 / 8%),
+    0 18px 42px -34px rgb(41 37 36 / 34%);
+}
+
+.dark .prose .mermaid-block {
+  box-shadow:
+    0 1px 2px rgb(0 0 0 / 30%),
+    0 18px 42px -30px rgb(0 0 0 / 80%);
+}
+
+.prose .mermaid-toolbar {
+  display: flex;
+  min-height: 2.75rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border-bottom: 1px solid color-mix(in oklab, var(--border) 88%, transparent);
+  background: color-mix(in oklab, var(--muted) 72%, var(--card));
+  padding: 0.35rem 0.5rem 0.35rem 1rem;
+  font-family: var(--font-site-ui);
+}
+
+.prose .mermaid-diagram-type {
+  overflow: hidden;
+  color: color-mix(in oklab, var(--foreground) 88%, var(--muted-foreground));
+  font-size: 0.75rem;
+  font-weight: 650;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.prose .mermaid-toolbar-actions {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 0.2rem;
+}
+
+.prose .mermaid-language {
+  margin-inline: 0.35rem 0.25rem;
+  color: color-mix(in oklab, var(--muted-foreground) 88%, var(--foreground));
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.075em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.prose .mermaid-control {
+  display: inline-flex;
+  height: 1.875rem;
+  min-width: 1.875rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  border: 1px solid transparent;
+  border-radius: 0.5rem;
+  padding: 0 0.42rem;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  font-family: var(--font-site-ui);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease,
+    opacity 150ms ease;
+}
+
+.prose .mermaid-control:hover:not(:disabled) {
+  border-color: color-mix(in oklab, var(--border) 86%, var(--foreground));
+  background: color-mix(in oklab, var(--card) 75%, transparent);
+  color: var(--foreground);
+}
+
+.prose .mermaid-control:focus-visible {
+  border-color: var(--ring);
+  outline: 2px solid color-mix(in oklab, var(--ring) 38%, transparent);
+  outline-offset: 1px;
+}
+
+.prose .mermaid-control:disabled {
+  cursor: default;
+  opacity: 0.35;
+}
+
+.prose .mermaid-control svg {
+  width: 0.875rem;
+  height: 0.875rem;
+  stroke-width: 1.8;
+}
+
+.prose .mermaid-zoom-reset {
+  min-width: 3.9rem;
+}
+
+.prose .mermaid-viewport {
+  position: relative;
+  min-height: 11rem;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  background-color: color-mix(in oklab, var(--card) 94%, var(--background));
+  background-image: radial-gradient(
+    circle,
+    color-mix(in oklab, var(--muted-foreground) 19%, transparent) 0.75px,
+    transparent 0.8px
+  );
+  background-position: 0.25rem 0.25rem;
+  background-size: 1rem 1rem;
+  padding: 1.75rem;
+  scrollbar-color: color-mix(in oklab, var(--muted-foreground) 52%, transparent)
+    color-mix(in oklab, var(--muted) 58%, transparent);
+  scrollbar-width: thin;
+}
+
+.prose .mermaid-viewport:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+}
+
+.prose .mermaid-viewport::-webkit-scrollbar {
+  height: 0.75rem;
+}
+
+.prose .mermaid-viewport::-webkit-scrollbar-track {
+  border-top: 1px solid color-mix(in oklab, var(--border) 72%, transparent);
+  background: color-mix(in oklab, var(--muted) 58%, transparent);
+}
+
+.prose .mermaid-viewport::-webkit-scrollbar-thumb {
+  border: 0.2rem solid transparent;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--muted-foreground) 52%, transparent);
+  background-clip: padding-box;
+}
+
+.prose .mermaid-canvas {
+  display: flex;
+  width: max-content;
+  min-width: 100%;
+  align-items: flex-start;
+  justify-content: center;
+  transition: opacity 180ms ease;
+}
+
+.prose .mermaid-canvas .mermaid-svg {
+  display: block;
+  width: var(--mermaid-render-width);
+  max-width: none;
+  height: auto;
+  flex: none;
+  overflow: visible;
+  background: transparent;
+}
+
+.prose .mermaid-block[data-rendering="true"] .mermaid-canvas {
+  opacity: 0.58;
+}
+
+.prose .mermaid-placeholder,
+.prose .mermaid-error {
+  display: flex;
+  min-height: 7.5rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  color: var(--muted-foreground);
+  font-family: var(--font-site-ui);
+  font-size: 0.8125rem;
+}
+
+.prose .mermaid-placeholder-mark {
+  width: 2.25rem;
+  height: 1.4rem;
+  border: 2px solid color-mix(in oklab, var(--primary) 72%, transparent);
+  border-radius: 48% 54% 46% 52%;
+  animation: mermaid-sketch-pulse 1.35s ease-in-out infinite alternate;
+  transform: rotate(-3deg);
+}
+
+.prose .mermaid-error {
+  flex-direction: column;
+  gap: 0.2rem;
+  text-align: center;
+}
+
+.prose .mermaid-error strong {
+  color: var(--foreground);
+  font-size: 0.875rem;
+  font-weight: 650;
+}
+
+.prose .mermaid-error span {
+  font-size: 0.75rem;
+}
+
+.prose .mermaid-block:fullscreen {
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  flex-direction: column;
+  border: 0;
+  border-radius: 0;
+  background: var(--background);
+}
+
+.prose .mermaid-block:fullscreen .mermaid-viewport {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  align-items: center;
+  padding: clamp(1rem, 4vw, 4rem);
+}
+
+.prose .mermaid-block:fullscreen .mermaid-canvas {
+  align-items: center;
+}
+
+@keyframes mermaid-sketch-pulse {
+  from {
+    opacity: 0.35;
+    transform: rotate(-3deg) scale(0.94);
+  }
+
+  to {
+    opacity: 0.9;
+    transform: rotate(2deg) scale(1.02);
+  }
 }
 
 .prose code:not(pre code) {
-  background: color-mix(in oklab, var(--muted) 75%, transparent);
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+  overflow-wrap: anywhere;
+  border: 1px solid color-mix(in oklab, var(--border) 86%, var(--foreground));
   border-radius: 0.375rem;
-  padding: 0.15rem 0.35rem;
+  background: color-mix(in oklab, var(--muted) 82%, var(--card));
+  padding: 0.12em 0.36em;
+  color: color-mix(in oklab, var(--foreground) 92%, var(--primary));
+  font-size: 0.875em;
+  font-weight: 500;
 }
 
-.dark .prose code:not(pre code) {
-  background: color-mix(in oklab, var(--muted) 85%, transparent);
+.prose code:not(pre code)::before,
+.prose code:not(pre code)::after {
+  content: none;
 }
 
 .prose a {
@@ -265,6 +669,97 @@ body {
 .prose .footnotes {
   font-size: 0.95rem;
   color: color-mix(in oklab, var(--foreground) 70%, transparent);
+}
+
+@media (max-width: 39.999rem) {
+  .prose .code-block-toolbar {
+    min-height: 2.5rem;
+  }
+
+  .prose .code-block pre[data-theme] > code {
+    padding-block: 1rem 1.125rem;
+    font-size: 0.8125rem;
+  }
+
+  .prose .code-block [data-line] {
+    padding-inline: 1rem;
+  }
+
+  .prose .mermaid-toolbar {
+    min-height: 2.625rem;
+    padding-left: 0.75rem;
+  }
+
+  .prose .mermaid-diagram-type {
+    font-size: 0.6875rem;
+  }
+
+  .prose .mermaid-language {
+    margin-inline: 0.25rem 0.125rem;
+    font-size: 0.625rem;
+  }
+
+  .prose .mermaid-control {
+    padding-inline: 0.35rem;
+  }
+
+  .prose .mermaid-zoom-reset {
+    min-width: 1.875rem;
+  }
+
+  .prose .mermaid-zoom-reset span {
+    display: none;
+  }
+
+  .prose .mermaid-viewport {
+    min-height: 9.5rem;
+    padding: 1.25rem 1rem;
+  }
+}
+
+@media print {
+  .prose .code-block {
+    box-shadow: none;
+  }
+
+  .prose .code-block-copy {
+    display: none;
+  }
+
+  .prose .code-block pre[data-theme] {
+    overflow: visible;
+    white-space: pre-wrap;
+  }
+
+  .prose .code-block pre[data-theme] > code {
+    width: auto;
+    overflow-wrap: anywhere;
+  }
+
+  .prose .mermaid-block {
+    break-inside: avoid;
+    box-shadow: none;
+  }
+
+  .prose .mermaid-toolbar {
+    display: none;
+  }
+
+  .prose .mermaid-viewport {
+    min-height: 0;
+    overflow: visible;
+    background: transparent;
+    padding: 0.75rem;
+  }
+
+  .prose .mermaid-canvas {
+    width: 100%;
+  }
+
+  .prose .mermaid-canvas .mermaid-svg {
+    width: 100%;
+    max-width: 100%;
+  }
 }
 
 :root {

--- a/src/components/mdx/CodeBlock.tsx
+++ b/src/components/mdx/CodeBlock.tsx
@@ -1,0 +1,89 @@
+import type { ComponentPropsWithoutRef } from "react";
+
+import CopyCodeButton from "@/components/mdx/CopyCodeButton";
+
+const languageNames: Record<string, string> = {
+  bash: "Bash",
+  c: "C",
+  cpp: "C++",
+  cs: "C#",
+  css: "CSS",
+  diff: "Diff",
+  dockerfile: "Dockerfile",
+  go: "Go",
+  graphql: "GraphQL",
+  html: "HTML",
+  java: "Java",
+  javascript: "JavaScript",
+  js: "JavaScript",
+  json: "JSON",
+  jsonc: "JSON with comments",
+  jsx: "JSX",
+  kotlin: "Kotlin",
+  lua: "Lua",
+  markdown: "Markdown",
+  md: "Markdown",
+  mdx: "MDX",
+  plaintext: "Plain text",
+  prisma: "Prisma",
+  py: "Python",
+  python: "Python",
+  regex: "Regular expression",
+  rs: "Rust",
+  ruby: "Ruby",
+  rust: "Rust",
+  sh: "Shell",
+  shell: "Shell",
+  sql: "SQL",
+  swift: "Swift",
+  text: "Plain text",
+  toml: "TOML",
+  ts: "TypeScript",
+  tsx: "TSX",
+  txt: "Plain text",
+  vue: "Vue",
+  xml: "XML",
+  yaml: "YAML",
+  yml: "YAML",
+  zsh: "Zsh",
+};
+
+type CodeBlockProps = ComponentPropsWithoutRef<"pre"> & {
+  "data-language"?: string;
+};
+
+function getLanguageName(language: string): string {
+  const normalizedLanguage = language.toLowerCase();
+  const knownName = languageNames[normalizedLanguage];
+
+  if (knownName !== undefined) {
+    return knownName;
+  }
+
+  if (normalizedLanguage.length <= 4) {
+    return normalizedLanguage.toUpperCase();
+  }
+
+  return normalizedLanguage
+    .split(/[-_]/u)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+export default function CodeBlock({
+  children,
+  ...props
+}: Readonly<CodeBlockProps>) {
+  const language = props["data-language"] ?? "plaintext";
+  const languageName = getLanguageName(language);
+
+  return (
+    <div className="code-block" data-language={language}>
+      <div className="code-block-toolbar">
+        <span className="code-block-language">{languageName}</span>
+        <CopyCodeButton language={languageName} />
+      </div>
+      <pre {...props}>{children}</pre>
+    </div>
+  );
+}

--- a/src/components/mdx/CopyCodeButton.tsx
+++ b/src/components/mdx/CopyCodeButton.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import type { MouseEvent } from "react";
+
+type CopyStatus = "copied" | "error" | "idle";
+
+const RESET_DELAY_MS = 2000;
+
+const buttonContent: Record<
+  CopyStatus,
+  { accessibleLabel: (language: string) => string; label: string }
+> = {
+  copied: {
+    accessibleLabel: (language) => `${language} code copied to clipboard`,
+    label: "Copied",
+  },
+  error: {
+    accessibleLabel: (language) => `Copying ${language} code failed. Try again`,
+    label: "Retry",
+  },
+  idle: {
+    accessibleLabel: (language) => `Copy ${language} code to clipboard`,
+    label: "Copy",
+  },
+};
+
+export default function CopyCodeButton({
+  language,
+}: Readonly<{ language: string }>) {
+  const [status, setStatus] = useState<CopyStatus>("idle");
+  const resetTimer = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current !== null) {
+        window.clearTimeout(resetTimer.current);
+      }
+    },
+    []
+  );
+
+  const handleCopy = async (event: MouseEvent<HTMLButtonElement>) => {
+    const code = event.currentTarget
+      .closest(".code-block")
+      ?.querySelector("pre code")
+      ?.textContent?.replace(/\n$/u, "");
+
+    if (resetTimer.current !== null) {
+      window.clearTimeout(resetTimer.current);
+    }
+
+    try {
+      if (code === undefined) {
+        throw new Error("Code content was not found");
+      }
+
+      await navigator.clipboard.writeText(code);
+      setStatus("copied");
+    } catch {
+      setStatus("error");
+    }
+
+    resetTimer.current = window.setTimeout(() => {
+      setStatus("idle");
+      resetTimer.current = null;
+    }, RESET_DELAY_MS);
+  };
+
+  const content = buttonContent[status];
+
+  return (
+    <button
+      aria-label={content.accessibleLabel(language)}
+      className="code-block-copy"
+      onClick={(event) => {
+        void handleCopy(event);
+      }}
+      type="button"
+    >
+      {status === "copied" ? (
+        <Check aria-hidden="true" />
+      ) : (
+        <Copy aria-hidden="true" />
+      )}
+      <span aria-live="polite">{content.label}</span>
+    </button>
+  );
+}

--- a/src/components/mdx/Mermaid.tsx
+++ b/src/components/mdx/Mermaid.tsx
@@ -1,65 +1,529 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Maximize2, Minimize2, RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
+import type { Mermaid, MermaidConfig, RenderResult } from "mermaid";
+import { useTheme } from "next-themes";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import type { CSSProperties } from "react";
 
-const sanitizeId = (value: string) => value.replaceAll(/[^a-zA-Z0-9-_]/g, "");
+import { cn } from "@/lib/utils";
 
 interface MermaidProps {
   chart: string;
   className?: string;
 }
 
-export default function Mermaid({ chart, className }: MermaidProps) {
-  const [svg, setSvg] = useState<string | null>(null);
+interface RenderedDiagram {
+  diagramType: string;
+  naturalWidth: number;
+  svg: string;
+}
+
+type RenderStatus = "error" | "loading" | "ready";
+type SiteTheme = "dark" | "light";
+
+const MAX_ZOOM = 2;
+const MIN_ZOOM = 0.75;
+const ZOOM_STEP = 0.25;
+const FALLBACK_DIAGRAM_WIDTH = 720;
+const ELK_LAYOUT_PATTERN =
+  /(?:^|\n)\s*flowchart-elk\b|layout\s*:\s*["']?elk(?:\.[a-zA-Z]+)?["']?/u;
+
+const diagramTypeNames: Record<string, string> = {
+  architecture: "Architecture",
+  block: "Block diagram",
+  c4: "C4 architecture",
+  class: "Class diagram",
+  classDiagram: "Class diagram",
+  er: "Entity relationship",
+  eventModeling: "Event model",
+  flowchart: "Flowchart",
+  "flowchart-elk": "Flowchart",
+  "flowchart-v2": "Flowchart",
+  gantt: "Gantt chart",
+  gitGraph: "Git graph",
+  journey: "User journey",
+  mindmap: "Mind map",
+  pie: "Pie chart",
+  sankey: "Sankey diagram",
+  sequence: "Sequence diagram",
+  stateDiagram: "State diagram",
+  "stateDiagram-v2": "State diagram",
+  timeline: "Timeline",
+};
+
+const siteThemeVariables: Record<
+  SiteTheme,
+  Record<string, boolean | string>
+> = {
+  dark: {
+    background: "#1a1918",
+    clusterBkg: "#242322",
+    clusterBorder: "#3a3836",
+    darkMode: true,
+    edgeLabelBackground: "#1a1918",
+    lineColor: "#a8a29e",
+    mainBkg: "#322619",
+    nodeBorder: "#d97706",
+    noteBkgColor: "#2b2319",
+    noteBorderColor: "#6a4b24",
+    noteTextColor: "#e8ae58",
+    primaryBorderColor: "#d97706",
+    primaryColor: "#322619",
+    primaryTextColor: "#e7e5e4",
+    secondaryBorderColor: "#6a4b24",
+    secondaryColor: "#2b2927",
+    secondaryTextColor: "#d6d3d1",
+    tertiaryBorderColor: "#3a3836",
+    tertiaryColor: "#242322",
+    tertiaryTextColor: "#a8a29e",
+    textColor: "#e7e5e4",
+  },
+  light: {
+    background: "#faf9f6",
+    clusterBkg: "#f2efea",
+    clusterBorder: "#d6d3d1",
+    darkMode: false,
+    edgeLabelBackground: "#faf9f6",
+    lineColor: "#78716c",
+    mainBkg: "#fff7ed",
+    nodeBorder: "#b45309",
+    noteBkgColor: "#f9ebd2",
+    noteBorderColor: "#e4c184",
+    noteTextColor: "#835018",
+    primaryBorderColor: "#b45309",
+    primaryColor: "#fff7ed",
+    primaryTextColor: "#292524",
+    secondaryBorderColor: "#e4c184",
+    secondaryColor: "#f7ead8",
+    secondaryTextColor: "#57534e",
+    tertiaryBorderColor: "#d6d3d1",
+    tertiaryColor: "#f2efea",
+    tertiaryTextColor: "#57534e",
+    textColor: "#292524",
+  },
+};
+
+let mermaidPromise: Promise<Mermaid> | undefined;
+let elkRegistrationPromise: Promise<void> | undefined;
+let renderQueue: Promise<null> = Promise.resolve(null);
+
+const fullscreenSubscribers = new Set<() => void>();
+
+function emitFullscreenChange() {
+  for (const subscriber of fullscreenSubscribers) {
+    subscriber();
+  }
+}
+
+function subscribeToFullscreen(subscriber: () => void) {
+  fullscreenSubscribers.add(subscriber);
+
+  if (fullscreenSubscribers.size === 1) {
+    document.addEventListener("fullscreenchange", emitFullscreenChange);
+  }
+
+  return () => {
+    fullscreenSubscribers.delete(subscriber);
+
+    if (fullscreenSubscribers.size === 0) {
+      document.removeEventListener("fullscreenchange", emitFullscreenChange);
+    }
+  };
+}
+
+function getFullscreenSnapshot() {
+  return document.fullscreenElement?.id ?? null;
+}
+
+function getServerFullscreenSnapshot() {
+  return null;
+}
+
+async function importMermaid() {
+  const { default: mermaid } = await import("mermaid");
+  return mermaid;
+}
+
+async function loadMermaid() {
+  mermaidPromise ??= importMermaid();
+  return await mermaidPromise;
+}
+
+async function importAndRegisterElk(mermaid: Mermaid) {
+  // Keep this lazy. The compatible 0.1.9 release is pinned because 0.2.x
+  // serializes live DOM nodes while rendering inside React.
+  const { default: elkLayouts } = await import("@mermaid-js/layout-elk");
+  mermaid.registerLayoutLoaders(elkLayouts);
+}
+
+async function registerElkLayouts(mermaid: Mermaid) {
+  elkRegistrationPromise ??= importAndRegisterElk(mermaid);
+  await elkRegistrationPromise;
+}
+
+async function enqueueRender<T>(render: () => Promise<T>) {
+  const previousRender = renderQueue;
+  const queueTurn = Promise.withResolvers<null>();
+  renderQueue = queueTurn.promise;
+
+  await previousRender;
+
+  try {
+    return await render();
+  } finally {
+    queueTurn.resolve(null);
+  }
+}
+
+function createHandDrawnSeed(chart: string) {
+  let seed = 17;
+
+  for (const character of chart) {
+    seed = (seed * 31 + (character.codePointAt(0) ?? 0)) % 2_147_483_647;
+  }
+
+  return seed === 0 ? 7 : seed;
+}
+
+function getDiagramTypeName(diagramType: string) {
+  const knownName = diagramTypeNames[diagramType];
+
+  if (knownName !== undefined) {
+    return knownName;
+  }
+
+  return diagramType
+    .replaceAll(/[-_]+/gu, " ")
+    .replaceAll(/([a-z])([A-Z])/gu, "$1 $2")
+    .replaceAll(/\bv\d+\b/gu, "")
+    .trim()
+    .replace(/^./u, (character) => character.toUpperCase());
+}
+
+function createMermaidConfig({
+  id,
+  seed,
+  theme,
+}: {
+  id: string;
+  seed: number;
+  theme: SiteTheme;
+}): MermaidConfig {
+  const isDark = theme === "dark";
+
+  return {
+    darkMode: isDark,
+    deterministicIDSeed: id,
+    deterministicIds: true,
+    flowchart: {
+      curve: "basis",
+      nodeSpacing: 44,
+      padding: 16,
+      rankSpacing: 52,
+      useMaxWidth: true,
+    },
+    fontFamily: "var(--font-site-body), ui-sans-serif, sans-serif",
+    fontSize: 16,
+    handDrawnSeed: seed,
+    look: "handDrawn",
+    markdownAutoWrap: true,
+    securityLevel: "strict",
+    startOnLoad: false,
+    suppressErrorRendering: true,
+    theme: "base",
+    themeCSS: `
+      .label, .nodeLabel, .edgeLabel, .messageText, .loopText {
+        font-weight: 600;
+      }
+      .edgeLabel {
+        border-radius: 0.375rem;
+      }
+    `,
+    themeVariables: siteThemeVariables[theme],
+    wrap: true,
+  };
+}
+
+function normalizeSvg(svg: string, diagramType: string) {
+  const template = document.createElement("template");
+  template.innerHTML = svg.trim();
+  const element = template.content.querySelector("svg");
+
+  if (element === null) {
+    throw new Error("Mermaid did not return an SVG element");
+  }
+
+  const viewBox = element
+    .getAttribute("viewBox")
+    ?.trim()
+    .split(/\s+/u)
+    .map(Number);
+  const viewBoxWidth = viewBox?.length === 4 ? viewBox[2] : undefined;
+  const naturalWidth =
+    viewBoxWidth !== undefined && Number.isFinite(viewBoxWidth)
+      ? Math.max(viewBoxWidth, 1)
+      : FALLBACK_DIAGRAM_WIDTH;
+
+  element.classList.add("mermaid-svg");
+  element.removeAttribute("height");
+  element.removeAttribute("style");
+  element.removeAttribute("width");
+  element.setAttribute("focusable", "false");
+  element.setAttribute("preserveAspectRatio", "xMidYMid meet");
+
+  if (
+    !element.hasAttribute("aria-label") &&
+    !element.hasAttribute("aria-labelledby")
+  ) {
+    element.setAttribute(
+      "aria-label",
+      `${getDiagramTypeName(diagramType)} diagram`
+    );
+  }
+
+  if (!element.hasAttribute("role")) {
+    element.setAttribute("role", "img");
+  }
+
+  return {
+    naturalWidth,
+    svg: element.outerHTML,
+  };
+}
+
+export default function Mermaid({ chart, className }: Readonly<MermaidProps>) {
+  const { resolvedTheme } = useTheme();
+  const generatedId = useId();
   const mermaidId = useMemo(
-    () => sanitizeId(`mermaid-${Math.random().toString(36).slice(2)}`),
-    []
+    () => `mermaid-${generatedId.replaceAll(/[^a-zA-Z0-9-_]/gu, "")}`,
+    [generatedId]
   );
+  const frameId = `${mermaidId}-frame`;
+  const seed = useMemo(() => createHandDrawnSeed(chart), [chart]);
+  const frameRef = useRef<HTMLElement>(null);
+  const canvasRef = useRef<HTMLDivElement>(null);
+  const bindFunctionsRef = useRef<RenderResult["bindFunctions"] | null>(null);
+  const [diagram, setDiagram] = useState<RenderedDiagram | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [status, setStatus] = useState<RenderStatus>("loading");
+  const [zoom, setZoom] = useState(1);
+  const fullscreenElementId = useSyncExternalStore(
+    subscribeToFullscreen,
+    getFullscreenSnapshot,
+    getServerFullscreenSnapshot
+  );
+  const isFullscreen = fullscreenElementId === frameId;
+  const siteTheme: SiteTheme = resolvedTheme === "dark" ? "dark" : "light";
 
   useEffect(() => {
     let cancelled = false;
 
-    const render = async () => {
-      try {
-        const mermaid = (await import("mermaid")).default;
-        mermaid.initialize({
-          securityLevel: "strict",
-          startOnLoad: false,
-          theme: "neutral",
-        });
+    const renderDiagram = async () => {
+      const mermaid = await loadMermaid();
 
-        const { svg } = await mermaid.render(mermaidId, chart);
-        if (!cancelled) {
-          setSvg(svg);
+      if (ELK_LAYOUT_PATTERN.test(chart)) {
+        await registerElkLayouts(mermaid);
+      }
+
+      return await enqueueRender(async () => {
+        mermaid.initialize(
+          createMermaidConfig({
+            id: mermaidId,
+            seed,
+            theme: siteTheme,
+          })
+        );
+
+        return await mermaid.render(mermaidId, chart);
+      });
+    };
+
+    const runRender = async () => {
+      try {
+        const result = await renderDiagram();
+        const normalizedSvg = normalizeSvg(result.svg, result.diagramType);
+
+        if (cancelled) {
+          return;
         }
-      } catch {
+
+        bindFunctionsRef.current = result.bindFunctions;
+        setDiagram({
+          diagramType: getDiagramTypeName(result.diagramType),
+          naturalWidth: normalizedSvg.naturalWidth,
+          svg: normalizedSvg.svg,
+        });
+        setStatus("ready");
+      } catch (error) {
         if (!cancelled) {
-          setSvg(null);
+          bindFunctionsRef.current = null;
+          setDiagram(null);
+          setErrorMessage(
+            error instanceof Error ? error.message : "Unknown rendering error"
+          );
+          setStatus("error");
         }
       }
     };
 
-    void render();
+    if (resolvedTheme === "dark" || resolvedTheme === "light") {
+      setErrorMessage(null);
+      setStatus("loading");
+      void runRender();
+    }
 
     return () => {
       cancelled = true;
     };
-  }, [chart, mermaidId]);
+  }, [chart, mermaidId, resolvedTheme, seed, siteTheme]);
 
-  if (svg === null || svg === "") {
-    return (
-      <pre className={className}>
-        <code>{chart}</code>
-      </pre>
+  useEffect(() => {
+    if (status === "ready" && canvasRef.current !== null) {
+      bindFunctionsRef.current?.(canvasRef.current);
+    }
+  }, [diagram, status]);
+
+  const changeZoom = (change: number) => {
+    setZoom((currentZoom) =>
+      Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, currentZoom + change))
     );
-  }
+  };
+
+  const toggleFullscreen = async () => {
+    const frame = frameRef.current;
+
+    if (frame === null) {
+      return;
+    }
+
+    try {
+      await (document.fullscreenElement === frame
+        ? document.exitFullscreen()
+        : frame.requestFullscreen());
+    } catch {
+      frame.focus();
+    }
+  };
+
+  const diagramStyle =
+    diagram === null
+      ? undefined
+      : ({
+          "--mermaid-render-width": `${Math.round(
+            diagram.naturalWidth * zoom
+          )}px`,
+        } as CSSProperties);
+  const diagramType = diagram?.diagramType ?? "Diagram";
 
   return (
-    <div
-      className={className}
-      role="img"
-      aria-label="Mermaid diagram"
-      dangerouslySetInnerHTML={{ __html: svg }}
-    />
+    <figure
+      aria-busy={status === "loading"}
+      className={cn("mermaid-block", className)}
+      data-error={status === "error" ? errorMessage : null}
+      data-rendering={
+        status === "loading" && diagram !== null ? "true" : "false"
+      }
+      id={frameId}
+      ref={frameRef}
+      tabIndex={-1}
+    >
+      <div className="mermaid-toolbar">
+        <span className="mermaid-diagram-type">{diagramType}</span>
+        <div className="mermaid-toolbar-actions">
+          <button
+            aria-label="Zoom diagram out"
+            className="mermaid-control"
+            disabled={zoom <= MIN_ZOOM || diagram === null}
+            onClick={() => {
+              changeZoom(-ZOOM_STEP);
+            }}
+            title="Zoom out"
+            type="button"
+          >
+            <ZoomOut aria-hidden="true" />
+          </button>
+          <button
+            aria-label="Reset diagram zoom"
+            className="mermaid-control mermaid-zoom-reset"
+            disabled={zoom === 1 || diagram === null}
+            onClick={() => {
+              setZoom(1);
+            }}
+            title="Reset zoom"
+            type="button"
+          >
+            <RotateCcw aria-hidden="true" />
+            <span>{Math.round(zoom * 100)}%</span>
+          </button>
+          <button
+            aria-label="Zoom diagram in"
+            className="mermaid-control"
+            disabled={zoom >= MAX_ZOOM || diagram === null}
+            onClick={() => {
+              changeZoom(ZOOM_STEP);
+            }}
+            title="Zoom in"
+            type="button"
+          >
+            <ZoomIn aria-hidden="true" />
+          </button>
+          <button
+            aria-label={
+              isFullscreen
+                ? "Exit full screen diagram"
+                : "View diagram full screen"
+            }
+            className="mermaid-control"
+            disabled={diagram === null}
+            onClick={() => {
+              void toggleFullscreen();
+            }}
+            title={isFullscreen ? "Exit full screen" : "Full screen"}
+            type="button"
+          >
+            {isFullscreen ? (
+              <Minimize2 aria-hidden="true" />
+            ) : (
+              <Maximize2 aria-hidden="true" />
+            )}
+          </button>
+          <span className="mermaid-language">Mermaid</span>
+        </div>
+      </div>
+      <div
+        aria-label={`${diagramType}. Scroll horizontally to inspect larger diagrams.`}
+        className="mermaid-viewport"
+        tabIndex={diagram === null ? -1 : 0}
+      >
+        {diagram === null ? null : (
+          <div
+            className="mermaid-canvas"
+            dangerouslySetInnerHTML={{ __html: diagram.svg }}
+            ref={canvasRef}
+            style={diagramStyle}
+          />
+        )}
+        {status === "loading" && diagram === null ? (
+          <div aria-live="polite" className="mermaid-placeholder" role="status">
+            <span aria-hidden="true" className="mermaid-placeholder-mark" />
+            <span>Drawing diagram…</span>
+          </div>
+        ) : null}
+        {status === "error" ? (
+          <div className="mermaid-error" role="alert">
+            <strong>Diagram unavailable</strong>
+            <span>The Mermaid source could not be rendered.</span>
+          </div>
+        ) : null}
+      </div>
+    </figure>
   );
 }

--- a/src/content/blog/how-we-built-our-react-native-app/page.mdx
+++ b/src/content/blog/how-we-built-our-react-native-app/page.mdx
@@ -156,7 +156,7 @@ As a starting point, however, the [official docs](https://facebook.github.io/rea
   and see what’s being sent across. This might help you understand what’s actually
   happening underneath and improve performance.
 
-```
+```js
 MessageQueue.spy(true)
 
 ```
@@ -175,7 +175,7 @@ MessageQueue.spy(true)
   redux-observable helped us mitigate some of those pains. Consider the following
   example:
 
-```
+```js
 
 export default function localitySelect(action$, store, { ajax }) {
   return action$
@@ -218,7 +218,7 @@ environment.
   and keeps them lean. Here’s an example that switches between a dark or light
   status bar on iOS based on the current screen:
 
-```
+```js
 
 const statusBarMiddleware = ({ getState }) => next => (action) => {
   if (!Object.values(NavigationActions).includes(action.type)) {
@@ -248,7 +248,7 @@ testers and designers). After experimenting and struggling with a bunch of
 approaches, we moved to Fastlane to automate this entire process. Following is
 an abridged version of our beta release cycle on iOS:
 
-```
+```ruby
 
 desc "Submit a new Beta Build to Crashlytics"
   lane :beta do |options|

--- a/src/content/blog/kickback-with-koa-webpack/page.mdx
+++ b/src/content/blog/kickback-with-koa-webpack/page.mdx
@@ -83,7 +83,7 @@ The final GitHub repository is linked [here](https://github.com/f0rr0/koa-webpac
 writing this, I discovered that the author of ’n’ is [TJ
 Holowaychuk](https://medium.com/u/bbb3c7ccb0a0) yet again.)
 
-```
+```bash
 sudo npm cache clean -f
 sudo npm install -g n
 sudo n latest
@@ -103,7 +103,7 @@ for source, and certain essential files for our development tools.
 Go ahead and clone the final repository to your machine to build the minimal
 server from source.
 
-```
+```bash
 
 git clone https://github.com/f0rr0/koa-webpack-boilerplate
 cd koa-webpack-boilerplate
@@ -141,7 +141,7 @@ file-type and pre-process it. Basically, what this means is, you can do the
 following in your front-end application with the
 [css-loader](https://github.com/webpack/css-loader):
 
-```
+```js
 
 require('css!./styles/main.css');
 
@@ -150,7 +150,7 @@ require('css!./styles/main.css');
 If this does not make you run naked in the streets, then I don’t know what will.
 You can even chain loaders to process files on the fly, like so:
 
-```
+```js
 
 require('style!css!sass!./styles/main.sass');
 
@@ -162,7 +162,7 @@ When used from the CLI, webpack looks for a configuration file named `webpack.co
 
 Note — You can view and install specific `dist-tags` for a package on `npm` like so:
 
-```
+```bash
 
 npm view <package-name> dist-tags
 npm install <package-name>@<dist-tag>
@@ -171,7 +171,7 @@ npm install <package-name>@<dist-tag>
 
 In the root directory of your repository:
 
-```
+```bash
 
 npm install -D webpack@beta
 
@@ -179,7 +179,7 @@ npm install -D webpack@beta
 
 This installs webpack as a **development dependency** to your package. Beginning from version 2+, the webpack config file can export a function which returns the configuration. The function is called by the CLI and the value passed via `--env` from the CLI is passed to the configuration function. Our minimal `webpack.config.js` will look like so:
 
-```
+```js
 
 const { resolve } = require('path');
 const { dependencies } = require('./package.json');
@@ -230,7 +230,7 @@ I’ll explain a couple of quirks related to a non-browser environment below:
 
 - **externals:** When writing a server and bundling it with webpack, we don’t want our dependencies to be resolved by webpack. Instead, they will become the dependencies of the bundle we generate. To accomplish this, we pull our dependencies from the `package.json` file and prefix them with `commonjs`. The Webpack generated import code for a prefixed fictional dependency named `xyz` will then look like so:
 
-```
+```js
 
 module.exports = require("xyz");
 
@@ -241,7 +241,7 @@ or `--save` option.
 
 - **target:** Setting the target for our bundle to _node_ compiles our modules to be run in a Node.js like environment. What this does is essentially the same as above. It prepends all native modules available in the current Node.js environment with `commonjs`. Internally, the names of all such modules available to the current process are obtained by:
 
-```
+```js
 
 process.binding("natives");
 
@@ -253,7 +253,7 @@ This returns an object with all the native modules like `dns`, `domain`, `events
 
 Babel is used in the [wild](https://babeljs.io/users/) by the likes of Facebook, Netflix, Airbnb and Yahoo. As mentioned earlier, we will use Babel to transpile our ES6/7 code. This is accomplished from within webpack via the `babel-loader`. Our config looks for files ending in `.js` in the `./src` directory and loads them with `babel-loader`. Before you can use it though, you need to install it:
 
-```
+```bash
 
 npm install -D babel-loader babel-core
 
@@ -265,7 +265,7 @@ If you updated your Node.js installation to the latest version, as mentioned ear
 
 The plugin we need is [babel-plugin-transform-async-to-generator](http://babeljs.io/docs/plugins/transform-async-to-generator/). The name is more than self-explanatory. Babel can be configured to use these plugins via the `.babelrc` file which lives in the root of our repository. Our tiny `.babelrc` file looks like so:
 
-```
+```json
 
 {
   "plugins": ["transform-async-to-generator"]
@@ -276,7 +276,7 @@ The plugin we need is [babel-plugin-transform-async-to-generator](http://babeljs
 Obviously, it needs to be installed as a **development dependency** before you
 can use it:
 
-```
+```bash
 
 npm install -D babel-plugin-transform-async-to-generator
 
@@ -286,7 +286,7 @@ npm install -D babel-plugin-transform-async-to-generator
 
 With our build tools in place, we can start writing the server finally. As mentioned earlier, Koa is a very minimal framework and does not offer much out of the box. Everything in Koa is middleware and there are quite a few of them. We will be using Koa 2 which can be installed with the `next` dist-tag. Go ahead and install Koa and a couple of middleware like so:
 
-```
+```bash
 
 npm install -S koa@next koa-route@next koa-logger@next
 
@@ -294,7 +294,7 @@ npm install -S koa@next koa-route@next koa-logger@next
 
 For the purpose of this article, we will be mocking a database with the [Pokeapi](https://pokeapi.co/). Since Koa expects `xyz` to return a Promise in all `await xyz` expressions, we will make use of [pokedex-promise-v2](https://github.com/PokeAPI/pokedex-promise-v2) which is simply a Promise based wrapper for the Pokeapi. Install it like so:
 
-```
+```bash
 
 npm install -S pokedex-promise-v2
 
@@ -303,7 +303,7 @@ npm install -S pokedex-promise-v2
 We will abstract our database logic into separate modules. Go ahead and create
 two new files in the `./src` directory.
 
-```
+```bash
 
 cd src
 touch pokemondb.js stats.js
@@ -313,7 +313,7 @@ touch pokemondb.js stats.js
 - **pokemondb.js** just exports a function that takes a string as an argument
   and returns a Promise.
 
-```
+```js
 
 import Pokedex from 'pokedex-promise-v2';
 
@@ -328,7 +328,7 @@ export default function get (pokemon) {
 - **stats.js** also exports a function that takes an object as an argument and
   return a string.
 
-```
+```js
 
 export default function stats (data) {
    return (
@@ -346,7 +346,7 @@ export default function stats (data) {
 With our mock database and helper method in place, we can go ahead and consume
 it in our server. The `index.js` looks like so:
 
-```
+```js
 
 import get from './pokemondb';
 import stats from './stats';
@@ -380,7 +380,7 @@ gracefully in a try-catch block.
 
 We will be using some neat npm run scripts to build and start our server.
 
-```
+```js
 
 'scripts': {
   'clean': 'rm -rf ./build',
@@ -397,7 +397,7 @@ a production build by passing `prod` via `--env` as mentioned earlier.
 Go ahead and run the following in the root of your repository and open
 `localhost:8000` in your browser.
 
-```
+```bash
 
 npm run build:prod
 npm start
@@ -423,7 +423,7 @@ Webpack in development mode with the `--watch` option. Webpack will now watch
 our files and generate a new bundle when we save changes. Run the `watch` script
 like so:
 
-```
+```bash
 
 npm run watch
 
@@ -432,7 +432,7 @@ npm run watch
 Webpack won’t exit since it keeps watching the files. Open a new shell in the
 root of your repository to start the server.
 
-```
+```bash
 
 npm start # in new shell tab
 
@@ -440,7 +440,7 @@ npm start # in new shell tab
 
 If you see an error like:
 
-```
+```text
 
 Error: listen EADDRINUSE :::8000
 
@@ -465,7 +465,7 @@ Note that we are currently using [webpack/hot/poll](https://github.com/webpack/w
 The watch script needs to be modified to enable HMR. This can also be done by
 using the `HotModuleReplacementPlugin` but don’t use both.
 
-```
+```js
 
 'watch': 'npm run clean && `npm bin`/webpack --env.dev --watch -- verbose --hot'
 

--- a/src/content/blog/kitchen-sink/page.mdx
+++ b/src/content/blog/kitchen-sink/page.mdx
@@ -33,16 +33,39 @@ Create a folder, add `page.mdx`, and drop assets next to it.
 
 Use fenced blocks with a language for syntax highlighting.
 
-```ts
+```ts {9-15}
 type Post = {
+  slug: string;
   title: string;
   date: string;
 };
 
-const posts: Post[] = [{ title: "Hello", date: "2025-01-01" }];
+const posts: Post[] = [{ slug: "hello", title: "Hello", date: "2025-01-01" }];
+
+const canonicalUrl = new URL(
+  "/blog/" +
+    posts[0].slug +
+    "?preview=true&source=src/content/blog&theme=system&layout=article",
+  "https://f0rr0.dev"
+).toString();
 ```
 
-Inline code like `next.config.ts` is styled too.
+Highlighted lines call attention to the part being discussed. Inline code like
+`next.config.ts` is styled too, including longer names such as
+`createSyntaxHighlightedBlogPostPreview`.
+
+This shell command is intentionally kept on one line to exercise horizontal
+scrolling without widening the page:
+
+```bash
+curl --request GET --header "Accept: text/html" "http://127.0.0.1:3000/blog/kitchen-sink?preview=true&source=src/content/blog&theme=system&layout=article&syntax-highlighter=shiki"
+```
+
+Blocks without a language use a readable fallback:
+
+```
+src/content/blog/my-post/page.mdx
+```
 
 ## Images
 
@@ -66,11 +89,47 @@ GFM tables are enabled:
 
 ## Mermaid diagrams
 
-Use `mermaid` fenced blocks for diagrams:
+Mermaid diagrams use a deterministic hand-drawn treatment. Dense generated
+flowcharts can opt into ELK layout while remaining plain-text source:
 
 ```mermaid
+---
+config:
+  layout: elk
+---
 flowchart LR
-  Idea --> Sketch --> Prototype --> Ship
+  accTitle: From a rough idea to a dependable release
+  accDescr: A product idea branches through research and technical discovery, converges in a prototype, and continues through review, release, and observation.
+
+  Idea([Rough idea]) --> Question{Worth exploring?}
+  Question -->|User signal| Research[Research the problem]
+  Question -->|Technical signal| Spike[Run a technical spike]
+  Research --> Sketch[Sketch the smallest useful flow]
+  Spike --> Sketch
+  Sketch --> Prototype[Build a focused prototype]
+  Prototype --> Review{Ready to learn from?}
+  Review -->|Not yet| Sketch
+  Review -->|Yes| Ship[Release behind a guardrail]
+  Ship --> Observe[Observe real usage]
+  Observe --> Learn[Feed learning into the next idea]
+```
+
+Specialized diagram types retain their native geometry while sharing the same
+paper-like surface, colors, responsive scrolling, and controls:
+
+```mermaid
+sequenceDiagram
+  accTitle: Rendering a generated diagram in an article
+  accDescr: The reader opens an article, Next.js serves the page, and Mermaid turns generated source into a themed SVG.
+
+  actor Reader
+  participant Blog as Next.js article
+  participant Renderer as Mermaid
+
+  Reader->>Blog: Open article
+  Blog-->>Reader: Show the article shell
+  Blog->>Renderer: Send generated diagram source
+  Renderer-->>Reader: Draw the themed SVG
 ```
 
 ## Links

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -1,11 +1,13 @@
 import type { MDXComponents } from "mdx/types";
 
+import CodeBlock from "@/components/mdx/CodeBlock";
 import MDXLink from "@/components/mdx/MDXLink";
 import Mermaid from "@/components/mdx/Mermaid";
 
 const components: MDXComponents = {
   Mermaid,
   a: MDXLink,
+  pre: CodeBlock,
 };
 
 export function useMDXComponents(overrides: MDXComponents = {}): MDXComponents {


### PR DESCRIPTION
## Summary

- add styled Shiki code frames with language labels, copy feedback, highlighted lines, responsive horizontal scrolling, and improved inline code
- render Mermaid with deterministic hand-drawn styling, branded light/dark themes, accessible SVGs, zoom/fullscreen controls, and opt-in ELK layout
- expand the kitchen-sink coverage and annotate historical code fences with languages
- pin the compatible ELK adapter after the newer release failed during browser rendering

## Why

Technical posts now present code and generated diagrams more clearly across themes and screen sizes without widening the article layout.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run build`
- Chromium visual QA in light/dark desktop, 390px, and 320px layouts
- verified diagram zoom/fullscreen controls, no console errors, and no page-level horizontal overflow