### PR TITLE
docs(blog): refine Zeroclaw article copy

### DIFF
--- a/src/content/blog/building-on-zeroclaw/page.mdx
+++ b/src/content/blog/building-on-zeroclaw/page.mdx
@@ -12,7 +12,7 @@ Every day, our family has roughly the same meeting without putting it on anyone'
 
 We don't have this discussion around the kitchen counter. On most weekdays, some of us are working from the office and others are working from home. We also have a cook who comes in to prepare breakfast, lunch and dinner. The cook needs a clear plan; the rest of us are replying between calls, meetings and whatever else the day has decided to throw at us. Chat became the obvious coordination layer because it is the one room everybody can be in.
 
-The conversation is asynchronous; the cook's schedule is not. Once lunch preparation starts, a brilliant reply from somebody at the office is mostly useful for tomorrow.
+The conversation is asynchronous; the cook's schedule is not. Once the cook starts preparing lunch, replies from the office are too late to change today's meal—but they can still shape tomorrow's.
 
 Someone asks the cook what's available. A few vegetables are listed. One person wants something light, another doesn't feel like eating paneer again, somebody at the office sees the thread late, and the whole thing starts moving backwards. The person at home becomes an unwilling message broker. None of this is particularly tragic. It is, however, an impressive amount of daily back-and-forth for lunch.
 
@@ -153,7 +153,7 @@ A pantry photo can therefore produce observations shaped like:
 
 Those observations are committed to the pantry store using the source message as an idempotency key. Retrying the image job doesn't mysteriously create three new capsicums. More importantly, the next meal recommendation can actually use what was visible in the photo. That small loop—send image, update pantry, get a better lunch suggestion—is ridiculously cool in practice.
 
-Instamart is connected rather than merely mentioned. A household member can link their account, after which the [meal tools can fetch recent order history](https://github.com/f0rr0/zeroclaw/blob/3e5eed1208b9b444830febcfeecb82a8f3259a3d/src/tools/meal_instamart_sync.rs#L532-L702) through the Instamart MCP integration. A pantry-related turn—or an empty pantry context—can trigger a bounded refresh for a connected user. Order items retain their original timestamps instead of all appearing magically fresh on sync day.
+Instamart is connected rather than merely mentioned. A household member can link their account, after which the [meal tools can fetch recent order history](https://github.com/f0rr0/zeroclaw/blob/3e5eed1208b9b444830febcfeecb82a8f3259a3d/src/tools/meal_instamart_sync.rs#L532-L702) through the [Instamart MCP integration](https://mcp.swiggy.com/builders/docs/reference/instamart/). A pantry-related turn—or an empty pantry context—can trigger a bounded refresh for a connected user. Order items retain their original timestamps instead of all appearing magically fresh on sync day.
 
 Of course, buying tomatoes on Tuesday does not mean tomatoes still exist on Friday. The [pantry projection](https://github.com/f0rr0/zeroclaw/blob/3e5eed1208b9b444830febcfeecb82a8f3259a3d/src/meal/store.rs#L603-L650) gives each observation a source weight and then lets it decay with age. In simplified form:
 
@@ -275,6 +275,6 @@ So the loop finally closes:
 
 The first version of this idea was “read the group from top to bottom and suggest lunch”, which is both vague and not really the problem. The problem was the repeated coordination: information arriving at different times, preferences belonging to different people, a pantry that changes underneath us, and no memory of how yesterday's choice went.
 
-This is still a weekend prototype. Photos and orders are evidence rather than truth, and our cook remains the final pantry sanity check. That is perfectly fine. The delightful part is that someone can send a photo, somebody else can have an Instamart account connected, the cook can mention what has run out, and the assistant turns all of it into one fresh, attributed view before suggesting lunch.
+The delightful part is watching the household's scattered knowledge become shared context. One person sends a pantry photo, another connects an Instamart account, and the cook adds what has run out. The assistant brings those signals together into one fresh, attributed view, then turns it into lunch suggestions grounded in what the kitchen can actually make.
 
 Thirteen and a half thousand lines may be a ridiculous response to “what should we eat?”. Going through the same meeting every day was beginning to feel slightly more ridiculous.

--- a/src/content/blog/building-on-zeroclaw/page.mdx
+++ b/src/content/blog/building-on-zeroclaw/page.mdx
@@ -12,7 +12,7 @@ Every day, our family has roughly the same meeting without putting it on anyone'
 
 We don't have this discussion around the kitchen counter. On most weekdays, some of us are working from the office and others are working from home. We also have a cook who comes in to prepare breakfast, lunch and dinner. The cook needs a clear plan; the rest of us are replying between calls, meetings and whatever else the day has decided to throw at us. Chat became the obvious coordination layer because it is the one room everybody can be in.
 
-The conversation is asynchronous; the cook's schedule is not. Once the cook starts preparing lunch, replies from the office are too late to change today's meal—but they can still shape tomorrow's.
+The conversation is asynchronous; the cook's schedule is not. Once the cook starts preparing lunch, later replies are too late to change today's meal. They can still shape tomorrow's.
 
 Someone asks the cook what's available. A few vegetables are listed. One person wants something light, another doesn't feel like eating paneer again, somebody at the office sees the thread late, and the whole thing starts moving backwards. The person at home becomes an unwilling message broker. None of this is particularly tragic. It is, however, an impressive amount of daily back-and-forth for lunch.
 


### PR DESCRIPTION
## Summary

- make the article's asynchronous lunch-planning constraint explicit
- replace the defensive conclusion with a more confident, product-forward payoff
- link the Instamart MCP integration to its official documentation

## Why

The original phrasing obscured the timing problem and ended on caveats instead of the value of combining household context. This revision makes both ideas clearer for readers.

## Impact

Readers get a more direct explanation of why late replies matter and a concrete path to learn about the Instamart MCP integration.

## Validation

- `bun run build`
- `mise x -- hk run pre-push` (format, lint, typecheck, and Typst formatting checks)
