### PR TITLE
Move blog content controls below content

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -217,7 +217,7 @@ body {
   align-items: center;
   justify-content: flex-end;
   gap: 0.25rem;
-  border-bottom: 1px solid color-mix(in oklab, var(--border) 88%, transparent);
+  border-top: 1px solid color-mix(in oklab, var(--border) 88%, transparent);
   background: color-mix(in oklab, var(--muted) 72%, var(--card));
   padding: 0.35rem 0.5rem 0.35rem 1rem;
   font-family: var(--font-site-ui);
@@ -397,7 +397,7 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  border-bottom: 1px solid color-mix(in oklab, var(--border) 88%, transparent);
+  border-top: 1px solid color-mix(in oklab, var(--border) 88%, transparent);
   background: color-mix(in oklab, var(--muted) 72%, var(--card));
   padding: 0.35rem 0.5rem 0.35rem 1rem;
   font-family: var(--font-site-ui);
@@ -700,7 +700,7 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  border-bottom: 1px solid color-mix(in oklab, var(--border) 88%, transparent);
+  border-top: 1px solid color-mix(in oklab, var(--border) 88%, transparent);
   background: color-mix(in oklab, var(--muted) 72%, var(--card));
   padding: 0.35rem 0.5rem 0.35rem 0.65rem;
   font-family: var(--font-site-ui);

--- a/src/components/mdx/CodeBlock.tsx
+++ b/src/components/mdx/CodeBlock.tsx
@@ -63,6 +63,7 @@ export default function CodeBlock({
 
     return (
       <figure className="code-block github-code-embed" data-language={language}>
+        <pre {...props}>{children}</pre>
         <figcaption className="github-code-embed-toolbar">
           <a
             aria-label={`View ${owner}/${repo}/${filePath}, ${lineLabel}, on GitHub`}
@@ -84,18 +85,17 @@ export default function CodeBlock({
             <CopyCodeButton language={languageName} />
           </div>
         </figcaption>
-        <pre {...props}>{children}</pre>
       </figure>
     );
   }
 
   return (
     <div className="code-block" data-language={language}>
+      <pre {...props}>{children}</pre>
       <div className="code-block-toolbar">
         <LanguageLabel className="code-block-language" language={language} />
         <CopyCodeButton language={languageName} />
       </div>
-      <pre {...props}>{children}</pre>
     </div>
   );
 }

--- a/src/components/mdx/Mermaid.tsx
+++ b/src/components/mdx/Mermaid.tsx
@@ -435,6 +435,32 @@ export default function Mermaid({ chart, className }: Readonly<MermaidProps>) {
       ref={frameRef}
       tabIndex={-1}
     >
+      <div
+        aria-label={`${diagramType}. Scroll horizontally to inspect larger diagrams.`}
+        className="mermaid-viewport"
+        tabIndex={diagram === null ? -1 : 0}
+      >
+        {diagram === null ? null : (
+          <div
+            className="mermaid-canvas"
+            dangerouslySetInnerHTML={{ __html: diagram.svg }}
+            ref={canvasRef}
+            style={diagramStyle}
+          />
+        )}
+        {status === "loading" && diagram === null ? (
+          <div aria-live="polite" className="mermaid-placeholder" role="status">
+            <span aria-hidden="true" className="mermaid-placeholder-mark" />
+            <span>Drawing diagram…</span>
+          </div>
+        ) : null}
+        {status === "error" ? (
+          <div className="mermaid-error" role="alert">
+            <strong>Diagram unavailable</strong>
+            <span>The Mermaid source could not be rendered.</span>
+          </div>
+        ) : null}
+      </div>
       <div className="mermaid-toolbar">
         <span className="mermaid-diagram-type">{diagramType}</span>
         <div className="mermaid-toolbar-actions">
@@ -497,32 +523,6 @@ export default function Mermaid({ chart, className }: Readonly<MermaidProps>) {
           </button>
           <span className="mermaid-language">Mermaid</span>
         </div>
-      </div>
-      <div
-        aria-label={`${diagramType}. Scroll horizontally to inspect larger diagrams.`}
-        className="mermaid-viewport"
-        tabIndex={diagram === null ? -1 : 0}
-      >
-        {diagram === null ? null : (
-          <div
-            className="mermaid-canvas"
-            dangerouslySetInnerHTML={{ __html: diagram.svg }}
-            ref={canvasRef}
-            style={diagramStyle}
-          />
-        )}
-        {status === "loading" && diagram === null ? (
-          <div aria-live="polite" className="mermaid-placeholder" role="status">
-            <span aria-hidden="true" className="mermaid-placeholder-mark" />
-            <span>Drawing diagram…</span>
-          </div>
-        ) : null}
-        {status === "error" ? (
-          <div className="mermaid-error" role="alert">
-            <strong>Diagram unavailable</strong>
-            <span>The Mermaid source could not be rendered.</span>
-          </div>
-        ) : null}
       </div>
     </figure>
   );


### PR DESCRIPTION
## What changed

- moves regular code-block language and copy controls below the code
- moves GitHub line-embed source, language, and copy controls below the excerpt
- moves Mermaid diagram metadata and zoom/fullscreen controls below the diagram
- flips each toolbar separator to a top border so the footer remains visually attached to its content

## Why

Bottom controls keep the content visually primary and match the preferred reference pattern. DOM order now matches visual and keyboard order instead of relying on CSS-only reordering.

## Impact

All blog code and diagram surfaces use the same bottom-control convention on desktop and mobile. GitHub paths continue to truncate on narrow viewports, and Mermaid controls remain at the bottom in fullscreen mode.

## Validation

- `bun run format:check`
- `bun run typecheck`
- `bun run lint:ox`
- `bun test`
- authenticated `bun run build`
- rendered desktop and 390px mobile checks for standard code blocks, GitHub embeds, and Mermaid diagrams
